### PR TITLE
feat(types): define Encode, Decode, EncodedSize traits and Error type

### DIFF
--- a/crates/basalt-types/src/error.rs
+++ b/crates/basalt-types/src/error.rs
@@ -1,0 +1,75 @@
+use std::string::FromUtf8Error;
+
+/// Crate-level result alias.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur during encoding or decoding of Minecraft protocol types.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("buffer underflow: need {needed} bytes, got {available}")]
+    BufferUnderflow { needed: usize, available: usize },
+
+    #[error("invalid data: {0}")]
+    InvalidData(String),
+
+    #[error("varint too large")]
+    VarIntTooLarge,
+
+    #[error("string too long: {len} bytes, max {max}")]
+    StringTooLong { len: usize, max: usize },
+
+    #[error("invalid utf-8: {0}")]
+    InvalidUtf8(#[from] FromUtf8Error),
+
+    #[error("nbt error: {0}")]
+    Nbt(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_buffer_underflow() {
+        let err = Error::BufferUnderflow {
+            needed: 4,
+            available: 2,
+        };
+        assert_eq!(err.to_string(), "buffer underflow: need 4 bytes, got 2");
+    }
+
+    #[test]
+    fn display_invalid_data() {
+        let err = Error::InvalidData("bad value".into());
+        assert_eq!(err.to_string(), "invalid data: bad value");
+    }
+
+    #[test]
+    fn display_varint_too_large() {
+        let err = Error::VarIntTooLarge;
+        assert_eq!(err.to_string(), "varint too large");
+    }
+
+    #[test]
+    fn display_string_too_long() {
+        let err = Error::StringTooLong {
+            len: 40000,
+            max: 32767,
+        };
+        assert_eq!(err.to_string(), "string too long: 40000 bytes, max 32767");
+    }
+
+    #[test]
+    fn display_nbt_error() {
+        let err = Error::Nbt("unexpected tag type".into());
+        assert_eq!(err.to_string(), "nbt error: unexpected tag type");
+    }
+
+    #[test]
+    fn from_utf8_error() {
+        let invalid = vec![0xFF, 0xFE];
+        let utf8_err = String::from_utf8(invalid).unwrap_err();
+        let err: Error = utf8_err.into();
+        assert!(matches!(err, Error::InvalidUtf8(_)));
+    }
+}

--- a/crates/basalt-types/src/lib.rs
+++ b/crates/basalt-types/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod error;
+pub mod traits;
 
 pub use error::{Error, Result};
+pub use traits::{Decode, Encode, EncodedSize};

--- a/crates/basalt-types/src/lib.rs
+++ b/crates/basalt-types/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod error;
 
+pub use error::{Error, Result};

--- a/crates/basalt-types/src/traits.rs
+++ b/crates/basalt-types/src/traits.rs
@@ -1,0 +1,72 @@
+use crate::Result;
+
+/// Serialize a value into a byte buffer.
+pub trait Encode {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()>;
+}
+
+/// Deserialize a value from a byte slice, advancing the cursor.
+pub trait Decode: Sized {
+    fn decode(buf: &mut &[u8]) -> Result<Self>;
+}
+
+/// Predict the exact serialized byte count for pre-allocation.
+pub trait EncodedSize {
+    fn encoded_size(&self) -> usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Error;
+
+    /// Dummy type to verify the traits compile and work together.
+    struct DummyByte(u8);
+
+    impl Encode for DummyByte {
+        fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+            buf.push(self.0);
+            Ok(())
+        }
+    }
+
+    impl Decode for DummyByte {
+        fn decode(buf: &mut &[u8]) -> Result<Self> {
+            if buf.is_empty() {
+                return Err(Error::BufferUnderflow {
+                    needed: 1,
+                    available: 0,
+                });
+            }
+            let value = buf[0];
+            *buf = &buf[1..];
+            Ok(DummyByte(value))
+        }
+    }
+
+    impl EncodedSize for DummyByte {
+        fn encoded_size(&self) -> usize {
+            1
+        }
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = DummyByte(42);
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = DummyByte::decode(&mut cursor).unwrap();
+        assert_eq!(decoded.0, 42);
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn decode_empty_buffer() {
+        let mut cursor: &[u8] = &[];
+        let result = DummyByte::decode(&mut cursor);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Error` enum with variants for buffer underflow, invalid data, VarInt overflow, string length, UTF-8, and NBT errors
- Add `Result<T>` type alias
- Add `Encode`, `Decode`, `EncodedSize` traits — sync, byte-slice based serialization contract
- `Decode` uses `&mut &[u8]` cursor pattern for ergonomic chaining

## Related issues

Closes #1

## Scope

`basalt-types` crate only (`src/error.rs`, `src/traits.rs`, `src/lib.rs`)

## Test plan

- [x] Error Display output verified for each variant
- [x] `From<FromUtf8Error>` conversion tested
- [x] Trait roundtrip tested with dummy implementation
- [x] Decode on empty buffer returns error
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (8 tests)