### PR TITLE
ci(coverage): add coverage job with 90% threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,42 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run tests with coverage
+        run: cargo llvm-cov --no-report --all-features
+      - name: Generate coverage report
+        env:
+          NO_COLOR: "1"
+        run: cargo llvm-cov report --fail-under-lines 90 2>&1 | tee coverage-report.txt
+      - name: Format coverage comment
+        if: github.event_name == 'pull_request' && always()
+        run: |
+          {
+            echo "## Coverage report"
+            echo ""
+            echo '```'
+            cat coverage-report.txt
+            echo '```'
+          } > coverage-comment.md
+      - name: Coverage comment
+        if: github.event_name == 'pull_request' && always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage
+          path: coverage-comment.md
+
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,9 +233,10 @@ GitHub Actions runs on every push to `main` and on pull requests:
 1. **Format** — `cargo fmt --all --check`
 2. **Clippy** — `cargo clippy --all-targets --all-features -- -D warnings`
 3. **Test** — `cargo test --all-features`
-4. **Cargo Deny** — advisory + license audit
+4. **Coverage** — `cargo llvm-cov --all-features --fail-under 90` (minimum 90%, posts report on PRs)
+5. **Cargo Deny** — advisory + license audit
 
-All four jobs run in parallel. The concurrency group cancels in-progress runs on the same ref.
+All five jobs run in parallel. The concurrency group cancels in-progress runs on the same ref.
 
 ## Testing strategy
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -49,6 +49,11 @@ const keywords = [
   // Example: "ci(ci): add cargo-deny advisory check"
   'ci',
 
+  // Code coverage: cargo-llvm-cov configuration, coverage thresholds,
+  // coverage CI job, coverage reporting.
+  // Example: "ci(coverage): add coverage job with 90% threshold"
+  'coverage',
+
   // CLAUDE.md guidelines: conventions, architectural decisions, patterns.
   // Example: "docs(claude): document commit scope convention"
   'claude',


### PR DESCRIPTION
## Summary

- Add `coverage` scope to commitlint config
- Add Coverage job to CI: `cargo llvm-cov --all-features --fail-under 90`
- Sticky coverage report comment on PRs via `marocchino/sticky-pull-request-comment`
- Document coverage in CLAUDE.md

## Related issues

None (infrastructure improvement)

## Scope

CI workflow, commitlint config, CLAUDE.md

## Test plan

- [ ] Coverage job runs and passes on this PR
- [ ] Coverage comment appears on the PR
- [ ] CI fails if coverage drops below 90%