### PR TITLE
feat(derive): implement Encode/Decode/EncodedSize derive macros

### DIFF
--- a/crates/basalt-derive/src/attrs.rs
+++ b/crates/basalt-derive/src/attrs.rs
@@ -1,0 +1,172 @@
+use proc_macro2::Span;
+use syn::{Attribute, Expr, ExprLit, ExprUnary, Lit, Result, UnOp};
+
+/// Parsed `#[packet(id = 0x00)]` attribute on a struct.
+#[derive(Debug, Clone)]
+pub struct PacketAttr {
+    /// The packet ID as an integer literal.
+    pub id: i32,
+}
+
+/// Parsed `#[field(...)]` attribute on a struct field.
+#[derive(Debug, Clone, Default)]
+pub struct FieldAttr {
+    /// Encode this integer as VarInt (i32) or VarLong (i64).
+    pub varint: bool,
+
+    /// This field has a VarInt length prefix (for Vec types).
+    pub length_varint: bool,
+
+    /// This field is a boolean-prefixed Option (Minecraft pattern).
+    pub optional: bool,
+
+    /// This field consumes all remaining bytes (must be the last field).
+    pub rest: bool,
+}
+
+/// Parsed `#[variant(id = N)]` attribute on an enum variant.
+#[derive(Debug, Clone)]
+pub struct VariantAttr {
+    /// Explicit discriminant value for this variant.
+    pub id: i32,
+}
+
+/// Parses an integer expression, handling both positive literals (`42`)
+/// and negative literals (`-1`) which Rust parses as unary minus + int literal.
+fn parse_int_expr(expr: &Expr) -> syn::Result<i32> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(lit_int),
+            ..
+        }) => lit_int.base10_parse::<i32>(),
+        Expr::Unary(ExprUnary {
+            op: UnOp::Neg(_),
+            expr: inner,
+            ..
+        }) => {
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Int(lit_int),
+                ..
+            }) = inner.as_ref()
+            {
+                Ok(-lit_int.base10_parse::<i32>()?)
+            } else {
+                Err(syn::Error::new_spanned(expr, "expected integer literal"))
+            }
+        }
+        _ => Err(syn::Error::new_spanned(expr, "expected integer literal")),
+    }
+}
+
+/// Extracts the `#[packet(id = ...)]` attribute from a list of attributes.
+///
+/// Returns `None` if no `#[packet]` attribute is present. Returns an error
+/// if the attribute is malformed (missing `id`, wrong type, etc.).
+pub fn parse_packet_attr(attrs: &[Attribute]) -> Result<Option<PacketAttr>> {
+    for attr in attrs {
+        if !attr.path().is_ident("packet") {
+            continue;
+        }
+
+        let mut id = None;
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("id") {
+                let value = meta.value()?;
+                let expr: Expr = value.parse()?;
+                id = Some(parse_int_expr(&expr)?);
+                Ok(())
+            } else {
+                Err(meta.error("expected `id`"))
+            }
+        })?;
+
+        match id {
+            Some(id) => return Ok(Some(PacketAttr { id })),
+            None => {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "#[packet] requires `id` parameter",
+                ));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Extracts the `#[field(...)]` attribute from a list of attributes.
+///
+/// Supports multiple flags: `varint`, `optional`, `rest`, `length = "varint"`.
+/// Returns a default `FieldAttr` if no `#[field]` attribute is present.
+pub fn parse_field_attr(attrs: &[Attribute]) -> Result<FieldAttr> {
+    let mut field_attr = FieldAttr::default();
+
+    for attr in attrs {
+        if !attr.path().is_ident("field") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("varint") {
+                field_attr.varint = true;
+                Ok(())
+            } else if meta.path.is_ident("optional") {
+                field_attr.optional = true;
+                Ok(())
+            } else if meta.path.is_ident("rest") {
+                field_attr.rest = true;
+                Ok(())
+            } else if meta.path.is_ident("length") {
+                let value = meta.value()?;
+                let lit: Lit = value.parse()?;
+                if let Lit::Str(s) = lit {
+                    if s.value() == "varint" {
+                        field_attr.length_varint = true;
+                        Ok(())
+                    } else {
+                        Err(syn::Error::new_spanned(s, "expected \"varint\""))
+                    }
+                } else {
+                    Err(syn::Error::new_spanned(lit, "expected string literal"))
+                }
+            } else {
+                Err(meta.error("expected `varint`, `optional`, `rest`, or `length`"))
+            }
+        })?;
+    }
+
+    Ok(field_attr)
+}
+
+/// Extracts the `#[variant(id = N)]` attribute from a list of attributes.
+///
+/// Returns `None` if no `#[variant]` attribute is present.
+pub fn parse_variant_attr(attrs: &[Attribute]) -> Result<Option<VariantAttr>> {
+    for attr in attrs {
+        if !attr.path().is_ident("variant") {
+            continue;
+        }
+
+        let mut id = None;
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("id") {
+                let value = meta.value()?;
+                let expr: Expr = value.parse()?;
+                id = Some(parse_int_expr(&expr)?);
+                Ok(())
+            } else {
+                Err(meta.error("expected `id`"))
+            }
+        })?;
+
+        match id {
+            Some(id) => return Ok(Some(VariantAttr { id })),
+            None => {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "#[variant] requires `id` parameter",
+                ));
+            }
+        }
+    }
+    Ok(None)
+}

--- a/crates/basalt-derive/src/decode.rs
+++ b/crates/basalt-derive/src/decode.rs
@@ -1,0 +1,222 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Result};
+
+use crate::attrs::{parse_field_attr, parse_packet_attr, parse_variant_attr};
+
+/// Generates the `Decode` implementation for a struct or enum.
+pub fn derive_decode(input: &DeriveInput) -> Result<TokenStream> {
+    match &input.data {
+        Data::Struct(data) => derive_decode_struct(input, data),
+        Data::Enum(data) => derive_decode_enum(input, data),
+        Data::Union(_) => Err(syn::Error::new_spanned(
+            input,
+            "Decode cannot be derived for unions",
+        )),
+    }
+}
+
+/// Generates `Decode` for a struct: decodes each field in declaration order.
+///
+/// If `#[packet(id = ...)]` is present, the packet ID is decoded as a VarInt
+/// and validated before reading the fields.
+fn derive_decode_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let packet_attr = parse_packet_attr(&input.attrs)?;
+
+    let fields = match &data.fields {
+        Fields::Named(fields) => &fields.named,
+        Fields::Unnamed(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Decode derive does not support tuple structs",
+            ));
+        }
+        Fields::Unit => {
+            let packet_decode = packet_attr.map(|p| {
+                let id = p.id;
+                let err_msg = format!("expected packet ID {id:#04x}");
+                quote! {
+                    let packet_id = basalt_types::Decode::decode(buf)?;
+                    if basalt_types::VarInt(#id) != packet_id {
+                        return Err(basalt_types::Error::InvalidData(#err_msg.into()));
+                    }
+                }
+            });
+            return Ok(quote! {
+                impl #impl_generics basalt_types::Decode for #name #ty_generics #where_clause {
+                    fn decode(buf: &mut &[u8]) -> basalt_types::Result<Self> {
+                        #packet_decode
+                        Ok(#name)
+                    }
+                }
+            });
+        }
+    };
+
+    let packet_decode = packet_attr.map(|p| {
+        let id = p.id;
+        let err_msg = format!("expected packet ID {id:#04x}");
+        quote! {
+            let packet_id: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+            if packet_id != basalt_types::VarInt(#id) {
+                return Err(basalt_types::Error::InvalidData(#err_msg.into()));
+            }
+        }
+    });
+
+    let mut field_decodes = Vec::new();
+    let mut field_names = Vec::new();
+
+    for field in fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let field_type = &field.ty;
+        let attr = parse_field_attr(&field.attrs)?;
+
+        field_names.push(field_name);
+
+        let decode = if attr.varint {
+            quote! {
+                let #field_name = {
+                    let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                    var.0
+                };
+            }
+        } else if attr.optional {
+            quote! {
+                let #field_name = {
+                    let present: bool = basalt_types::Decode::decode(buf)?;
+                    if present {
+                        Some(basalt_types::Decode::decode(buf)?)
+                    } else {
+                        None
+                    }
+                };
+            }
+        } else if attr.length_varint {
+            quote! {
+                let #field_name = {
+                    let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                    let len = len.0 as usize;
+                    let mut items = Vec::with_capacity(len);
+                    for _ in 0..len {
+                        items.push(basalt_types::Decode::decode(buf)?);
+                    }
+                    items
+                };
+            }
+        } else if attr.rest {
+            quote! {
+                let #field_name = {
+                    let rest = buf.to_vec();
+                    *buf = &buf[buf.len()..];
+                    rest
+                };
+            }
+        } else {
+            quote! {
+                let #field_name: #field_type = basalt_types::Decode::decode(buf)?;
+            }
+        };
+
+        field_decodes.push(decode);
+    }
+
+    Ok(quote! {
+        impl #impl_generics basalt_types::Decode for #name #ty_generics #where_clause {
+            fn decode(buf: &mut &[u8]) -> basalt_types::Result<Self> {
+                #packet_decode
+                #(#field_decodes)*
+                Ok(#name {
+                    #(#field_names),*
+                })
+            }
+        }
+    })
+}
+
+/// Generates `Decode` for an enum: reads a VarInt discriminant and decodes
+/// the corresponding variant's fields.
+fn derive_decode_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+    let mut next_id: i32 = 0;
+
+    for variant in &data.variants {
+        let variant_name = &variant.ident;
+        let variant_attr = parse_variant_attr(&variant.attrs)?;
+        let id = variant_attr.map_or(next_id, |a| a.id);
+        next_id = id + 1;
+
+        let arm = match &variant.fields {
+            Fields::Unit => {
+                quote! {
+                    #id => Ok(#name::#variant_name),
+                }
+            }
+            Fields::Named(fields) => {
+                let field_names: Vec<_> = fields
+                    .named
+                    .iter()
+                    .map(|f| f.ident.as_ref().unwrap())
+                    .collect();
+                let field_types: Vec<_> = fields.named.iter().map(|f| &f.ty).collect();
+                let field_decodes: Vec<_> = field_names
+                    .iter()
+                    .zip(field_types.iter())
+                    .map(|(name, ty)| {
+                        quote! {
+                            let #name: #ty = basalt_types::Decode::decode(buf)?;
+                        }
+                    })
+                    .collect();
+                quote! {
+                    #id => {
+                        #(#field_decodes)*
+                        Ok(#name::#variant_name { #(#field_names),* })
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let field_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|i| syn::Ident::new(&format!("f{i}"), proc_macro2::Span::call_site()))
+                    .collect();
+                let field_types: Vec<_> = fields.unnamed.iter().map(|f| &f.ty).collect();
+                let field_decodes: Vec<_> = field_names
+                    .iter()
+                    .zip(field_types.iter())
+                    .map(|(name, ty)| {
+                        quote! {
+                            let #name: #ty = basalt_types::Decode::decode(buf)?;
+                        }
+                    })
+                    .collect();
+                quote! {
+                    #id => {
+                        #(#field_decodes)*
+                        Ok(#name::#variant_name(#(#field_names),*))
+                    }
+                }
+            }
+        };
+        match_arms.push(arm);
+    }
+
+    let name_str = name.to_string();
+    Ok(quote! {
+        impl #impl_generics basalt_types::Decode for #name #ty_generics #where_clause {
+            fn decode(buf: &mut &[u8]) -> basalt_types::Result<Self> {
+                let discriminant: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                match discriminant.0 {
+                    #(#match_arms)*
+                    other => Err(basalt_types::Error::InvalidData(
+                        format!("unknown {} discriminant: {}", #name_str, other)
+                    )),
+                }
+            }
+        }
+    })
+}

--- a/crates/basalt-derive/src/encode.rs
+++ b/crates/basalt-derive/src/encode.rs
@@ -1,0 +1,191 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Result};
+
+use crate::attrs::{parse_field_attr, parse_packet_attr, parse_variant_attr};
+
+/// Generates the `Encode` implementation for a struct or enum.
+pub fn derive_encode(input: &DeriveInput) -> Result<TokenStream> {
+    match &input.data {
+        Data::Struct(data) => derive_encode_struct(input, data),
+        Data::Enum(data) => derive_encode_enum(input, data),
+        Data::Union(_) => Err(syn::Error::new_spanned(
+            input,
+            "Encode cannot be derived for unions",
+        )),
+    }
+}
+
+/// Generates `Encode` for a struct: encodes each field in declaration order.
+///
+/// If `#[packet(id = ...)]` is present, the packet ID is encoded as a VarInt
+/// before the fields.
+fn derive_encode_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let packet_attr = parse_packet_attr(&input.attrs)?;
+
+    let fields = match &data.fields {
+        Fields::Named(fields) => &fields.named,
+        Fields::Unnamed(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Encode derive does not support tuple structs",
+            ));
+        }
+        Fields::Unit => {
+            // Unit struct — nothing to encode beyond packet ID
+            let packet_encode = packet_attr.map(|p| {
+                let id = p.id;
+                quote! {
+                    basalt_types::Encode::encode(&basalt_types::VarInt(#id), buf)?;
+                }
+            });
+            return Ok(quote! {
+                impl #impl_generics basalt_types::Encode for #name #ty_generics #where_clause {
+                    fn encode(&self, buf: &mut Vec<u8>) -> basalt_types::Result<()> {
+                        #packet_encode
+                        Ok(())
+                    }
+                }
+            });
+        }
+    };
+
+    let packet_encode = packet_attr.map(|p| {
+        let id = p.id;
+        quote! {
+            basalt_types::Encode::encode(&basalt_types::VarInt(#id), buf)?;
+        }
+    });
+
+    let mut field_encodes = Vec::new();
+    for field in fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let attr = parse_field_attr(&field.attrs)?;
+
+        let encode = if attr.varint {
+            quote! {
+                basalt_types::Encode::encode(&basalt_types::VarInt(self.#field_name), buf)?;
+            }
+        } else if attr.optional {
+            quote! {
+                match &self.#field_name {
+                    Some(value) => {
+                        basalt_types::Encode::encode(&true, buf)?;
+                        basalt_types::Encode::encode(value, buf)?;
+                    }
+                    None => {
+                        basalt_types::Encode::encode(&false, buf)?;
+                    }
+                }
+            }
+        } else if attr.length_varint {
+            quote! {
+                basalt_types::Encode::encode(&basalt_types::VarInt(self.#field_name.len() as i32), buf)?;
+                for item in &self.#field_name {
+                    basalt_types::Encode::encode(item, buf)?;
+                }
+            }
+        } else if attr.rest {
+            quote! {
+                buf.extend_from_slice(&self.#field_name);
+            }
+        } else {
+            quote! {
+                basalt_types::Encode::encode(&self.#field_name, buf)?;
+            }
+        };
+
+        field_encodes.push(encode);
+    }
+
+    Ok(quote! {
+        impl #impl_generics basalt_types::Encode for #name #ty_generics #where_clause {
+            fn encode(&self, buf: &mut Vec<u8>) -> basalt_types::Result<()> {
+                #packet_encode
+                #(#field_encodes)*
+                Ok(())
+            }
+        }
+    })
+}
+
+/// Generates `Encode` for an enum: encodes a VarInt discriminant followed
+/// by the variant's fields (if any).
+fn derive_encode_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+    let mut next_id: i32 = 0;
+
+    for variant in &data.variants {
+        let variant_name = &variant.ident;
+        let variant_attr = parse_variant_attr(&variant.attrs)?;
+        let id = variant_attr.map_or(next_id, |a| a.id);
+        next_id = id + 1;
+
+        let arm = match &variant.fields {
+            Fields::Unit => {
+                quote! {
+                    #name::#variant_name => {
+                        basalt_types::Encode::encode(&basalt_types::VarInt(#id), buf)?;
+                    }
+                }
+            }
+            Fields::Named(fields) => {
+                let field_names: Vec<_> = fields
+                    .named
+                    .iter()
+                    .map(|f| f.ident.as_ref().unwrap())
+                    .collect();
+                let field_encodes: Vec<_> = field_names
+                    .iter()
+                    .map(|name| {
+                        quote! {
+                            basalt_types::Encode::encode(#name, buf)?;
+                        }
+                    })
+                    .collect();
+                quote! {
+                    #name::#variant_name { #(#field_names),* } => {
+                        basalt_types::Encode::encode(&basalt_types::VarInt(#id), buf)?;
+                        #(#field_encodes)*
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let field_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|i| syn::Ident::new(&format!("f{i}"), proc_macro2::Span::call_site()))
+                    .collect();
+                let field_encodes: Vec<_> = field_names
+                    .iter()
+                    .map(|name| {
+                        quote! {
+                            basalt_types::Encode::encode(#name, buf)?;
+                        }
+                    })
+                    .collect();
+                quote! {
+                    #name::#variant_name(#(#field_names),*) => {
+                        basalt_types::Encode::encode(&basalt_types::VarInt(#id), buf)?;
+                        #(#field_encodes)*
+                    }
+                }
+            }
+        };
+        match_arms.push(arm);
+    }
+
+    Ok(quote! {
+        impl #impl_generics basalt_types::Encode for #name #ty_generics #where_clause {
+            fn encode(&self, buf: &mut Vec<u8>) -> basalt_types::Result<()> {
+                match self {
+                    #(#match_arms)*
+                }
+                Ok(())
+            }
+        }
+    })
+}

--- a/crates/basalt-derive/src/lib.rs
+++ b/crates/basalt-derive/src/lib.rs
@@ -1,1 +1,79 @@
+//! Proc-macro crate for deriving `Encode`, `Decode`, and `EncodedSize` traits.
+//!
+//! Generates serialization implementations for Minecraft protocol structs
+//! and enums. The generated code references `basalt_types` — consumer crates
+//! must depend on `basalt-types` alongside `basalt-derive`.
+//!
+//! # Struct attributes
+//!
+//! - `#[packet(id = 0x00)]` — associates a packet ID, encoded as VarInt before fields
+//!
+//! # Field attributes
+//!
+//! - `#[field(varint)]` — encode i32/i64 as VarInt/VarLong
+//! - `#[field(length = "varint")]` — VarInt length prefix for Vec
+//! - `#[field(optional)]` — boolean-prefixed Option
+//! - `#[field(rest)]` — consume remaining bytes (last field only, must be Vec<u8>)
+//!
+//! # Enum attributes
+//!
+//! - `#[variant(id = N)]` — explicit discriminant (default: sequential from 0)
 
+mod attrs;
+mod decode;
+mod encode;
+mod size;
+
+use proc_macro::TokenStream;
+use syn::{DeriveInput, parse_macro_input};
+
+/// Derives the `Encode` trait for a struct or enum.
+///
+/// For structs, encodes each field in declaration order. If `#[packet(id)]`
+/// is present, a VarInt packet ID is written first. Field attributes control
+/// encoding behavior (varint, optional, length-prefixed, rest).
+///
+/// For enums, writes a VarInt discriminant followed by the variant's fields.
+/// Discriminants are sequential from 0 unless overridden with `#[variant(id)]`.
+#[proc_macro_derive(Encode, attributes(packet, field, variant))]
+pub fn derive_encode(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match encode::derive_encode(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Derives the `Decode` trait for a struct or enum.
+///
+/// For structs, decodes each field in declaration order. If `#[packet(id)]`
+/// is present, a VarInt packet ID is read and validated first. Field
+/// attributes control decoding behavior.
+///
+/// For enums, reads a VarInt discriminant and decodes the matching variant.
+/// Returns `Error::InvalidData` for unknown discriminants.
+#[proc_macro_derive(Decode, attributes(packet, field, variant))]
+pub fn derive_decode(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match decode::derive_decode(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Derives the `EncodedSize` trait for a struct or enum.
+///
+/// For structs, sums the encoded size of each field. If `#[packet(id)]`
+/// is present, includes the VarInt packet ID size. Field attributes
+/// are accounted for (varint size, optional prefix byte, length prefix).
+///
+/// For enums, returns the VarInt discriminant size plus the matched
+/// variant's fields size.
+#[proc_macro_derive(EncodedSize, attributes(packet, field, variant))]
+pub fn derive_encoded_size(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match size::derive_encoded_size(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}

--- a/crates/basalt-derive/src/size.rs
+++ b/crates/basalt-derive/src/size.rs
@@ -1,0 +1,176 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Result};
+
+use crate::attrs::{parse_field_attr, parse_packet_attr, parse_variant_attr};
+
+/// Generates the `EncodedSize` implementation for a struct or enum.
+pub fn derive_encoded_size(input: &DeriveInput) -> Result<TokenStream> {
+    match &input.data {
+        Data::Struct(data) => derive_encoded_size_struct(input, data),
+        Data::Enum(data) => derive_encoded_size_enum(input, data),
+        Data::Union(_) => Err(syn::Error::new_spanned(
+            input,
+            "EncodedSize cannot be derived for unions",
+        )),
+    }
+}
+
+/// Generates `EncodedSize` for a struct: sums the encoded size of each field.
+///
+/// If `#[packet(id = ...)]` is present, includes the VarInt packet ID size.
+fn derive_encoded_size_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let packet_attr = parse_packet_attr(&input.attrs)?;
+
+    let fields = match &data.fields {
+        Fields::Named(fields) => &fields.named,
+        Fields::Unnamed(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "EncodedSize derive does not support tuple structs",
+            ));
+        }
+        Fields::Unit => {
+            let packet_size = packet_attr.map(|p| {
+                let id = p.id;
+                quote! { basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#id)) }
+            });
+            let total = packet_size.unwrap_or(quote! { 0 });
+            return Ok(quote! {
+                impl #impl_generics basalt_types::EncodedSize for #name #ty_generics #where_clause {
+                    fn encoded_size(&self) -> usize {
+                        #total
+                    }
+                }
+            });
+        }
+    };
+
+    let packet_size = packet_attr.map(|p| {
+        let id = p.id;
+        quote! { basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#id)) + }
+    });
+
+    let mut field_sizes = Vec::new();
+    for field in fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let attr = parse_field_attr(&field.attrs)?;
+
+        let size = if attr.varint {
+            quote! {
+                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(self.#field_name))
+            }
+        } else if attr.optional {
+            quote! {
+                1 + match &self.#field_name {
+                    Some(value) => basalt_types::EncodedSize::encoded_size(value),
+                    None => 0,
+                }
+            }
+        } else if attr.length_varint {
+            quote! {
+                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(self.#field_name.len() as i32))
+                + self.#field_name.iter().map(|item| basalt_types::EncodedSize::encoded_size(item)).sum::<usize>()
+            }
+        } else if attr.rest {
+            quote! {
+                self.#field_name.len()
+            }
+        } else {
+            quote! {
+                basalt_types::EncodedSize::encoded_size(&self.#field_name)
+            }
+        };
+
+        field_sizes.push(size);
+    }
+
+    Ok(quote! {
+        impl #impl_generics basalt_types::EncodedSize for #name #ty_generics #where_clause {
+            fn encoded_size(&self) -> usize {
+                #packet_size
+                #(#field_sizes)+*
+            }
+        }
+    })
+}
+
+/// Generates `EncodedSize` for an enum: VarInt discriminant size plus
+/// the variant's fields size.
+fn derive_encoded_size_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+    let mut next_id: i32 = 0;
+
+    for variant in &data.variants {
+        let variant_name = &variant.ident;
+        let variant_attr = parse_variant_attr(&variant.attrs)?;
+        let id = variant_attr.map_or(next_id, |a| a.id);
+        next_id = id + 1;
+
+        let arm = match &variant.fields {
+            Fields::Unit => {
+                quote! {
+                    #name::#variant_name => {
+                        basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#id))
+                    }
+                }
+            }
+            Fields::Named(fields) => {
+                let field_names: Vec<_> = fields
+                    .named
+                    .iter()
+                    .map(|f| f.ident.as_ref().unwrap())
+                    .collect();
+                let field_sizes: Vec<_> = field_names
+                    .iter()
+                    .map(|name| {
+                        quote! {
+                            basalt_types::EncodedSize::encoded_size(#name)
+                        }
+                    })
+                    .collect();
+                quote! {
+                    #name::#variant_name { #(#field_names),* } => {
+                        basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#id))
+                        #(+ #field_sizes)*
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let field_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|i| syn::Ident::new(&format!("f{i}"), proc_macro2::Span::call_site()))
+                    .collect();
+                let field_sizes: Vec<_> = field_names
+                    .iter()
+                    .map(|name| {
+                        quote! {
+                            basalt_types::EncodedSize::encoded_size(#name)
+                        }
+                    })
+                    .collect();
+                quote! {
+                    #name::#variant_name(#(#field_names),*) => {
+                        basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#id))
+                        #(+ #field_sizes)*
+                    }
+                }
+            }
+        };
+        match_arms.push(arm);
+    }
+
+    Ok(quote! {
+        impl #impl_generics basalt_types::EncodedSize for #name #ty_generics #where_clause {
+            fn encoded_size(&self) -> usize {
+                match self {
+                    #(#match_arms)*
+                }
+            }
+        }
+    })
+}

--- a/crates/basalt-protocol/src/lib.rs
+++ b/crates/basalt-protocol/src/lib.rs
@@ -1,1 +1,413 @@
+#[cfg(test)]
+mod derive_tests {
+    use basalt_derive::{Decode, Encode, EncodedSize};
+    use basalt_types::{Decode as _, Encode as _, EncodedSize as _, Error, VarInt};
 
+    // -- Basic struct --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    struct SimpleStruct {
+        x: i32,
+        y: i32,
+        z: i32,
+    }
+
+    #[test]
+    fn simple_struct_roundtrip() {
+        let original = SimpleStruct {
+            x: 100,
+            y: -200,
+            z: 300,
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = SimpleStruct::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Packet ID --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    #[packet(id = 0x00)]
+    struct HandshakePacket {
+        #[field(varint)]
+        protocol_version: i32,
+        server_address: String,
+        server_port: u16,
+        #[field(varint)]
+        next_state: i32,
+    }
+
+    #[test]
+    fn packet_with_id_roundtrip() {
+        let original = HandshakePacket {
+            protocol_version: 763,
+            server_address: "localhost".into(),
+            server_port: 25565,
+            next_state: 1,
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+
+        // First byte should be VarInt(0x00) = 0x00
+        assert_eq!(buf[0], 0x00);
+
+        let mut cursor = buf.as_slice();
+        let decoded = HandshakePacket::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn packet_wrong_id_fails() {
+        let packet = HandshakePacket {
+            protocol_version: 763,
+            server_address: "localhost".into(),
+            server_port: 25565,
+            next_state: 1,
+        };
+        let mut buf = Vec::new();
+        packet.encode(&mut buf).unwrap();
+
+        // Corrupt the packet ID
+        buf[0] = 0x01;
+        let mut cursor = buf.as_slice();
+        assert!(matches!(
+            HandshakePacket::decode(&mut cursor),
+            Err(Error::InvalidData(_))
+        ));
+    }
+
+    // -- VarInt field --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    struct VarIntFields {
+        #[field(varint)]
+        small: i32,
+        #[field(varint)]
+        large: i32,
+    }
+
+    #[test]
+    fn varint_field_roundtrip() {
+        let original = VarIntFields {
+            small: 1,
+            large: 300000,
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        // VarInt(1) = 1 byte, VarInt(300000) = 3 bytes
+        assert_eq!(buf.len(), 4);
+        assert_eq!(original.encoded_size(), 4);
+
+        let mut cursor = buf.as_slice();
+        let decoded = VarIntFields::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Optional field --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    struct OptionalFields {
+        #[field(optional)]
+        name: Option<String>,
+        value: i32,
+    }
+
+    #[test]
+    fn optional_present_roundtrip() {
+        let original = OptionalFields {
+            name: Some("hello".into()),
+            value: 42,
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = OptionalFields::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn optional_absent_roundtrip() {
+        let original = OptionalFields {
+            name: None,
+            value: 42,
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = OptionalFields::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Length-prefixed Vec --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    struct LengthPrefixed {
+        #[field(length = "varint")]
+        items: Vec<i32>,
+    }
+
+    #[test]
+    fn length_prefixed_roundtrip() {
+        let original = LengthPrefixed {
+            items: vec![10, 20, 30],
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = LengthPrefixed::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn length_prefixed_empty_roundtrip() {
+        let original = LengthPrefixed { items: vec![] };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+
+        let mut cursor = buf.as_slice();
+        let decoded = LengthPrefixed::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Rest field --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    struct WithRest {
+        header: u8,
+        #[field(rest)]
+        data: Vec<u8>,
+    }
+
+    #[test]
+    fn rest_field_roundtrip() {
+        let original = WithRest {
+            header: 0xFF,
+            data: vec![1, 2, 3, 4, 5],
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = WithRest::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn rest_field_empty() {
+        let original = WithRest {
+            header: 0x01,
+            data: vec![],
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+
+        let mut cursor = buf.as_slice();
+        let decoded = WithRest::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Enum with unit variants --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    enum NextState {
+        Status,
+        Login,
+        Transfer,
+    }
+
+    #[test]
+    fn enum_unit_roundtrip() {
+        for (variant, expected_id) in [
+            (NextState::Status, 0),
+            (NextState::Login, 1),
+            (NextState::Transfer, 2),
+        ] {
+            let mut buf = Vec::new();
+            variant.encode(&mut buf).unwrap();
+
+            // Verify the discriminant
+            let mut check = buf.as_slice();
+            let id = VarInt::decode(&mut check).unwrap();
+            assert_eq!(id.0, expected_id);
+
+            let mut cursor = buf.as_slice();
+            let decoded = NextState::decode(&mut cursor).unwrap();
+            assert!(cursor.is_empty());
+            assert_eq!(decoded, variant);
+        }
+    }
+
+    // -- Enum with explicit discriminants --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    enum GameMode {
+        #[variant(id = -1)]
+        Undefined,
+        #[variant(id = 0)]
+        Survival,
+        #[variant(id = 1)]
+        Creative,
+        #[variant(id = 2)]
+        Adventure,
+        #[variant(id = 3)]
+        Spectator,
+    }
+
+    #[test]
+    fn enum_explicit_id_roundtrip() {
+        for (variant, expected_id) in [
+            (GameMode::Undefined, -1),
+            (GameMode::Survival, 0),
+            (GameMode::Creative, 1),
+            (GameMode::Adventure, 2),
+            (GameMode::Spectator, 3),
+        ] {
+            let mut buf = Vec::new();
+            variant.encode(&mut buf).unwrap();
+
+            let mut check = buf.as_slice();
+            let id = VarInt::decode(&mut check).unwrap();
+            assert_eq!(id.0, expected_id);
+
+            let mut cursor = buf.as_slice();
+            let decoded = GameMode::decode(&mut cursor).unwrap();
+            assert!(cursor.is_empty());
+            assert_eq!(decoded, variant);
+        }
+    }
+
+    // -- Enum with data variants --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    enum ChatMessage {
+        Text { message: String },
+        Command { command: String },
+    }
+
+    #[test]
+    fn enum_data_roundtrip() {
+        let original = ChatMessage::Text {
+            message: "hello".into(),
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+
+        let mut cursor = buf.as_slice();
+        let decoded = ChatMessage::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Enum with tuple variants --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    enum SimpleEnum {
+        A(u8),
+        B(u16, u32),
+    }
+
+    #[test]
+    fn enum_tuple_roundtrip() {
+        let original = SimpleEnum::B(100, 200);
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+
+        let mut cursor = buf.as_slice();
+        let decoded = SimpleEnum::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Unknown enum discriminant --
+
+    #[test]
+    fn enum_unknown_discriminant() {
+        let mut buf = Vec::new();
+        VarInt(99).encode(&mut buf).unwrap();
+        let mut cursor = buf.as_slice();
+        assert!(matches!(
+            NextState::decode(&mut cursor),
+            Err(Error::InvalidData(_))
+        ));
+    }
+
+    // -- Nested derived structs --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    struct Outer {
+        name: String,
+        inner: Inner,
+    }
+
+    #[test]
+    fn nested_struct_roundtrip() {
+        let original = Outer {
+            name: "test".into(),
+            inner: Inner { value: 42 },
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+
+        let mut cursor = buf.as_slice();
+        let decoded = Outer::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    // -- Mixed attributes --
+
+    #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+    #[packet(id = 0x0E)]
+    struct ComplexPacket {
+        #[field(varint)]
+        entity_id: i32,
+        #[field(optional)]
+        custom_name: Option<String>,
+        #[field(length = "varint")]
+        scores: Vec<i32>,
+        active: bool,
+    }
+
+    #[test]
+    fn complex_packet_roundtrip() {
+        let original = ComplexPacket {
+            entity_id: 42,
+            custom_name: Some("Steve".into()),
+            scores: vec![100, 200, 300],
+            active: true,
+        };
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = ComplexPacket::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+}


### PR DESCRIPTION
## Summary

- Derive `Encode`/`Decode`/`EncodedSize` for structs and enums
- `#[packet(id = 0x00)]` — VarInt packet ID prefix
- `#[field(varint)]` — encode i32/i64 as VarInt/VarLong
- `#[field(optional)]` — boolean-prefixed Option
- `#[field(length = "varint")]` — VarInt length-prefixed Vec
- `#[field(rest)]` — consume remaining bytes (last field only)
- Enum support with VarInt discriminant (sequential or `#[variant(id = N)]`)
- Supports unit, named, and tuple enum variants
- Handles negative discriminant values (e.g., `#[variant(id = -1)]`)
- 17 roundtrip tests in basalt-protocol

## Related issues

Closes #22

## Scope

- `basalt-derive` crate (`src/lib.rs`, `src/attrs.rs`, `src/encode.rs`, `src/decode.rs`, `src/size.rs`)
- `basalt-protocol` crate (`src/lib.rs` — derive tests)

## Test plan

- [x] Basic struct roundtrip (3 i32 fields)
- [x] Packet ID encode/decode + wrong ID rejection
- [x] VarInt field encoding (verifies byte count)
- [x] Optional field: present + absent roundtrip
- [x] Length-prefixed Vec: full + empty roundtrip
- [x] Rest field: full + empty roundtrip
- [x] Unit enum with sequential discriminants
- [x] Enum with explicit IDs (including -1)
- [x] Named and tuple enum variants with data
- [x] Unknown discriminant returns InvalidData
- [x] Nested derived structs
- [x] Complex packet with mixed attributes
- [x] `cargo fmt/clippy/test` all pass (241 tests total)