### PR TITLE
feat(types): implement UUID and Identifier

### DIFF
--- a/crates/basalt-types/src/identifier.rs
+++ b/crates/basalt-types/src/identifier.rs
@@ -1,0 +1,313 @@
+use std::fmt;
+
+use crate::{Decode, Encode, EncodedSize, Error, Result, VarInt};
+
+/// A namespaced identifier in the format `namespace:path`.
+///
+/// Identifiers (also called ResourceLocations) are used throughout the
+/// Minecraft protocol to reference game content: blocks (`minecraft:stone`),
+/// items (`minecraft:diamond`), entities (`minecraft:creeper`), dimensions
+/// (`minecraft:overworld`), registries, and plugin channels. They are
+/// encoded on the wire as a single VarInt-prefixed UTF-8 string in the
+/// format `namespace:path`.
+///
+/// The namespace defaults to `minecraft` when absent. Valid characters are:
+/// - Namespace: `[a-z0-9._-]`
+/// - Path: `[a-z0-9._-/]`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Identifier {
+    /// The namespace part (e.g., `minecraft`, `mymod`).
+    pub namespace: String,
+    /// The path part (e.g., `stone`, `textures/block/dirt`).
+    pub path: String,
+}
+
+impl Identifier {
+    /// Creates a new identifier with the given namespace and path.
+    ///
+    /// Validates that both namespace and path contain only allowed characters.
+    /// Returns `Error::InvalidData` if validation fails.
+    pub fn new(namespace: impl Into<String>, path: impl Into<String>) -> Result<Self> {
+        let namespace = namespace.into();
+        let path = path.into();
+
+        if !namespace.chars().all(is_valid_namespace_char) {
+            return Err(Error::InvalidData(format!(
+                "invalid namespace character in '{namespace}'"
+            )));
+        }
+        if !path.chars().all(is_valid_path_char) {
+            return Err(Error::InvalidData(format!(
+                "invalid path character in '{path}'"
+            )));
+        }
+
+        Ok(Self { namespace, path })
+    }
+
+    /// Creates a new identifier under the `minecraft` namespace.
+    ///
+    /// This is a convenience for the most common case, since the majority
+    /// of identifiers in the protocol use the `minecraft` namespace.
+    pub fn minecraft(path: impl Into<String>) -> Result<Self> {
+        Self::new("minecraft", path)
+    }
+
+    /// Returns the full identifier string in `namespace:path` format.
+    pub fn as_str(&self) -> String {
+        format!("{}:{}", self.namespace, self.path)
+    }
+}
+
+/// Returns true if the character is valid in an identifier namespace.
+///
+/// Allowed characters: lowercase ASCII letters, digits, dots, underscores,
+/// and hyphens (`[a-z0-9._-]`).
+fn is_valid_namespace_char(c: char) -> bool {
+    c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '_' || c == '-'
+}
+
+/// Returns true if the character is valid in an identifier path.
+///
+/// Allowed characters: same as namespace plus forward slashes
+/// (`[a-z0-9._-/]`). Slashes enable hierarchical paths like
+/// `textures/block/dirt`.
+fn is_valid_path_char(c: char) -> bool {
+    is_valid_namespace_char(c) || c == '/'
+}
+
+/// Parses an identifier string in `namespace:path` or bare `path` format.
+///
+/// If no colon is present, the namespace defaults to `minecraft`, matching
+/// the Minecraft protocol convention. Returns `Error::InvalidData` if the
+/// string contains invalid characters or is empty.
+fn parse_identifier(s: &str) -> Result<Identifier> {
+    if s.is_empty() {
+        return Err(Error::InvalidData("empty identifier".into()));
+    }
+
+    let (namespace, path) = match s.find(':') {
+        Some(pos) => (&s[..pos], &s[pos + 1..]),
+        None => ("minecraft", s),
+    };
+
+    Identifier::new(namespace, path)
+}
+
+/// Encodes an Identifier as a VarInt-prefixed UTF-8 string in `namespace:path` format.
+///
+/// The full `namespace:path` string is written using the standard Minecraft
+/// string encoding (VarInt length prefix + UTF-8 bytes). This is the same
+/// wire format used for all string fields in the protocol.
+impl Encode for Identifier {
+    /// Writes the identifier as a VarInt-prefixed `namespace:path` string.
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        self.as_str().encode(buf)
+    }
+}
+
+/// Decodes an Identifier from a VarInt-prefixed UTF-8 string.
+///
+/// Reads the string using the standard Minecraft string decoding, then
+/// parses it as `namespace:path`. If no colon is present, the namespace
+/// defaults to `minecraft`. Validates that all characters are in the
+/// allowed sets for namespace and path.
+impl Decode for Identifier {
+    /// Reads a protocol string and parses it as an identifier.
+    ///
+    /// Fails with `Error::InvalidData` if the identifier contains invalid
+    /// characters or is empty. Also inherits string decoding errors
+    /// (buffer underflow, string too long, invalid UTF-8).
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let s = String::decode(buf)?;
+        parse_identifier(&s)
+    }
+}
+
+/// Computes the wire size of the identifier in `namespace:path` format.
+///
+/// The total size includes the VarInt length prefix and the full
+/// `namespace:path` UTF-8 byte count (including the colon separator).
+impl EncodedSize for Identifier {
+    /// Returns the VarInt prefix size plus the byte length of `namespace:path`.
+    fn encoded_size(&self) -> usize {
+        let str_len = self.namespace.len() + 1 + self.path.len();
+        VarInt(str_len as i32).encoded_size() + str_len
+    }
+}
+
+/// Displays the identifier in `namespace:path` format.
+impl fmt::Display for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.namespace, self.path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(namespace: &str, path: &str) {
+        let id = Identifier::new(namespace, path).unwrap();
+        let mut buf = Vec::with_capacity(id.encoded_size());
+        id.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), id.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = Identifier::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, id);
+    }
+
+    // -- Construction --
+
+    #[test]
+    fn new_valid() {
+        let id = Identifier::new("minecraft", "stone").unwrap();
+        assert_eq!(id.namespace, "minecraft");
+        assert_eq!(id.path, "stone");
+    }
+
+    #[test]
+    fn minecraft_shorthand() {
+        let id = Identifier::minecraft("diamond").unwrap();
+        assert_eq!(id.namespace, "minecraft");
+        assert_eq!(id.path, "diamond");
+    }
+
+    #[test]
+    fn custom_namespace() {
+        let id = Identifier::new("mymod", "custom_block").unwrap();
+        assert_eq!(id.namespace, "mymod");
+        assert_eq!(id.path, "custom_block");
+    }
+
+    #[test]
+    fn path_with_slashes() {
+        let id = Identifier::new("minecraft", "textures/block/dirt").unwrap();
+        assert_eq!(id.path, "textures/block/dirt");
+    }
+
+    #[test]
+    fn invalid_namespace_uppercase() {
+        assert!(Identifier::new("Minecraft", "stone").is_err());
+    }
+
+    #[test]
+    fn invalid_namespace_space() {
+        assert!(Identifier::new("my mod", "stone").is_err());
+    }
+
+    #[test]
+    fn invalid_path_uppercase() {
+        assert!(Identifier::new("minecraft", "Stone").is_err());
+    }
+
+    #[test]
+    fn valid_special_chars() {
+        assert!(Identifier::new("my-mod.v2", "custom_item-v3").is_ok());
+    }
+
+    // -- Parsing --
+
+    #[test]
+    fn parse_with_namespace() {
+        let id = parse_identifier("minecraft:stone").unwrap();
+        assert_eq!(id.namespace, "minecraft");
+        assert_eq!(id.path, "stone");
+    }
+
+    #[test]
+    fn parse_without_namespace() {
+        let id = parse_identifier("stone").unwrap();
+        assert_eq!(id.namespace, "minecraft");
+        assert_eq!(id.path, "stone");
+    }
+
+    #[test]
+    fn parse_empty() {
+        assert!(parse_identifier("").is_err());
+    }
+
+    #[test]
+    fn parse_custom_namespace() {
+        let id = parse_identifier("mymod:custom_block").unwrap();
+        assert_eq!(id.namespace, "mymod");
+        assert_eq!(id.path, "custom_block");
+    }
+
+    // -- Encode/Decode --
+
+    #[test]
+    fn roundtrip_minecraft() {
+        roundtrip("minecraft", "stone");
+    }
+
+    #[test]
+    fn roundtrip_custom() {
+        roundtrip("mymod", "custom_block");
+    }
+
+    #[test]
+    fn roundtrip_with_path_slashes() {
+        roundtrip("minecraft", "textures/block/dirt");
+    }
+
+    #[test]
+    fn decode_bare_path() {
+        // Encode "stone" (no namespace) as a raw string
+        let mut buf = Vec::new();
+        "stone".to_string().encode(&mut buf).unwrap();
+
+        let mut cursor = buf.as_slice();
+        let id = Identifier::decode(&mut cursor).unwrap();
+        assert_eq!(id.namespace, "minecraft");
+        assert_eq!(id.path, "stone");
+    }
+
+    // -- Display --
+
+    #[test]
+    fn display() {
+        let id = Identifier::new("minecraft", "stone").unwrap();
+        assert_eq!(id.to_string(), "minecraft:stone");
+    }
+
+    #[test]
+    fn as_str() {
+        let id = Identifier::new("mymod", "item").unwrap();
+        assert_eq!(id.as_str(), "mymod:item");
+    }
+
+    // -- EncodedSize --
+
+    #[test]
+    fn encoded_size_includes_colon() {
+        let id = Identifier::new("minecraft", "stone").unwrap();
+        // "minecraft:stone" = 15 chars, VarInt(15) = 1 byte
+        assert_eq!(id.encoded_size(), 16);
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn namespace_strategy() -> impl Strategy<Value = String> {
+            "[a-z0-9._\\-]{1,20}"
+        }
+
+        fn path_strategy() -> impl Strategy<Value = String> {
+            "[a-z0-9._\\-/]{1,50}"
+        }
+
+        proptest! {
+            #[test]
+            fn identifier_roundtrip(
+                namespace in namespace_strategy(),
+                path in path_strategy(),
+            ) {
+                roundtrip(&namespace, &path);
+            }
+        }
+    }
+}

--- a/crates/basalt-types/src/lib.rs
+++ b/crates/basalt-types/src/lib.rs
@@ -1,12 +1,16 @@
 mod byte_array;
 pub mod error;
+mod identifier;
 mod position;
 mod primitives;
 mod string;
 pub mod traits;
+mod uuid;
 mod varint;
 
 pub use error::{Error, Result};
+pub use identifier::Identifier;
 pub use position::{BlockPosition, ChunkPosition, Position};
 pub use traits::{Decode, Encode, EncodedSize};
+pub use uuid::Uuid;
 pub use varint::{VarInt, VarLong};

--- a/crates/basalt-types/src/uuid.rs
+++ b/crates/basalt-types/src/uuid.rs
@@ -1,0 +1,236 @@
+use std::fmt;
+
+use crate::{Decode, Encode, EncodedSize, Result};
+
+/// A 128-bit universally unique identifier used throughout the Minecraft protocol.
+///
+/// UUIDs identify players, entities, and various protocol objects. They are
+/// encoded as two consecutive big-endian 64-bit integers (most significant
+/// bits first, then least significant bits), occupying exactly 16 bytes on
+/// the wire. The Minecraft protocol uses UUIDs in login packets (player UUID),
+/// entity spawn packets, player info, and boss bar management.
+///
+/// The standard display format is `8-4-4-4-12` lowercase hex with dashes
+/// (e.g., `550e8400-e29b-41d4-a716-446655440000`).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Uuid {
+    /// Most significant 64 bits of the UUID.
+    pub most: u64,
+    /// Least significant 64 bits of the UUID.
+    pub least: u64,
+}
+
+impl Uuid {
+    /// Creates a new UUID from its most and least significant 64-bit halves.
+    pub fn new(most: u64, least: u64) -> Self {
+        Self { most, least }
+    }
+
+    /// Creates a UUID from a 16-byte array in big-endian order.
+    ///
+    /// The first 8 bytes form the most significant bits, the last 8 form
+    /// the least significant bits.
+    pub fn from_bytes(bytes: [u8; 16]) -> Self {
+        let most = u64::from_be_bytes(bytes[..8].try_into().unwrap());
+        let least = u64::from_be_bytes(bytes[8..].try_into().unwrap());
+        Self { most, least }
+    }
+
+    /// Converts the UUID to a 16-byte array in big-endian order.
+    pub fn to_bytes(self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[..8].copy_from_slice(&self.most.to_be_bytes());
+        bytes[8..].copy_from_slice(&self.least.to_be_bytes());
+        bytes
+    }
+}
+
+/// Encodes a UUID as two consecutive big-endian u64 values (16 bytes total).
+///
+/// The most significant 64 bits are written first, followed by the least
+/// significant 64 bits. This matches the Minecraft protocol wire format
+/// for all UUID fields.
+impl Encode for Uuid {
+    /// Writes the UUID as 16 big-endian bytes (most significant first).
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        self.most.encode(buf)?;
+        self.least.encode(buf)
+    }
+}
+
+/// Decodes a UUID from two consecutive big-endian u64 values (16 bytes).
+///
+/// Reads the most significant 64 bits first, then the least significant
+/// 64 bits. Fails if fewer than 16 bytes remain in the buffer.
+impl Decode for Uuid {
+    /// Reads 16 big-endian bytes and reconstructs the UUID.
+    ///
+    /// Fails with `Error::BufferUnderflow` if fewer than 16 bytes remain.
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let most = u64::decode(buf)?;
+        let least = u64::decode(buf)?;
+        Ok(Self { most, least })
+    }
+}
+
+/// A UUID always occupies exactly 16 bytes on the wire.
+impl EncodedSize for Uuid {
+    fn encoded_size(&self) -> usize {
+        16
+    }
+}
+
+/// Displays the UUID in the standard `8-4-4-4-12` lowercase hex format.
+///
+/// This matches the format used by Mojang's API and the Minecraft client
+/// (e.g., `550e8400-e29b-41d4-a716-446655440000`).
+impl fmt::Display for Uuid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bytes = self.to_bytes();
+        write!(
+            f,
+            "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            bytes[0],
+            bytes[1],
+            bytes[2],
+            bytes[3],
+            bytes[4],
+            bytes[5],
+            bytes[6],
+            bytes[7],
+            bytes[8],
+            bytes[9],
+            bytes[10],
+            bytes[11],
+            bytes[12],
+            bytes[13],
+            bytes[14],
+            bytes[15],
+        )
+    }
+}
+
+/// Debug output uses the same `8-4-4-4-12` hex format as Display for readability.
+impl fmt::Debug for Uuid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Uuid({})", self)
+    }
+}
+
+/// Converts a 16-byte array into a UUID.
+impl From<[u8; 16]> for Uuid {
+    fn from(bytes: [u8; 16]) -> Self {
+        Self::from_bytes(bytes)
+    }
+}
+
+/// Converts a UUID into a 16-byte array in big-endian order.
+impl From<Uuid> for [u8; 16] {
+    fn from(uuid: Uuid) -> Self {
+        uuid.to_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(most: u64, least: u64) {
+        let uuid = Uuid::new(most, least);
+        let mut buf = Vec::with_capacity(uuid.encoded_size());
+        uuid.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), 16);
+
+        let mut cursor = buf.as_slice();
+        let decoded = Uuid::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, uuid);
+    }
+
+    #[test]
+    fn zero_uuid() {
+        roundtrip(0, 0);
+    }
+
+    #[test]
+    fn max_uuid() {
+        roundtrip(u64::MAX, u64::MAX);
+    }
+
+    #[test]
+    fn known_uuid() {
+        // Notch's UUID: 069a79f4-44e9-4726-a5be-fca90e38aaf5
+        let uuid = Uuid::new(0x069a79f444e94726, 0xa5befca90e38aaf5);
+        roundtrip(uuid.most, uuid.least);
+    }
+
+    #[test]
+    fn display_format() {
+        let uuid = Uuid::new(0x550e8400e29b41d4, 0xa716446655440000);
+        assert_eq!(uuid.to_string(), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn debug_format() {
+        let uuid = Uuid::new(0x550e8400e29b41d4, 0xa716446655440000);
+        assert_eq!(
+            format!("{:?}", uuid),
+            "Uuid(550e8400-e29b-41d4-a716-446655440000)"
+        );
+    }
+
+    #[test]
+    fn from_bytes() {
+        let bytes = [
+            0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44,
+            0x00, 0x00,
+        ];
+        let uuid = Uuid::from_bytes(bytes);
+        assert_eq!(uuid.most, 0x550e8400e29b41d4);
+        assert_eq!(uuid.least, 0xa716446655440000);
+    }
+
+    #[test]
+    fn to_bytes() {
+        let uuid = Uuid::new(0x550e8400e29b41d4, 0xa716446655440000);
+        let bytes = uuid.to_bytes();
+        assert_eq!(
+            bytes,
+            [
+                0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44,
+                0x00, 0x00
+            ]
+        );
+    }
+
+    #[test]
+    fn bytes_roundtrip() {
+        let original = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let uuid = Uuid::from(original);
+        let back: [u8; 16] = uuid.into();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn encoded_size_is_16() {
+        assert_eq!(Uuid::new(0, 0).encoded_size(), 16);
+    }
+
+    #[test]
+    fn underflow() {
+        let mut cursor: &[u8] = &[0x01; 15];
+        assert!(Uuid::decode(&mut cursor).is_err());
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn uuid_roundtrip(most: u64, least: u64) {
+                roundtrip(most, least);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `Uuid` — 128-bit identifier encoded as two big-endian u64 (16 bytes), Display in 8-4-4-4-12 hex, From/Into for `[u8; 16]`
- `Identifier` — namespaced `namespace:path` format, validated character sets, defaults to `minecraft` namespace when absent
- 31 new tests (unit + proptest roundtrip)

## Related issues

Closes #6

## Scope

`basalt-types` crate only (`src/uuid.rs`, `src/identifier.rs`, `src/lib.rs`)

## Test plan

- [x] UUID roundtrip: zero, max, known (Notch's UUID)
- [x] UUID Display/Debug format verification
- [x] UUID from_bytes/to_bytes/bytes roundtrip
- [x] Identifier construction: valid, minecraft shorthand, custom namespace, path with slashes
- [x] Identifier validation: rejects uppercase, spaces, invalid chars
- [x] Identifier parsing: with namespace, without (defaults to minecraft), empty
- [x] Identifier encode/decode roundtrip
- [x] Proptest roundtrip for both types
- [x] `cargo fmt/clippy/test` all pass (131 tests total)