### PR TITLE
refactor(net): rename EncryptedStream to ProtocolStream

### DIFF
--- a/crates/basalt-net/src/connection.rs
+++ b/crates/basalt-net/src/connection.rs
@@ -12,7 +12,7 @@ use basalt_protocol::packets::status::{
 use basalt_types::{Encode, EncodedSize};
 
 use crate::error::{Error, Result};
-use crate::stream::EncryptedStream;
+use crate::stream::ProtocolStream;
 
 /// Marker type for the Handshake connection state.
 pub struct Handshake;
@@ -37,12 +37,12 @@ pub enum HandshakeResult {
 
 /// A type-safe Minecraft protocol connection.
 ///
-/// The connection wraps an `EncryptedStream` (TCP with optional AES/CFB-8
+/// The connection wraps an `ProtocolStream` (TCP with optional AES/CFB-8
 /// encryption) and enforces the protocol state machine at compile time
 /// using Rust's type system. Each state transition consumes the old
 /// connection and returns a new one in the next state.
 pub struct Connection<S> {
-    stream: EncryptedStream,
+    stream: ProtocolStream,
     _state: PhantomData<S>,
 }
 
@@ -50,7 +50,7 @@ impl Connection<Handshake> {
     /// Wraps a TCP stream as a new Handshake connection.
     pub fn accept(stream: TcpStream) -> Self {
         Self {
-            stream: EncryptedStream::new(stream),
+            stream: ProtocolStream::new(stream),
             _state: PhantomData,
         }
     }

--- a/crates/basalt-net/src/stream.rs
+++ b/crates/basalt-net/src/stream.rs
@@ -7,17 +7,20 @@ use crate::crypto::CipherPair;
 use crate::error::{Error, Result};
 use crate::framing::{MAX_PACKET_SIZE, RawPacket};
 
-/// A TCP stream with optional transparent encryption.
+/// A TCP stream with optional transparent encryption and compression.
 ///
-/// Wraps a `TcpStream` and an optional `CipherPair`. When encryption is
-/// enabled, all reads are decrypted and all writes are encrypted
-/// automatically. The caller doesn't need to know whether encryption
-/// is active — the API is identical either way.
+/// Wraps a `TcpStream` with optional AES-128 CFB-8 encryption and zlib
+/// compression. Both layers are transparent to the caller — the API is
+/// identical regardless of which layers are active.
 ///
-/// Encryption is activated once during the login handshake via
-/// `enable_encryption()` and stays active for the lifetime of the
-/// connection. There is no way to disable it.
-pub struct EncryptedStream {
+/// The layers are activated during the login handshake:
+/// 1. Encryption via `enable_encryption()` after Encryption Response
+/// 2. Compression via `enable_compression()` after Set Compression
+///
+/// Once enabled, neither layer can be disabled. On the wire, compression
+/// is applied first (at the frame level), then encryption wraps everything
+/// including the length prefix.
+pub struct ProtocolStream {
     /// The underlying TCP stream.
     stream: TcpStream,
     /// The cipher pair, if encryption has been enabled.
@@ -28,7 +31,7 @@ pub struct EncryptedStream {
     compression_threshold: Option<usize>,
 }
 
-impl EncryptedStream {
+impl ProtocolStream {
     /// Creates a new unencrypted stream from a TCP connection.
     pub fn new(stream: TcpStream) -> Self {
         Self {
@@ -215,12 +218,12 @@ mod tests {
     use super::*;
     use tokio::net::TcpListener;
 
-    async fn connected_pair() -> (EncryptedStream, EncryptedStream) {
+    async fn connected_pair() -> (ProtocolStream, ProtocolStream) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let client = TcpStream::connect(addr).await.unwrap();
         let (server, _) = listener.accept().await.unwrap();
-        (EncryptedStream::new(server), EncryptedStream::new(client))
+        (ProtocolStream::new(server), ProtocolStream::new(client))
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Rename `EncryptedStream` → `ProtocolStream` — the stream now handles both encryption and compression, not just encryption
- Updated doc comments to describe both layers
- No behavior changes

## Test plan

- [x] All 371 tests pass unchanged
- [x] `cargo fmt/clippy/test` all pass