### PR TITLE
feat(server): chat system with commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@
 
 ## Architecture
 
-Four crates in a Cargo workspace under `crates/`, plus an `xtask` codegen tool:
+Five crates in a Cargo workspace under `crates/`, plus an `xtask` codegen tool:
 
 ```
-basalt-types → basalt-derive → basalt-protocol → basalt-net
+basalt-types → basalt-derive → basalt-protocol → basalt-net → basalt-server
                                       ↑
                                    xtask (codegen)
 ```
@@ -25,12 +25,36 @@ basalt-types → basalt-derive → basalt-protocol → basalt-net
 | `basalt-derive` | Proc macros for `Encode`/`Decode`/`EncodedSize` | `syn`, `quote`, `proc-macro2` |
 | `basalt-protocol` | Packet definitions, version-aware registry, registry data, chunk builder | `basalt-types`, `basalt-derive` |
 | `basalt-net` | Async networking, encryption, compression, connection typestate, middleware pipeline | `basalt-protocol`, `tokio`, `aes`, `cfb8`, `flate2` |
+| `basalt-server` | Minecraft server: connection lifecycle, play loop, chat, commands, player state | `basalt-net`, `basalt-protocol`, `basalt-types`, `tokio` |
 | `xtask` | Code generation from minecraft-data JSON → Rust packet structs | `serde_json` |
 
 - `basalt-types` and `basalt-derive` have no interdependency.
 - `basalt-protocol` depends on both.
 - `basalt-net` depends on `basalt-protocol`.
+- `basalt-server` depends on `basalt-net` — it is the top-level application crate.
 - `xtask` is a standalone binary that generates code into `basalt-protocol`.
+
+### basalt-server structure
+
+```
+crates/basalt-server/
+├── src/
+│   ├── lib.rs           # Server struct, public API, accept loop
+│   ├── connection.rs    # Per-player lifecycle: handshake → login → config → play
+│   ├── play.rs          # Play loop, packet dispatch (sync) + action execution (async)
+│   ├── player.rs        # PlayerState: position, rotation, keep-alive tracking
+│   └── chat.rs          # Chat message echo, command dispatch (/say, /tp, /gamemode, /help)
+├── examples/
+│   └── server.rs        # 14-line launcher: Server::new("0.0.0.0:25565").run().await
+└── tests/
+    └── e2e.rs           # End-to-end tests: status ping, login flow, chat, commands
+```
+
+The play loop separates sync and async concerns:
+- `dispatch_packet()` — pure sync function that updates `PlayerState` and returns a `PacketAction` enum
+- `execute_action()` — async function that sends response packets (chat echo, command feedback)
+
+This keeps the state-update logic unit-testable without a TCP connection.
 
 ## Architectural principles
 
@@ -74,7 +98,8 @@ basalt/
 │   ├── basalt-types/
 │   ├── basalt-derive/
 │   ├── basalt-protocol/
-│   └── basalt-net/
+│   ├── basalt-net/
+│   └── basalt-server/        # Minecraft server: connection lifecycle, play loop, chat, commands
 ├── minecraft-data/           # Git submodule — PrismarineJS/minecraft-data
 ├── xtask/                    # Codegen tool
 │   └── src/

--- a/crates/basalt-server/src/chat.rs
+++ b/crates/basalt-server/src/chat.rs
@@ -1,0 +1,221 @@
+//! Chat message handling and command dispatch.
+//!
+//! Processes incoming chat messages and slash commands from players.
+//! Chat messages are echoed back as `SystemChat` packets. Commands
+//! are parsed and executed, with feedback sent to the player.
+
+use basalt_net::connection::{Connection, Play};
+use basalt_protocol::packets::play::chat::ClientboundPlaySystemChat;
+use basalt_protocol::packets::play::player::{
+    ClientboundPlayGameStateChange, ClientboundPlayPosition,
+};
+use basalt_types::{NamedColor, TextColor, TextComponent};
+
+use crate::player::PlayerState;
+
+/// Sends a system chat message to the player.
+///
+/// Builds a `SystemChat` packet from a `TextComponent` and writes it
+/// to the connection. Use `is_action_bar: true` to show the message
+/// in the action bar instead of the chat window.
+pub(crate) async fn send_system_message(
+    conn: &mut Connection<Play>,
+    component: &TextComponent,
+    is_action_bar: bool,
+) -> basalt_net::Result<()> {
+    let packet = ClientboundPlaySystemChat {
+        content: component.to_nbt(),
+        is_action_bar,
+    };
+    conn.write_packet_typed(ClientboundPlaySystemChat::PACKET_ID, &packet)
+        .await
+}
+
+/// Sends a welcome message when a player joins the server.
+pub(crate) async fn send_welcome(
+    conn: &mut Connection<Play>,
+    username: &str,
+) -> basalt_net::Result<()> {
+    let msg = TextComponent::text(format!("Welcome to Basalt, {username}!"))
+        .color(TextColor::Named(NamedColor::Gold))
+        .bold(true);
+    send_system_message(conn, &msg, false).await
+}
+
+/// Handles a player chat message by echoing it as a system message.
+///
+/// The message is formatted as `<username> message` and sent back
+/// to the player. In a multi-player setup (#53), this would broadcast
+/// to all connected players.
+pub(crate) async fn handle_chat_message(
+    conn: &mut Connection<Play>,
+    username: &str,
+    message: &str,
+) -> basalt_net::Result<()> {
+    let formatted = TextComponent::text("<")
+        .append(TextComponent::text(username).color(TextColor::Named(NamedColor::Aqua)))
+        .append(TextComponent::text("> "))
+        .append(TextComponent::text(message));
+    send_system_message(conn, &formatted, false).await
+}
+
+/// Handles a slash command from the player.
+///
+/// Parses the command string and dispatches to the appropriate handler.
+/// Unknown commands receive a red error message.
+pub(crate) async fn handle_command(
+    conn: &mut Connection<Play>,
+    player: &mut PlayerState,
+    command: &str,
+) -> basalt_net::Result<()> {
+    let parts: Vec<&str> = command.splitn(2, ' ').collect();
+    let cmd = parts[0];
+    let args = parts.get(1).unwrap_or(&"");
+
+    match cmd {
+        "say" => cmd_say(conn, args).await,
+        "tp" => cmd_tp(conn, player, args).await,
+        "gamemode" => cmd_gamemode(conn, args).await,
+        "help" => cmd_help(conn).await,
+        _ => {
+            let msg = TextComponent::text(format!("Unknown command: /{cmd}"))
+                .color(TextColor::Named(NamedColor::Red));
+            send_system_message(conn, &msg, false).await
+        }
+    }
+}
+
+/// `/say <message>` — broadcasts a server message.
+async fn cmd_say(conn: &mut Connection<Play>, message: &str) -> basalt_net::Result<()> {
+    let msg = TextComponent::text("[Server] ")
+        .color(TextColor::Named(NamedColor::LightPurple))
+        .bold(true)
+        .append(TextComponent::text(message).color(TextColor::Named(NamedColor::White)));
+    send_system_message(conn, &msg, false).await
+}
+
+/// `/tp <x> <y> <z>` — teleports the player to the given coordinates.
+async fn cmd_tp(
+    conn: &mut Connection<Play>,
+    player: &mut PlayerState,
+    args: &str,
+) -> basalt_net::Result<()> {
+    let coords: Vec<&str> = args.split_whitespace().collect();
+    if coords.len() != 3 {
+        let msg =
+            TextComponent::text("Usage: /tp <x> <y> <z>").color(TextColor::Named(NamedColor::Red));
+        return send_system_message(conn, &msg, false).await;
+    }
+
+    let x: f64 = match coords[0].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            let msg = TextComponent::text("Invalid x coordinate")
+                .color(TextColor::Named(NamedColor::Red));
+            return send_system_message(conn, &msg, false).await;
+        }
+    };
+    let y: f64 = match coords[1].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            let msg = TextComponent::text("Invalid y coordinate")
+                .color(TextColor::Named(NamedColor::Red));
+            return send_system_message(conn, &msg, false).await;
+        }
+    };
+    let z: f64 = match coords[2].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            let msg = TextComponent::text("Invalid z coordinate")
+                .color(TextColor::Named(NamedColor::Red));
+            return send_system_message(conn, &msg, false).await;
+        }
+    };
+
+    player.update_position(x, y, z);
+    player.teleport_confirmed = false;
+
+    let position = ClientboundPlayPosition {
+        teleport_id: 2,
+        x,
+        y,
+        z,
+        dx: 0.0,
+        dy: 0.0,
+        dz: 0.0,
+        yaw: player.yaw,
+        pitch: player.pitch,
+        flags: 0,
+    };
+    conn.write_packet_typed(ClientboundPlayPosition::PACKET_ID, &position)
+        .await?;
+
+    let msg = TextComponent::text(format!("Teleported to {x}, {y}, {z}"))
+        .color(TextColor::Named(NamedColor::Green));
+    send_system_message(conn, &msg, false).await
+}
+
+/// `/gamemode <mode>` — changes the player's gamemode.
+///
+/// Accepted modes: survival (0), creative (1), adventure (2), spectator (3).
+async fn cmd_gamemode(conn: &mut Connection<Play>, args: &str) -> basalt_net::Result<()> {
+    let mode: f32 = match args.trim() {
+        "survival" | "0" => 0.0,
+        "creative" | "1" => 1.0,
+        "adventure" | "2" => 2.0,
+        "spectator" | "3" => 3.0,
+        _ => {
+            let msg =
+                TextComponent::text("Usage: /gamemode <survival|creative|adventure|spectator>")
+                    .color(TextColor::Named(NamedColor::Red));
+            return send_system_message(conn, &msg, false).await;
+        }
+    };
+
+    // GameEvent reason=3 = change game mode
+    let event = ClientboundPlayGameStateChange {
+        reason: 3,
+        game_mode: mode,
+    };
+    conn.write_packet_typed(ClientboundPlayGameStateChange::PACKET_ID, &event)
+        .await?;
+
+    let name = match mode as u8 {
+        0 => "Survival",
+        1 => "Creative",
+        2 => "Adventure",
+        _ => "Spectator",
+    };
+    let msg = TextComponent::text(format!("Game mode set to {name}"))
+        .color(TextColor::Named(NamedColor::Green));
+    send_system_message(conn, &msg, false).await
+}
+
+/// `/help` — shows available commands.
+async fn cmd_help(conn: &mut Connection<Play>) -> basalt_net::Result<()> {
+    let msg = TextComponent::text("Available commands:")
+        .color(TextColor::Named(NamedColor::Gold))
+        .append(
+            TextComponent::text("\n /say <message>").color(TextColor::Named(NamedColor::Yellow)),
+        )
+        .append(
+            TextComponent::text(" — broadcast a server message")
+                .color(TextColor::Named(NamedColor::Gray)),
+        )
+        .append(
+            TextComponent::text("\n /tp <x> <y> <z>").color(TextColor::Named(NamedColor::Yellow)),
+        )
+        .append(
+            TextComponent::text(" — teleport to coordinates")
+                .color(TextColor::Named(NamedColor::Gray)),
+        )
+        .append(
+            TextComponent::text("\n /gamemode <mode>").color(TextColor::Named(NamedColor::Yellow)),
+        )
+        .append(
+            TextComponent::text(" — change game mode").color(TextColor::Named(NamedColor::Gray)),
+        )
+        .append(TextComponent::text("\n /help").color(TextColor::Named(NamedColor::Yellow)))
+        .append(TextComponent::text(" — show this help").color(TextColor::Named(NamedColor::Gray)));
+    send_system_message(conn, &msg, false).await
+}

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -17,6 +17,7 @@
 //! }
 //! ```
 
+mod chat;
 mod connection;
 mod play;
 mod player;

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -34,6 +34,7 @@ pub(crate) async fn run_play_loop(
     player: &mut PlayerState,
 ) -> basalt_net::Result<()> {
     send_initial_world(&mut conn, addr, player).await?;
+    crate::chat::send_welcome(&mut conn, &player.username).await?;
 
     println!(
         "[{addr}] {} joined the void world! Starting play loop.",
@@ -156,7 +157,10 @@ async fn play_loop(
             }
             result = conn.read_packet() => {
                 match result {
-                    Ok(packet) => dispatch_packet(addr, player, packet),
+                    Ok(packet) => {
+                        let action = dispatch_packet(addr, player, packet);
+                        execute_action(conn, player, action).await?;
+                    }
                     Err(e) => {
                         println!("[{addr}] {} disconnected: {e}", player.username);
                         break;
@@ -169,16 +173,30 @@ async fn play_loop(
     Ok(())
 }
 
-/// Dispatches a single serverbound Play packet to the appropriate handler.
+/// Result of dispatching a packet synchronously.
 ///
-/// This is a pure function that updates `PlayerState` without any IO.
-/// Packets that require sending a response (chat, commands) will return
-/// an action in a future iteration; for now they are logged.
+/// Most packets only update `PlayerState` and return `Handled`. Packets
+/// that need async IO (chat, commands) return an action that the caller
+/// executes with the connection.
+pub(crate) enum PacketAction {
+    /// Packet was fully handled (state updated, logged).
+    Handled,
+    /// A chat message that needs to be echoed back.
+    Chat { username: String, message: String },
+    /// A command that needs to be executed.
+    Command { command: String },
+}
+
+/// Dispatches a single serverbound Play packet synchronously.
+///
+/// Updates `PlayerState` for movement, keep-alive, teleport confirm,
+/// and player loaded packets. Returns a `PacketAction` for packets
+/// that require async IO (chat and commands).
 pub(crate) fn dispatch_packet(
     addr: SocketAddr,
     player: &mut PlayerState,
     packet: ServerboundPlayPacket,
-) {
+) -> PacketAction {
     match packet {
         // -- Keep-alive --
         ServerboundPlayPacket::KeepAlive(ka) => {
@@ -195,6 +213,7 @@ pub(crate) fn dispatch_packet(
                     player.username, player.last_keep_alive_id, ka.keep_alive_id
                 );
             }
+            PacketAction::Handled
         }
 
         // -- Teleport confirm --
@@ -204,41 +223,56 @@ pub(crate) fn dispatch_packet(
                 player.username, tc.teleport_id
             );
             player.teleport_confirmed = true;
+            PacketAction::Handled
         }
 
         // -- Player loaded --
         ServerboundPlayPacket::PlayerLoaded(_) => {
             println!("[{addr}] {} finished loading", player.username);
             player.loaded = true;
+            PacketAction::Handled
         }
 
         // -- Movement --
         ServerboundPlayPacket::Position(p) => {
             player.update_position(p.x, p.y, p.z);
             player.update_on_ground(p.flags);
+            PacketAction::Handled
         }
         ServerboundPlayPacket::PositionLook(p) => {
             player.update_position(p.x, p.y, p.z);
             player.update_look(p.yaw, p.pitch);
             player.update_on_ground(p.flags);
+            PacketAction::Handled
         }
         ServerboundPlayPacket::Look(p) => {
             player.update_look(p.yaw, p.pitch);
             player.update_on_ground(p.flags);
+            PacketAction::Handled
         }
         ServerboundPlayPacket::Flying(p) => {
             player.update_on_ground(p.flags);
+            PacketAction::Handled
         }
 
-        // -- Chat (logged for now, handled in #52) --
+        // -- Chat --
         ServerboundPlayPacket::ChatMessage(msg) => {
             println!("[{addr}] <{}> {}", player.username, msg.message);
+            PacketAction::Chat {
+                username: player.username.clone(),
+                message: msg.message,
+            }
         }
+
+        // -- Commands --
         ServerboundPlayPacket::ChatCommand(cmd) => {
             println!(
                 "[{addr}] {} issued command: /{}",
                 player.username, cmd.command
             );
+            PacketAction::Command {
+                command: cmd.command,
+            }
         }
 
         // -- Client settings / plugin channels (acknowledged silently) --
@@ -248,9 +282,7 @@ pub(crate) fn dispatch_packet(
         | ServerboundPlayPacket::ChunkBatchReceived(_)
         | ServerboundPlayPacket::Pong(_)
         | ServerboundPlayPacket::MessageAcknowledgement(_)
-        | ServerboundPlayPacket::ConfigurationAcknowledged(_) => {
-            // Expected protocol traffic — handle silently
-        }
+        | ServerboundPlayPacket::ConfigurationAcknowledged(_) => PacketAction::Handled,
 
         // -- Everything else --
         other => {
@@ -259,8 +291,27 @@ pub(crate) fn dispatch_packet(
                 player.username,
                 std::mem::discriminant(&other)
             );
+            PacketAction::Handled
         }
     }
+}
+
+/// Executes the async part of a packet action (chat echo, command dispatch).
+async fn execute_action(
+    conn: &mut Connection<Play>,
+    player: &mut PlayerState,
+    action: PacketAction,
+) -> basalt_net::Result<()> {
+    match action {
+        PacketAction::Handled => {}
+        PacketAction::Chat { username, message } => {
+            crate::chat::handle_chat_message(conn, &username, &message).await?;
+        }
+        PacketAction::Command { command } => {
+            crate::chat::handle_command(conn, player, &command).await?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/basalt-server/tests/e2e.rs
+++ b/crates/basalt-server/tests/e2e.rs
@@ -236,8 +236,8 @@ async fn e2e_server_handles_teleport_confirm() {
     )
     .await;
 
-    // Read all initial Play packets (Login, SpawnPosition, GameEvent, Chunk, Position)
-    for _ in 0..5 {
+    // Read all initial Play packets (Login, SpawnPosition, GameEvent, Chunk, Position, Welcome)
+    for _ in 0..6 {
         framing::read_raw_packet(&mut client)
             .await
             .unwrap()
@@ -285,4 +285,264 @@ async fn e2e_server_handles_teleport_confirm() {
 
     // Small delay to let the server log the disconnect
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}
+
+/// Helper: connects a client and fast-tracks through to Play state.
+/// Returns the client stream positioned right after all initial Play
+/// packets have been consumed (Login, SpawnPosition, GameEvent, Chunk,
+/// Position, Welcome message).
+async fn connect_to_play(addr: std::net::SocketAddr) -> TcpStream {
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    client_handshake(&mut client, addr.port(), 2).await;
+
+    use basalt_protocol::packets::login::{
+        ServerboundLoginLoginAcknowledged, ServerboundLoginLoginStart,
+    };
+    send_packet(
+        &mut client,
+        ServerboundLoginLoginStart::PACKET_ID,
+        &ServerboundLoginLoginStart {
+            username: "ChatTester".into(),
+            player_uuid: Uuid::default(),
+        },
+    )
+    .await;
+
+    // LoginSuccess
+    let _: (_, ClientboundLoginSuccess) = recv_packet(&mut client).await;
+
+    // LoginAcknowledged
+    send_packet(
+        &mut client,
+        ServerboundLoginLoginAcknowledged::PACKET_ID,
+        &ServerboundLoginLoginAcknowledged,
+    )
+    .await;
+
+    // Read Config packets until FinishConfiguration
+    loop {
+        let raw = framing::read_raw_packet(&mut client)
+            .await
+            .unwrap()
+            .unwrap();
+        use basalt_protocol::packets::configuration::ClientboundConfigurationFinishConfiguration;
+        if raw.id == ClientboundConfigurationFinishConfiguration::PACKET_ID {
+            break;
+        }
+    }
+
+    // Send FinishConfiguration ack
+    use basalt_protocol::packets::configuration::ServerboundConfigurationFinishConfiguration;
+    send_packet(
+        &mut client,
+        ServerboundConfigurationFinishConfiguration::PACKET_ID,
+        &ServerboundConfigurationFinishConfiguration,
+    )
+    .await;
+
+    // Read initial Play packets (Login, SpawnPosition, GameEvent, Chunk,
+    // Position, Welcome message = 6 packets)
+    for _ in 0..6 {
+        framing::read_raw_packet(&mut client)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    client
+}
+
+// -- Chat tests --
+
+#[tokio::test]
+async fn e2e_server_chat_message_echoed() {
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Send a chat message
+    use basalt_protocol::packets::play::chat::ServerboundPlayChatMessage;
+    send_packet(
+        &mut client,
+        ServerboundPlayChatMessage::PACKET_ID,
+        &ServerboundPlayChatMessage {
+            message: "hello world".into(),
+            timestamp: 0,
+            salt: 0,
+            signature: None,
+            offset: 0,
+            acknowledged: vec![],
+        },
+    )
+    .await;
+
+    // Read the SystemChat response
+    use basalt_protocol::packets::play::chat::ClientboundPlaySystemChat;
+    let (id, _response): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+    // The response contains an NbtCompound with the formatted message
+}
+
+#[tokio::test]
+async fn e2e_server_command_help() {
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Send /help command
+    use basalt_protocol::packets::play::chat::ServerboundPlayChatCommand;
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "help".into(),
+        },
+    )
+    .await;
+
+    // Read the SystemChat response with help text
+    use basalt_protocol::packets::play::chat::ClientboundPlaySystemChat;
+    let (id, _response): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+}
+
+#[tokio::test]
+async fn e2e_server_command_unknown() {
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Send unknown command
+    use basalt_protocol::packets::play::chat::ServerboundPlayChatCommand;
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "doesnotexist".into(),
+        },
+    )
+    .await;
+
+    // Read error response
+    use basalt_protocol::packets::play::chat::ClientboundPlaySystemChat;
+    let (id, _response): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+}
+
+#[tokio::test]
+async fn e2e_server_command_say() {
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    use basalt_protocol::packets::play::chat::{
+        ClientboundPlaySystemChat, ServerboundPlayChatCommand,
+    };
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "say hello everyone".into(),
+        },
+    )
+    .await;
+
+    let (id, _): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+}
+
+#[tokio::test]
+async fn e2e_server_command_tp() {
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    use basalt_protocol::packets::play::chat::{
+        ClientboundPlaySystemChat, ServerboundPlayChatCommand,
+    };
+
+    // Valid tp
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "tp 10 200 -30".into(),
+        },
+    )
+    .await;
+
+    // Read PlayerPosition packet (teleport) + SystemChat feedback
+    use basalt_protocol::packets::play::player::ClientboundPlayPosition;
+    let (id, pos): (_, ClientboundPlayPosition) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlayPosition::PACKET_ID);
+    assert_eq!(pos.x, 10.0);
+    assert_eq!(pos.y, 200.0);
+    assert_eq!(pos.z, -30.0);
+
+    let (id, _): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+
+    // Invalid tp (wrong args)
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "tp 10".into(),
+        },
+    )
+    .await;
+
+    let (id, _): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+
+    // Invalid tp (bad number)
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "tp abc 0 0".into(),
+        },
+    )
+    .await;
+
+    let (id, _): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+}
+
+#[tokio::test]
+async fn e2e_server_command_gamemode() {
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    use basalt_protocol::packets::play::chat::{
+        ClientboundPlaySystemChat, ServerboundPlayChatCommand,
+    };
+
+    // Valid gamemode
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "gamemode survival".into(),
+        },
+    )
+    .await;
+
+    // Read GameStateChange + SystemChat feedback
+    use basalt_protocol::packets::play::player::ClientboundPlayGameStateChange;
+    let (id, event): (_, ClientboundPlayGameStateChange) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlayGameStateChange::PACKET_ID);
+    assert_eq!(event.reason, 3); // change game mode
+    assert_eq!(event.game_mode, 0.0); // survival
+
+    let (id, _): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
+
+    // Invalid gamemode
+    send_packet(
+        &mut client,
+        ServerboundPlayChatCommand::PACKET_ID,
+        &ServerboundPlayChatCommand {
+            command: "gamemode invalid".into(),
+        },
+    )
+    .await;
+
+    let (id, _): (_, ClientboundPlaySystemChat) = recv_packet(&mut client).await;
+    assert_eq!(id, ClientboundPlaySystemChat::PACKET_ID);
 }

--- a/crates/basalt-types/src/text.rs
+++ b/crates/basalt-types/src/text.rs
@@ -287,6 +287,15 @@ impl TextComponent {
         self.extra.push(child);
         self
     }
+
+    /// Converts this text component into an `NbtCompound`.
+    ///
+    /// Useful for protocol packets that accept an `NbtCompound` directly
+    /// (e.g., `SystemChat`, `KickDisconnect`, title packets) instead of
+    /// going through the `Encode` trait.
+    pub fn to_nbt(&self) -> NbtCompound {
+        component_to_nbt(self)
+    }
 }
 
 // -- NBT conversion --


### PR DESCRIPTION
## Summary

- **TextComponent::to_nbt()**: new public method on TextComponent for building SystemChat packets without going through the Encode trait
- **Chat echo**: player chat messages are formatted as `<username> message` and sent back via SystemChat
- **Commands**: `/say`, `/tp <x> <y> <z>`, `/gamemode <mode>`, `/help` with colored feedback and error messages
- **Welcome message**: golden "Welcome to Basalt, username!" on join
- **Sync/async split**: `dispatch_packet()` returns a `PacketAction` enum (sync, testable) and `execute_action()` sends responses (async)
- **CLAUDE.md**: documents basalt-server in architecture, dependencies, and internal structure
- 9 e2e tests covering chat echo, all 4 commands (valid + invalid args), unknown commands

Closes #52

## Test plan

- [x] `cargo test` — 434 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Coverage >= 90% (90.78%)
- [ ] CI passes
- [ ] Manual test: connect Minecraft client, type in chat, use /help, /tp, /gamemode, /say
