### PR TITLE
feat(net): implement TCP framing, connection typestate, and codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,23 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,11 +48,9 @@ dependencies = [
 name = "basalt-net"
 version = "0.1.0"
 dependencies = [
- "aes",
  "basalt-protocol",
- "cfb8",
- "criterion",
- "flate2",
+ "basalt-types",
+ "thiserror",
  "tokio",
 ]
 
@@ -133,15 +114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cfb8"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014c0a0e1ad0dae6a86c082db2f9bd7fe8c2c734227047d0d8b4d4a3a094a1e1"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,16 +147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,24 +170,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "criterion"
@@ -295,16 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,16 +267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,16 +277,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -446,15 +360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,16 +433,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "mio"
@@ -904,12 +799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,12 +897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,12 +913,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/basalt-net/Cargo.toml
+++ b/crates/basalt-net/Cargo.toml
@@ -7,11 +7,10 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+basalt-types = { workspace = true }
 basalt-protocol = { workspace = true }
 tokio = { workspace = true }
-aes = { workspace = true }
-cfb8 = { workspace = true }
-flate2 = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/basalt-net/src/connection.rs
+++ b/crates/basalt-net/src/connection.rs
@@ -1,0 +1,262 @@
+use std::marker::PhantomData;
+
+use tokio::net::TcpStream;
+
+use basalt_protocol::packets::handshake::{HandshakePacket, ServerboundHandshakePacket};
+use basalt_protocol::packets::status::{PingResponse, ServerboundStatusPacket, StatusResponse};
+use basalt_types::{Encode, EncodedSize};
+
+use crate::error::{Error, Result};
+use crate::framing;
+
+/// Marker type for the Handshake connection state.
+///
+/// In this state, the server waits for the client's Handshake packet,
+/// which declares the protocol version and desired next state (Status
+/// or Login). No other packets are valid.
+pub struct Handshake;
+
+/// Marker type for the Status connection state.
+///
+/// In this state, the server exchanges status information with the client:
+/// server list data (MOTD, player count, icon) and latency measurement.
+/// This is the server list ping flow.
+pub struct Status;
+
+/// A type-safe Minecraft protocol connection.
+///
+/// The connection wraps a TCP stream and enforces the protocol state machine
+/// at compile time using Rust's type system. Each state transition consumes
+/// the old connection and returns a new one in the next state, making it
+/// impossible to call methods for the wrong state.
+///
+/// The type parameter `S` is a zero-sized marker type that represents the
+/// current connection state (Handshake, Status, Login, etc.).
+pub struct Connection<S> {
+    stream: TcpStream,
+    _state: PhantomData<S>,
+}
+
+impl Connection<Handshake> {
+    /// Wraps a TCP stream as a new Handshake connection.
+    ///
+    /// This is the entry point for all incoming connections. The client
+    /// is expected to send a Handshake packet as its first message.
+    pub fn accept(stream: TcpStream) -> Self {
+        Self {
+            stream,
+            _state: PhantomData,
+        }
+    }
+
+    /// Reads the client's Handshake packet and transitions to the next state.
+    ///
+    /// Reads a single framed packet from the stream, decodes it as a
+    /// Handshake packet, and returns both the packet (for inspection) and
+    /// the connection transitioned to the appropriate next state.
+    ///
+    /// Currently only supports transitioning to Status (next_state = 1).
+    /// Login (next_state = 2) will be supported when Login packets are
+    /// implemented.
+    pub async fn read_handshake(mut self) -> Result<(Connection<Status>, HandshakePacket)> {
+        let raw = framing::read_raw_packet(&mut self.stream)
+            .await?
+            .ok_or_else(|| {
+                Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed before handshake",
+                ))
+            })?;
+
+        let mut cursor = raw.payload.as_slice();
+        let ServerboundHandshakePacket::Handshake(packet) =
+            ServerboundHandshakePacket::decode_by_id(raw.id, &mut cursor)?;
+
+        Ok((
+            Connection {
+                stream: self.stream,
+                _state: PhantomData,
+            },
+            packet,
+        ))
+    }
+}
+
+impl Connection<Status> {
+    /// Reads a serverbound Status packet from the client.
+    ///
+    /// Returns the decoded packet enum, which is either a StatusRequest
+    /// (asking for server info) or a PingRequest (latency measurement).
+    pub async fn read_packet(&mut self) -> Result<ServerboundStatusPacket> {
+        let raw = framing::read_raw_packet(&mut self.stream)
+            .await?
+            .ok_or_else(|| {
+                Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed during status",
+                ))
+            })?;
+
+        let mut cursor = raw.payload.as_slice();
+        Ok(ServerboundStatusPacket::decode_by_id(raw.id, &mut cursor)?)
+    }
+
+    /// Writes a StatusResponse packet to the client.
+    ///
+    /// Sends the server's status information (MOTD, player count, icon)
+    /// as a JSON string. This is the response to a StatusRequest.
+    pub async fn write_status_response(&mut self, response: &StatusResponse) -> Result<()> {
+        self.write_packet(StatusResponse::PACKET_ID, response).await
+    }
+
+    /// Writes a PingResponse packet to the client.
+    ///
+    /// Echoes back the client's ping payload for latency measurement.
+    /// This is the response to a PingRequest.
+    pub async fn write_ping_response(&mut self, response: &PingResponse) -> Result<()> {
+        self.write_packet(PingResponse::PACKET_ID, response).await
+    }
+
+    /// Encodes and writes a packet with the given ID to the stream.
+    async fn write_packet<P: Encode + EncodedSize>(
+        &mut self,
+        packet_id: i32,
+        packet: &P,
+    ) -> Result<()> {
+        let mut payload = Vec::with_capacity(packet.encoded_size());
+        packet
+            .encode(&mut payload)
+            .map_err(|e| Error::Protocol(basalt_protocol::Error::Type(e)))?;
+        framing::write_raw_packet(&mut self.stream, packet_id, &payload).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use basalt_protocol::packets::status::{PingRequest, StatusRequest};
+    use basalt_types::Decode as _;
+    use tokio::net::TcpListener;
+
+    /// Helper: creates a connected pair of TcpStreams via a local listener.
+    async fn connected_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+        (server, client)
+    }
+
+    /// Helper: writes a framed packet from the client side.
+    async fn client_send<P: Encode + EncodedSize>(
+        stream: &mut TcpStream,
+        packet_id: i32,
+        packet: &P,
+    ) {
+        let mut payload = Vec::with_capacity(packet.encoded_size());
+        packet.encode(&mut payload).unwrap();
+        framing::write_raw_packet(stream, packet_id, &payload)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn handshake_to_status_transition() {
+        let (server_stream, mut client_stream) = connected_pair().await;
+
+        // Client sends handshake
+        let handshake = HandshakePacket {
+            protocol_version: 767,
+            server_address: "localhost".into(),
+            server_port: 25565,
+            next_state: 1,
+        };
+        client_send(&mut client_stream, HandshakePacket::PACKET_ID, &handshake).await;
+
+        // Server reads handshake and transitions to Status
+        let conn = Connection::<Handshake>::accept(server_stream);
+        let (mut conn, received_handshake) = conn.read_handshake().await.unwrap();
+        assert_eq!(received_handshake, handshake);
+
+        // Client sends StatusRequest
+        client_send(&mut client_stream, StatusRequest::PACKET_ID, &StatusRequest).await;
+
+        // Server reads StatusRequest
+        let packet = conn.read_packet().await.unwrap();
+        assert!(matches!(packet, ServerboundStatusPacket::StatusRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn full_status_ping_flow() {
+        let (server_stream, mut client_stream) = connected_pair().await;
+
+        // Client sends handshake
+        let handshake = HandshakePacket {
+            protocol_version: 767,
+            server_address: "localhost".into(),
+            server_port: 25565,
+            next_state: 1,
+        };
+        client_send(&mut client_stream, HandshakePacket::PACKET_ID, &handshake).await;
+
+        // Server accepts and transitions
+        let conn = Connection::<Handshake>::accept(server_stream);
+        let (mut conn, _) = conn.read_handshake().await.unwrap();
+
+        // Client sends StatusRequest
+        client_send(&mut client_stream, StatusRequest::PACKET_ID, &StatusRequest).await;
+        let packet = conn.read_packet().await.unwrap();
+        assert!(matches!(packet, ServerboundStatusPacket::StatusRequest(_)));
+
+        // Server sends StatusResponse
+        let response = StatusResponse {
+            json_response: r#"{"version":{"name":"1.21","protocol":767}}"#.into(),
+        };
+        conn.write_status_response(&response).await.unwrap();
+
+        // Client reads StatusResponse
+        let raw = framing::read_raw_packet(&mut client_stream)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(raw.id, StatusResponse::PACKET_ID);
+
+        // Client sends PingRequest
+        let ping = PingRequest {
+            payload: 1234567890,
+        };
+        client_send(&mut client_stream, PingRequest::PACKET_ID, &ping).await;
+
+        // Server reads PingRequest and responds
+        let packet = conn.read_packet().await.unwrap();
+        match packet {
+            ServerboundStatusPacket::PingRequest(req) => {
+                assert_eq!(req.payload, 1234567890);
+                let pong = PingResponse {
+                    payload: req.payload,
+                };
+                conn.write_ping_response(&pong).await.unwrap();
+            }
+            _ => panic!("expected PingRequest"),
+        }
+
+        // Client reads PingResponse
+        let raw = framing::read_raw_packet(&mut client_stream)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(raw.id, PingResponse::PACKET_ID);
+        let mut cursor = raw.payload.as_slice();
+        let pong = PingResponse::decode(&mut cursor).unwrap();
+        assert_eq!(pong.payload, 1234567890);
+    }
+
+    #[tokio::test]
+    async fn handshake_eof_returns_error() {
+        let (server_stream, client_stream) = connected_pair().await;
+        drop(client_stream); // Close immediately
+
+        let conn = Connection::<Handshake>::accept(server_stream);
+        assert!(conn.read_handshake().await.is_err());
+    }
+}

--- a/crates/basalt-net/src/error.rs
+++ b/crates/basalt-net/src/error.rs
@@ -1,0 +1,39 @@
+/// Crate-level result alias.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur during network operations.
+///
+/// Covers IO failures (TCP read/write), protocol-level errors (unknown
+/// packets, malformed data), and framing errors (oversized packets).
+/// Higher layers should map these errors to appropriate disconnect
+/// reasons for the client.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A TCP read or write operation failed.
+    ///
+    /// This includes connection resets, broken pipes, timeouts, and
+    /// other OS-level socket errors. Usually means the client disconnected.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// A protocol-level error occurred during packet encoding or decoding.
+    ///
+    /// Wraps errors from basalt-protocol: unknown packet IDs, type
+    /// serialization failures (buffer underflow, invalid data, etc.).
+    #[error(transparent)]
+    Protocol(#[from] basalt_protocol::Error),
+
+    /// A packet exceeded the maximum allowed size.
+    ///
+    /// The Minecraft protocol limits packet size to prevent memory
+    /// exhaustion from malicious or corrupted data. The default limit
+    /// is 2 MiB (2,097,152 bytes). Connections sending oversized packets
+    /// should be disconnected.
+    #[error("packet too large: {size} bytes, max {max}")]
+    PacketTooLarge {
+        /// The actual packet size in bytes.
+        size: usize,
+        /// The maximum allowed packet size in bytes.
+        max: usize,
+    },
+}

--- a/crates/basalt-net/src/framing.rs
+++ b/crates/basalt-net/src/framing.rs
@@ -1,0 +1,235 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use basalt_types::{Decode, Encode, EncodedSize, VarInt};
+
+use crate::error::{Error, Result};
+
+/// Maximum allowed packet size in bytes (2 MiB).
+///
+/// Packets larger than this are rejected to prevent memory exhaustion
+/// from malicious or corrupted data. This matches the vanilla Minecraft
+/// server's practical limit.
+const MAX_PACKET_SIZE: usize = 2 * 1024 * 1024;
+
+/// A raw framed packet read from the wire.
+///
+/// Contains the packet ID and the payload bytes (without the length prefix
+/// or the packet ID). This is the intermediate representation between the
+/// TCP byte stream and the typed packet structs.
+#[derive(Debug)]
+pub struct RawPacket {
+    /// The VarInt packet ID read from the frame.
+    pub id: i32,
+    /// The remaining payload bytes after the packet ID.
+    pub payload: Vec<u8>,
+}
+
+/// Reads a single VarInt length-prefixed packet from an async reader.
+///
+/// The Minecraft protocol frames every packet as:
+/// `VarInt(length) | VarInt(packet_id) | payload`
+///
+/// This function reads the length prefix, validates it against the max
+/// packet size, reads the full frame, then splits the packet ID from
+/// the payload.
+///
+/// Returns `None` on clean EOF (stream closed), `Err` on IO errors or
+/// malformed frames.
+pub async fn read_raw_packet<R: AsyncReadExt + Unpin>(reader: &mut R) -> Result<Option<RawPacket>> {
+    // Read the VarInt length prefix byte-by-byte
+    let length = match read_varint(reader).await? {
+        Some(len) => len,
+        None => return Ok(None), // Clean EOF
+    };
+
+    if length < 0 {
+        return Err(Error::Protocol(basalt_protocol::Error::Type(
+            basalt_types::Error::InvalidData("negative packet length".into()),
+        )));
+    }
+    let length = length as usize;
+
+    if length > MAX_PACKET_SIZE {
+        return Err(Error::PacketTooLarge {
+            size: length,
+            max: MAX_PACKET_SIZE,
+        });
+    }
+
+    // Read the full frame (packet ID + payload)
+    let mut frame = vec![0u8; length];
+    reader.read_exact(&mut frame).await?;
+
+    // Extract packet ID from the frame
+    let mut cursor = frame.as_slice();
+    let packet_id = basalt_types::VarInt::decode(&mut cursor)
+        .map_err(|e| Error::Protocol(basalt_protocol::Error::Type(e)))?;
+
+    let payload = cursor.to_vec();
+
+    Ok(Some(RawPacket {
+        id: packet_id.0,
+        payload,
+    }))
+}
+
+/// Writes a single VarInt length-prefixed packet to an async writer.
+///
+/// Frames the packet as: `VarInt(packet_id_size + payload_size) | VarInt(packet_id) | payload`
+///
+/// The payload should already be encoded (the packet struct's fields as bytes).
+/// The packet ID is written as a VarInt inside the frame.
+pub async fn write_raw_packet<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    packet_id: i32,
+    payload: &[u8],
+) -> Result<()> {
+    let id_varint = VarInt(packet_id);
+    let frame_length = id_varint.encoded_size() + payload.len();
+
+    // Encode the full frame: length prefix + packet ID + payload
+    let mut buf = Vec::with_capacity(VarInt(frame_length as i32).encoded_size() + frame_length);
+    VarInt(frame_length as i32)
+        .encode(&mut buf)
+        .map_err(|e| Error::Protocol(basalt_protocol::Error::Type(e)))?;
+    id_varint
+        .encode(&mut buf)
+        .map_err(|e| Error::Protocol(basalt_protocol::Error::Type(e)))?;
+    buf.extend_from_slice(payload);
+
+    writer.write_all(&buf).await?;
+    Ok(())
+}
+
+/// Reads a VarInt from an async reader, one byte at a time.
+///
+/// Returns `None` on clean EOF (first byte read returns 0 bytes).
+/// Returns `Err` on IO errors or if the VarInt exceeds 5 bytes.
+async fn read_varint<R: AsyncReadExt + Unpin>(reader: &mut R) -> Result<Option<i32>> {
+    let mut value: u32 = 0;
+    let mut position: u32 = 0;
+    let mut byte = [0u8; 1];
+
+    loop {
+        match reader.read_exact(&mut byte).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                if position == 0 {
+                    return Ok(None); // Clean EOF before any data
+                }
+                return Err(e.into()); // EOF mid-VarInt
+            }
+            Err(e) => return Err(e.into()),
+        }
+
+        value |= ((byte[0] & 0x7F) as u32) << position;
+        position += 7;
+
+        if byte[0] & 0x80 == 0 {
+            return Ok(Some(value as i32));
+        }
+
+        if position >= 32 {
+            return Err(Error::Protocol(basalt_protocol::Error::Type(
+                basalt_types::Error::VarIntTooLarge,
+            )));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Helper: create a framed packet in a buffer (length + id + payload).
+    fn frame_packet(packet_id: i32, payload: &[u8]) -> Vec<u8> {
+        let id_varint = VarInt(packet_id);
+        let frame_length = id_varint.encoded_size() + payload.len();
+
+        let mut buf = Vec::new();
+        VarInt(frame_length as i32).encode(&mut buf).unwrap();
+        id_varint.encode(&mut buf).unwrap();
+        buf.extend_from_slice(payload);
+        buf
+    }
+
+    #[tokio::test]
+    async fn read_empty_packet() {
+        let data = frame_packet(0x00, &[]);
+        let mut cursor = Cursor::new(data);
+        let raw = read_raw_packet(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(raw.id, 0x00);
+        assert!(raw.payload.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_packet_with_payload() {
+        let payload = [0x01, 0x02, 0x03, 0x04];
+        let data = frame_packet(0x0A, &payload);
+        let mut cursor = Cursor::new(data);
+        let raw = read_raw_packet(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(raw.id, 0x0A);
+        assert_eq!(raw.payload, payload);
+    }
+
+    #[tokio::test]
+    async fn read_eof_returns_none() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        let result = read_raw_packet(&mut cursor).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_oversized_packet() {
+        // Frame with length > MAX_PACKET_SIZE
+        let mut data = Vec::new();
+        VarInt((MAX_PACKET_SIZE + 1) as i32)
+            .encode(&mut data)
+            .unwrap();
+        let mut cursor = Cursor::new(data);
+        assert!(matches!(
+            read_raw_packet(&mut cursor).await,
+            Err(Error::PacketTooLarge { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn write_and_read_roundtrip() {
+        let payload = vec![0xAA, 0xBB, 0xCC];
+        let mut buf = Vec::new();
+        write_raw_packet(&mut buf, 0x05, &payload).await.unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let raw = read_raw_packet(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(raw.id, 0x05);
+        assert_eq!(raw.payload, payload);
+    }
+
+    #[tokio::test]
+    async fn multiple_packets_in_stream() {
+        let mut buf = Vec::new();
+        write_raw_packet(&mut buf, 0x00, &[]).await.unwrap();
+        write_raw_packet(&mut buf, 0x01, &[0xFF]).await.unwrap();
+        write_raw_packet(&mut buf, 0x02, &[0x01, 0x02])
+            .await
+            .unwrap();
+
+        let mut cursor = Cursor::new(buf);
+
+        let p1 = read_raw_packet(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(p1.id, 0x00);
+        assert!(p1.payload.is_empty());
+
+        let p2 = read_raw_packet(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(p2.id, 0x01);
+        assert_eq!(p2.payload, [0xFF]);
+
+        let p3 = read_raw_packet(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(p3.id, 0x02);
+        assert_eq!(p3.payload, [0x01, 0x02]);
+
+        // EOF
+        assert!(read_raw_packet(&mut cursor).await.unwrap().is_none());
+    }
+}

--- a/crates/basalt-net/src/lib.rs
+++ b/crates/basalt-net/src/lib.rs
@@ -1,1 +1,16 @@
+//! Async networking layer for the Minecraft protocol.
+//!
+//! Handles TCP connection management with VarInt length-prefixed framing
+//! and type-safe connection state transitions. The connection typestate
+//! pattern uses Rust's type system to enforce the Minecraft protocol
+//! state machine at compile time: Handshake → Status/Login → etc.
+//!
+//! Encryption (AES/CFB-8), compression (zlib), and the middleware
+//! pipeline will be added in subsequent issues.
 
+pub mod connection;
+pub mod error;
+pub mod framing;
+
+pub use connection::Connection;
+pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

- `Error` type wrapping IO + protocol errors + PacketTooLarge
- TCP framing: VarInt length-prefixed async read/write with 2 MiB max packet size
- Connection typestate: `Connection<Handshake>` → `Connection<Status>` with compile-time state enforcement
- Full server list ping flow tested over TCP loopback
- 9 new net tests (framing roundtrip, multi-packet, EOF, oversized, handshake transition, full ping flow)

## Related issues

Closes #26

## Scope

`basalt-net` crate (`src/error.rs`, `src/framing.rs`, `src/connection.rs`, `src/lib.rs`, `Cargo.toml`)

## Test plan

- [x] Framing: empty packet, packet with payload, write+read roundtrip
- [x] Framing: multiple packets in stream, EOF returns None
- [x] Framing: oversized packet rejected
- [x] Connection: Handshake → Status transition
- [x] Connection: full ping flow (Handshake → StatusRequest → StatusResponse → PingRequest → PingResponse)
- [x] Connection: EOF before handshake returns error
- [x] `cargo fmt/clippy/test` all pass (276 tests total)