### PR TITLE
feat(types): implement String and ByteArray

### DIFF
--- a/crates/basalt-types/src/byte_array.rs
+++ b/crates/basalt-types/src/byte_array.rs
@@ -1,0 +1,116 @@
+use crate::{Decode, Encode, EncodedSize, Error, Result, VarInt};
+
+/// Encodes a byte vector as a Minecraft protocol byte array.
+///
+/// Minecraft byte arrays are raw byte sequences prefixed by a VarInt
+/// indicating the length. They are used for plugin channel data, chunk
+/// sections, encryption payloads, and other binary blobs in the protocol.
+/// Unlike strings, byte arrays have no encoding or length constraints
+/// beyond what the packet format imposes.
+impl Encode for Vec<u8> {
+    /// Writes a VarInt length prefix followed by the raw bytes.
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        VarInt(self.len() as i32).encode(buf)?;
+        buf.extend_from_slice(self);
+        Ok(())
+    }
+}
+
+/// Decodes a Minecraft protocol byte array into a `Vec<u8>`.
+///
+/// Reads a VarInt byte length, then reads exactly that many bytes from
+/// the buffer. No validation is performed on the byte content — the
+/// caller is responsible for interpreting the data.
+impl Decode for Vec<u8> {
+    /// Reads the VarInt length prefix, then copies the raw payload.
+    ///
+    /// Fails with `Error::BufferUnderflow` if the buffer is shorter
+    /// than the declared length.
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let len = VarInt::decode(buf)?.0 as usize;
+        if buf.len() < len {
+            return Err(Error::BufferUnderflow {
+                needed: len,
+                available: buf.len(),
+            });
+        }
+        let (bytes, rest) = buf.split_at(len);
+        let value = bytes.to_vec();
+        *buf = rest;
+        Ok(value)
+    }
+}
+
+/// Computes the wire size of a Minecraft protocol byte array.
+///
+/// The total size is the VarInt-encoded length prefix plus the byte count.
+/// This enables exact buffer pre-allocation before encoding.
+impl EncodedSize for Vec<u8> {
+    /// Returns the VarInt prefix size plus the array's byte length.
+    fn encoded_size(&self) -> usize {
+        VarInt(self.len() as i32).encoded_size() + self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(data: &[u8]) {
+        let original = data.to_vec();
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = Vec::<u8>::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn empty() {
+        roundtrip(&[]);
+    }
+
+    #[test]
+    fn small() {
+        roundtrip(&[0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn large() {
+        roundtrip(&vec![0xAB; 1024]);
+    }
+
+    #[test]
+    fn truncated_buffer() {
+        let mut buf = Vec::new();
+        VarInt(10).encode(&mut buf).unwrap();
+        buf.extend_from_slice(&[0x01; 5]);
+
+        let mut cursor = buf.as_slice();
+        assert!(matches!(
+            Vec::<u8>::decode(&mut cursor),
+            Err(Error::BufferUnderflow { .. })
+        ));
+    }
+
+    #[test]
+    fn encoded_size_accounts_for_varint_prefix() {
+        assert_eq!(Vec::<u8>::new().encoded_size(), 1);
+        assert_eq!(vec![0u8; 3].encoded_size(), 4);
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn byte_array_roundtrip(data in proptest::collection::vec(any::<u8>(), 0..1000)) {
+                roundtrip(&data);
+            }
+        }
+    }
+}

--- a/crates/basalt-types/src/lib.rs
+++ b/crates/basalt-types/src/lib.rs
@@ -1,5 +1,7 @@
+mod byte_array;
 pub mod error;
 mod primitives;
+mod string;
 pub mod traits;
 mod varint;
 

--- a/crates/basalt-types/src/primitives.rs
+++ b/crates/basalt-types/src/primitives.rs
@@ -1,15 +1,27 @@
 use crate::{Decode, Encode, EncodedSize, Error, Result};
 
-// -- bool --
-
+/// Encodes a boolean as a single byte in the Minecraft protocol.
+///
+/// The Minecraft protocol represents booleans as a single unsigned byte:
+/// `0x00` for `false`, `0x01` for `true`. This is used in many packets
+/// for flags like on-ground state, sneaking, sprinting, etc.
 impl Encode for bool {
+    /// Writes `0x01` if true, `0x00` if false. Always writes exactly one byte.
     fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
         buf.push(if *self { 0x01 } else { 0x00 });
         Ok(())
     }
 }
 
+/// Decodes a boolean from a single byte in the Minecraft protocol.
+///
+/// Any non-zero byte is interpreted as `true`, matching the Minecraft
+/// server behavior. This is intentionally lenient — the protocol spec
+/// says `0x01` for true, but servers may send other non-zero values.
 impl Decode for bool {
+    /// Reads one byte. Returns `true` for any non-zero value, `false` for `0x00`.
+    ///
+    /// Fails with `BufferUnderflow` if the buffer is empty.
     fn decode(buf: &mut &[u8]) -> Result<Self> {
         if buf.is_empty() {
             return Err(Error::BufferUnderflow {
@@ -23,24 +35,45 @@ impl Decode for bool {
     }
 }
 
+/// A boolean always occupies exactly one byte on the wire.
 impl EncodedSize for bool {
     fn encoded_size(&self) -> usize {
         1
     }
 }
 
-// -- Macro for fixed-size numeric types --
-
+/// Generates `Encode`, `Decode`, and `EncodedSize` implementations for
+/// fixed-size numeric types using big-endian byte order.
+///
+/// The Minecraft protocol uses big-endian (network byte order) for all
+/// fixed-size integers and floating-point values. Each type occupies a
+/// fixed number of bytes on the wire, regardless of the value.
 macro_rules! impl_numeric {
     ($ty:ty, $size:expr) => {
+        /// Encodes as a fixed-size big-endian value.
+        ///
+        /// The Minecraft protocol uses big-endian (network byte order) for all
+        /// fixed-size numeric types. The value is written as exactly
+        #[doc = concat!(stringify!($size), " bytes.")]
         impl Encode for $ty {
+            /// Writes the value as big-endian bytes. Always writes exactly
+            #[doc = concat!(stringify!($size), " bytes.")]
             fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
                 buf.extend_from_slice(&self.to_be_bytes());
                 Ok(())
             }
         }
 
+        /// Decodes from a fixed-size big-endian value.
+        ///
+        /// Reads exactly
+        #[doc = concat!(stringify!($size), " bytes from the buffer and interprets them as big-endian.")]
         impl Decode for $ty {
+            /// Reads
+            #[doc = concat!(stringify!($size), " big-endian bytes and advances the cursor.")]
+            ///
+            /// Fails with `BufferUnderflow` if fewer than
+            #[doc = concat!(stringify!($size), " bytes remain.")]
             fn decode(buf: &mut &[u8]) -> Result<Self> {
                 if buf.len() < $size {
                     return Err(Error::BufferUnderflow {
@@ -55,6 +88,8 @@ macro_rules! impl_numeric {
             }
         }
 
+        /// The encoded size is always
+        #[doc = concat!(stringify!($size), " bytes, regardless of the value.")]
         impl EncodedSize for $ty {
             fn encoded_size(&self) -> usize {
                 $size

--- a/crates/basalt-types/src/string.rs
+++ b/crates/basalt-types/src/string.rs
@@ -1,0 +1,181 @@
+use crate::{Decode, Encode, EncodedSize, Error, Result, VarInt};
+
+/// Maximum byte length for a Minecraft protocol string.
+const MAX_STRING_BYTES: usize = 32767;
+
+/// Encodes a Rust `String` as a Minecraft protocol string.
+///
+/// Minecraft protocol strings are UTF-8 byte sequences prefixed by a VarInt
+/// indicating the byte length (not character count). They are used for player
+/// names, chat messages, identifiers, server addresses, and many other text
+/// fields. The maximum allowed length is 32767 bytes.
+impl Encode for String {
+    /// Writes a VarInt length prefix followed by the UTF-8 bytes.
+    ///
+    /// Fails with `Error::StringTooLong` if the string exceeds 32767 bytes.
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        let bytes = self.as_bytes();
+        if bytes.len() > MAX_STRING_BYTES {
+            return Err(Error::StringTooLong {
+                len: bytes.len(),
+                max: MAX_STRING_BYTES,
+            });
+        }
+        VarInt(bytes.len() as i32).encode(buf)?;
+        buf.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+/// Decodes a Minecraft protocol string into a Rust `String`.
+///
+/// Reads a VarInt byte length, validates it against the 32767-byte limit,
+/// then reads that many bytes and validates them as UTF-8. Multi-byte
+/// UTF-8 characters (accented letters, emoji, CJK) are handled correctly
+/// since the length prefix counts bytes, not characters.
+impl Decode for String {
+    /// Reads the VarInt length prefix, then the UTF-8 payload.
+    ///
+    /// Fails with `Error::StringTooLong` if the declared length exceeds
+    /// 32767 bytes, `Error::BufferUnderflow` if the buffer is shorter than
+    /// the declared length, or `Error::InvalidUtf8` if the bytes are not
+    /// valid UTF-8.
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let len = VarInt::decode(buf)?.0 as usize;
+        if len > MAX_STRING_BYTES {
+            return Err(Error::StringTooLong {
+                len,
+                max: MAX_STRING_BYTES,
+            });
+        }
+        if buf.len() < len {
+            return Err(Error::BufferUnderflow {
+                needed: len,
+                available: buf.len(),
+            });
+        }
+        let (bytes, rest) = buf.split_at(len);
+        let value = String::from_utf8(bytes.to_vec())?;
+        *buf = rest;
+        Ok(value)
+    }
+}
+
+/// Computes the wire size of a Minecraft protocol string.
+///
+/// The total size is the VarInt-encoded length prefix plus the UTF-8 byte
+/// count. This enables exact buffer pre-allocation before encoding.
+impl EncodedSize for String {
+    /// Returns the VarInt prefix size plus the string's byte length.
+    fn encoded_size(&self) -> usize {
+        let len = self.len();
+        VarInt(len as i32).encoded_size() + len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(s: &str) {
+        let original = s.to_string();
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = String::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn empty_string() {
+        roundtrip("");
+    }
+
+    #[test]
+    fn short_string() {
+        roundtrip("hello");
+    }
+
+    #[test]
+    fn unicode_string() {
+        roundtrip("héllo wörld 🌍");
+    }
+
+    #[test]
+    fn max_length_string() {
+        let s = "a".repeat(MAX_STRING_BYTES);
+        roundtrip(&s);
+    }
+
+    #[test]
+    fn too_long_encode() {
+        let s = "a".repeat(MAX_STRING_BYTES + 1);
+        let mut buf = Vec::new();
+        assert!(matches!(
+            s.encode(&mut buf),
+            Err(Error::StringTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn too_long_decode() {
+        let mut buf = Vec::new();
+        VarInt(MAX_STRING_BYTES as i32 + 1)
+            .encode(&mut buf)
+            .unwrap();
+        buf.extend_from_slice(&vec![0u8; MAX_STRING_BYTES + 1]);
+
+        let mut cursor = buf.as_slice();
+        assert!(matches!(
+            String::decode(&mut cursor),
+            Err(Error::StringTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn truncated_buffer() {
+        let mut buf = Vec::new();
+        VarInt(10).encode(&mut buf).unwrap();
+        buf.extend_from_slice(b"short");
+
+        let mut cursor = buf.as_slice();
+        assert!(matches!(
+            String::decode(&mut cursor),
+            Err(Error::BufferUnderflow { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_utf8() {
+        let mut buf = Vec::new();
+        VarInt(2).encode(&mut buf).unwrap();
+        buf.extend_from_slice(&[0xFF, 0xFE]);
+
+        let mut cursor = buf.as_slice();
+        assert!(matches!(
+            String::decode(&mut cursor),
+            Err(Error::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn encoded_size_accounts_for_varint_prefix() {
+        assert_eq!("".to_string().encoded_size(), 1);
+        assert_eq!("hi".to_string().encoded_size(), 3);
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn string_roundtrip(s in ".{0,1000}") {
+                roundtrip(&s);
+            }
+        }
+    }
+}

--- a/crates/basalt-types/src/varint.rs
+++ b/crates/basalt-types/src/varint.rs
@@ -3,19 +3,31 @@ use crate::{Decode, Encode, EncodedSize, Error, Result};
 const SEGMENT_BITS: u8 = 0x7F;
 const CONTINUE_BIT: u8 = 0x80;
 
-/// Variable-length i32, encoded in 1-5 bytes.
+/// A variable-length encoded 32-bit signed integer, occupying 1 to 5 bytes.
 ///
-/// MSB of each byte is the continuation bit. Lower 7 bits carry the value,
-/// least significant group first.
+/// VarInt is the most common type in the Minecraft protocol. It is used for
+/// packet IDs, packet lengths, string length prefixes, array lengths, enum
+/// discriminants, and many field values. The encoding uses the MSB of each
+/// byte as a continuation bit (1 = more bytes follow, 0 = last byte), with
+/// the lower 7 bits carrying the value in little-endian order (least
+/// significant group first). Negative values use two's complement and
+/// always require 5 bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VarInt(pub i32);
 
 impl VarInt {
-    /// Maximum number of bytes a VarInt can occupy.
+    /// Maximum number of bytes a VarInt can occupy on the wire.
     pub const MAX_BYTES: usize = 5;
 }
 
+/// Encodes the VarInt as 1-5 bytes using MSB continuation bit encoding.
+///
+/// Each byte carries 7 bits of the value (least significant first). The MSB
+/// is set to 1 if more bytes follow, 0 on the final byte. Negative values
+/// are encoded as their unsigned two's complement representation and always
+/// produce 5 bytes.
 impl Encode for VarInt {
+    /// Writes the variable-length encoded bytes to the buffer.
     fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
         let mut value = self.0 as u32;
         loop {
@@ -29,7 +41,15 @@ impl Encode for VarInt {
     }
 }
 
+/// Decodes a VarInt by reading 1-5 bytes from the buffer.
+///
+/// Reads bytes one at a time, accumulating 7-bit groups until a byte
+/// without the continuation bit is found. If more than 5 bytes have
+/// the continuation bit set, the value would exceed 32 bits and the
+/// decoder returns `Error::VarIntTooLarge`. If the buffer runs out
+/// mid-VarInt, returns `Error::BufferUnderflow`.
 impl Decode for VarInt {
+    /// Reads and decodes a VarInt, advancing the cursor past all consumed bytes.
     fn decode(buf: &mut &[u8]) -> Result<Self> {
         let mut value: u32 = 0;
         let mut position: u32 = 0;
@@ -62,6 +82,11 @@ impl Decode for VarInt {
     }
 }
 
+/// Computes the number of bytes this VarInt will occupy when encoded.
+///
+/// Returns 1-5 based on the unsigned magnitude of the value. Small
+/// positive values (0-127) take 1 byte, while negative values always
+/// take 5 bytes due to two's complement sign extension.
 impl EncodedSize for VarInt {
     fn encoded_size(&self) -> usize {
         let value = self.0 as u32;
@@ -75,29 +100,39 @@ impl EncodedSize for VarInt {
     }
 }
 
+/// Wraps a raw `i32` into a `VarInt` for protocol encoding.
 impl From<i32> for VarInt {
     fn from(value: i32) -> Self {
         VarInt(value)
     }
 }
 
+/// Extracts the inner `i32` value from a `VarInt`.
 impl From<VarInt> for i32 {
     fn from(value: VarInt) -> Self {
         value.0
     }
 }
 
-/// Variable-length i64, encoded in 1-10 bytes.
+/// A variable-length encoded 64-bit signed integer, occupying 1 to 10 bytes.
 ///
-/// Same encoding as VarInt but for 64-bit values.
+/// VarLong uses the same MSB continuation bit encoding as [`VarInt`] but
+/// for 64-bit values. It is used in the protocol for large values like
+/// entity UUIDs in some contexts, timestamps, and world seed. Negative
+/// values use two's complement and always require 10 bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VarLong(pub i64);
 
 impl VarLong {
-    /// Maximum number of bytes a VarLong can occupy.
+    /// Maximum number of bytes a VarLong can occupy on the wire.
     pub const MAX_BYTES: usize = 10;
 }
 
+/// Encodes the VarLong as 1-10 bytes using MSB continuation bit encoding.
+///
+/// Same algorithm as [`VarInt`] but operating on 64-bit values. Negative
+/// values are encoded as their unsigned two's complement representation
+/// and always produce 10 bytes.
 impl Encode for VarLong {
     fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
         let mut value = self.0 as u64;
@@ -112,6 +147,12 @@ impl Encode for VarLong {
     }
 }
 
+/// Decodes a VarLong by reading 1-10 bytes from the buffer.
+///
+/// Same algorithm as [`VarInt`] decoding but allowing up to 10 bytes
+/// (64 bits). Returns `Error::VarIntTooLarge` if more than 10 bytes
+/// carry continuation bits, `Error::BufferUnderflow` if the buffer
+/// ends mid-value.
 impl Decode for VarLong {
     fn decode(buf: &mut &[u8]) -> Result<Self> {
         let mut value: u64 = 0;
@@ -144,6 +185,11 @@ impl Decode for VarLong {
     }
 }
 
+/// Computes the number of bytes this VarLong will occupy when encoded.
+///
+/// Returns 1-10 based on the unsigned magnitude. Small positive values
+/// (0-127) take 1 byte, `i64::MAX` takes 9, and negative values always
+/// take 10 bytes.
 impl EncodedSize for VarLong {
     fn encoded_size(&self) -> usize {
         let value = self.0 as u64;
@@ -162,12 +208,14 @@ impl EncodedSize for VarLong {
     }
 }
 
+/// Wraps a raw `i64` into a `VarLong` for protocol encoding.
 impl From<i64> for VarLong {
     fn from(value: i64) -> Self {
         VarLong(value)
     }
 }
 
+/// Extracts the inner `i64` value from a `VarLong`.
 impl From<VarLong> for i64 {
     fn from(value: VarLong) -> Self {
         value.0


### PR DESCRIPTION
## Summary

- `String` — VarInt-prefixed UTF-8 with 32767 byte max length
- `Vec<u8>` (ByteArray) — VarInt-prefixed raw byte sequence
- 16 new tests (unit + proptest roundtrip)

## Related issues

Closes #4

## Scope

`basalt-types` crate only (`src/string.rs`, `src/byte_array.rs`, `src/lib.rs`)

## Test plan

- [x] String roundtrip: empty, short, unicode, max-length
- [x] String errors: too long (encode + decode), truncated, invalid UTF-8
- [x] EncodedSize accounts for VarInt prefix
- [x] ByteArray roundtrip: empty, small, large (1024 bytes)
- [x] ByteArray errors: truncated buffer
- [x] Proptest roundtrip for both types
- [x] `cargo fmt/clippy/test` all pass