### PR TITLE
refactor: remaining structural improvements (DashMap, broadcast, PacketContext, OpaqueBytes, PacketWriter)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +97,11 @@ dependencies = [
  "basalt-net",
  "basalt-protocol",
  "basalt-types",
+ "dashmap",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -102,6 +113,12 @@ dependencies = [
  "proptest",
  "thiserror",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -143,10 +160,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -306,6 +339,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,7 +382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -332,6 +390,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -356,6 +420,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,14 +473,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -400,6 +521,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -429,10 +556,211 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -456,6 +784,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,7 +807,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -487,6 +831,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -510,6 +856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +875,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -548,7 +906,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -596,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -681,6 +1054,61 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "quote"
@@ -800,6 +1228,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,7 +1295,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -829,6 +1350,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -895,6 +1422,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,8 +1474,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -938,6 +1501,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,7 +1530,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -971,6 +1554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1572,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -994,7 +1602,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1007,6 +1615,86 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1033,6 +1721,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1767,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1092,6 +1813,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1171,12 +1902,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1187,12 +1937,159 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1283,11 +2180,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1304,6 +2230,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ cfb8 = "0.8"
 # Compression
 flate2 = "1"
 
+# Concurrent data structures
+dashmap = "6"
+
 # HTTP / serialization
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/basalt-net/src/connection.rs
+++ b/crates/basalt-net/src/connection.rs
@@ -249,6 +249,16 @@ impl Connection<Play> {
     }
 }
 
+impl crate::writer::PacketWriter for Connection<Play> {
+    async fn write_packet_typed<P: Encode + EncodedSize>(
+        &mut self,
+        packet_id: i32,
+        packet: &P,
+    ) -> Result<()> {
+        self.write_packet(packet_id, packet).await
+    }
+}
+
 // -- Shared helpers --
 
 impl<S> Connection<S> {

--- a/crates/basalt-net/src/lib.rs
+++ b/crates/basalt-net/src/lib.rs
@@ -15,6 +15,7 @@ pub mod error;
 pub mod framing;
 pub mod pipeline;
 pub mod stream;
+pub mod writer;
 
 pub use connection::{Connection, HandshakeResult};
 pub use error::{Error, Result};

--- a/crates/basalt-net/src/writer.rs
+++ b/crates/basalt-net/src/writer.rs
@@ -1,0 +1,23 @@
+//! Packet writer trait for abstracting packet output.
+//!
+//! `PacketWriter` decouples packet sending from the concrete TCP
+//! connection. This enables unit testing of packet-sending code
+//! without a real TCP stream — tests can use a mock writer that
+//! records packets instead of sending them over the network.
+
+use crate::error::Result;
+use basalt_types::{Encode, EncodedSize};
+
+/// Abstraction over writing protocol packets.
+///
+/// The main implementation is `Connection<Play>`, but tests can
+/// provide mock implementations that capture packets for assertions.
+#[allow(async_fn_in_trait)]
+pub trait PacketWriter {
+    /// Writes a typed packet with the given ID to the output.
+    async fn write_packet_typed<P: Encode + EncodedSize>(
+        &mut self,
+        packet_id: i32,
+        packet: &P,
+    ) -> Result<()>;
+}

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -11,6 +11,7 @@ basalt-protocol = { workspace = true }
 basalt-net = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
+dashmap = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/basalt-server/src/connection.rs
+++ b/crates/basalt-server/src/connection.rs
@@ -17,7 +17,6 @@ use basalt_protocol::packets::status::{
     ClientboundStatusPing, ClientboundStatusServerInfo, ServerboundStatusPacket,
 };
 use basalt_protocol::registry_data::build_default_registries;
-use tokio::sync::mpsc;
 
 use crate::play::run_play_loop;
 use crate::player::PlayerState;
@@ -166,21 +165,20 @@ async fn handle_configuration(
         skin_properties,
     );
 
-    // Create the broadcast channel for this player
-    let (tx, rx) = mpsc::channel::<BroadcastMessage>(64);
+    // Subscribe to broadcast channel before registering so we don't
+    // miss our own join notification (we filter it in the play loop).
+    let broadcast_rx = state.subscribe();
 
     // Register in the server state — get the list of existing players
-    let existing_players = state
-        .register_player(PlayerHandle {
-            username: username.to_string(),
-            uuid: player_uuid,
-            entity_id,
-            skin_properties: player.skin_properties.clone(),
-            sender: tx,
-        })
-        .await;
+    let existing_players = state.register_player(PlayerHandle {
+        username: username.to_string(),
+        uuid: player_uuid,
+        entity_id,
+        skin_properties: player.skin_properties.clone(),
+    });
 
-    // Notify existing players that this player joined
+    // Notify all players (including ourselves) that we joined.
+    // Our play loop will filter out our own join message.
     let snapshot = PlayerSnapshot {
         username: player.username.clone(),
         uuid: player.uuid,
@@ -192,25 +190,26 @@ async fn handle_configuration(
         pitch: player.pitch,
         skin_properties: player.skin_properties.clone(),
     };
-    state
-        .broadcast_except(
-            BroadcastMessage::PlayerJoined { info: snapshot },
-            &player_uuid,
-        )
-        .await;
+    state.broadcast(BroadcastMessage::PlayerJoined { info: snapshot });
 
     // Run the play loop — this blocks until the player disconnects
-    let result = run_play_loop(conn, addr, &mut player, &state, rx, &existing_players).await;
+    let result = run_play_loop(
+        conn,
+        addr,
+        &mut player,
+        &state,
+        broadcast_rx,
+        &existing_players,
+    )
+    .await;
 
     // Unregister and notify others
-    state.unregister_player(&player_uuid).await;
-    state
-        .broadcast(BroadcastMessage::PlayerLeft {
-            uuid: player_uuid,
-            entity_id,
-            username: player.username.clone(),
-        })
-        .await;
+    state.unregister_player(&player_uuid);
+    state.broadcast(BroadcastMessage::PlayerLeft {
+        uuid: player_uuid,
+        entity_id,
+        username: player.username.clone(),
+    });
 
     result
 }

--- a/crates/basalt-server/src/handler.rs
+++ b/crates/basalt-server/src/handler.rs
@@ -1,0 +1,30 @@
+//! Packet handler trait for extensible packet dispatch.
+//!
+//! The `PacketHandler` trait decouples packet processing from the play
+//! loop. Each handler implements `handle()` which receives the packet,
+//! player state, and a `PacketContext` for sending responses. This
+//! pattern is extensible for plugins — a plugin registers handlers
+//! that the server calls alongside built-in ones.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use basalt_net::connection::{Connection, Play};
+
+use crate::state::ServerState;
+
+/// Context available to packet handlers for sending responses
+/// and accessing shared state.
+///
+/// Wraps the connection and server state so handlers don't need
+/// to take multiple parameters. Also carries the player's address
+/// for logging.
+pub(crate) struct PacketContext<'a> {
+    /// The player's TCP connection for sending response packets.
+    pub conn: &'a mut Connection<Play>,
+    /// Shared server state for broadcasting and player lookups.
+    pub state: &'a Arc<ServerState>,
+    /// The player's socket address for logging.
+    #[allow(dead_code)]
+    pub addr: SocketAddr,
+}

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -21,6 +21,7 @@ mod chat;
 mod chunk;
 mod connection;
 pub mod error;
+mod handler;
 mod helpers;
 mod play;
 mod player;

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -27,7 +27,7 @@ use basalt_protocol::packets::play::world::{
     ClientboundPlaySpawnPosition,
 };
 use basalt_types::{Encode, Position, VarInt, Vec3i16};
-use tokio::sync::mpsc;
+use tokio::sync::broadcast;
 
 use crate::helpers::{RawPayload, angle_to_byte};
 use crate::player::PlayerState;
@@ -39,7 +39,7 @@ pub(crate) async fn run_play_loop(
     addr: SocketAddr,
     player: &mut PlayerState,
     state: &Arc<ServerState>,
-    rx: mpsc::Receiver<BroadcastMessage>,
+    rx: broadcast::Receiver<BroadcastMessage>,
     existing_players: &[PlayerSnapshot],
 ) -> crate::error::Result<()> {
     send_initial_world(&mut conn, addr, player).await?;
@@ -181,7 +181,7 @@ async fn play_loop(
     addr: SocketAddr,
     player: &mut PlayerState,
     state: &Arc<ServerState>,
-    mut rx: mpsc::Receiver<BroadcastMessage>,
+    mut rx: broadcast::Receiver<BroadcastMessage>,
 ) -> crate::error::Result<()> {
     let mut keep_alive = tokio::time::interval(std::time::Duration::from_secs(15));
     keep_alive.tick().await;
@@ -216,7 +216,7 @@ async fn play_loop(
                     }
                 }
             }
-            Some(msg) = rx.recv() => {
+            Ok(msg) = rx.recv() => {
                 handle_broadcast(conn, player, msg).await?;
             }
         }
@@ -338,26 +338,21 @@ async fn execute_action(
         PacketAction::Handled => {}
         PacketAction::Chat { username, message } => {
             let content = crate::chat::build_chat_component(&username, &message).to_nbt();
-            state.broadcast(BroadcastMessage::Chat { content }).await;
+            state.broadcast(BroadcastMessage::Chat { content });
         }
         PacketAction::Command { command } => {
             crate::chat::handle_command(conn, player, &command).await?;
         }
         PacketAction::Moved => {
-            state
-                .broadcast_except(
-                    BroadcastMessage::EntityMoved {
-                        entity_id: player.entity_id,
-                        x: player.x,
-                        y: player.y,
-                        z: player.z,
-                        yaw: player.yaw,
-                        pitch: player.pitch,
-                        on_ground: player.on_ground,
-                    },
-                    &player.uuid,
-                )
-                .await;
+            state.broadcast(BroadcastMessage::EntityMoved {
+                entity_id: player.entity_id,
+                x: player.x,
+                y: player.y,
+                z: player.z,
+                yaw: player.yaw,
+                pitch: player.pitch,
+                on_ground: player.on_ground,
+            });
         }
     }
     Ok(())
@@ -379,6 +374,10 @@ async fn handle_broadcast(
                 .await?;
         }
         BroadcastMessage::PlayerJoined { info } => {
+            // Skip our own join message
+            if info.uuid == player.uuid {
+                return Ok(());
+            }
             send_player_info_add(conn, &info).await?;
             send_spawn_entity(conn, &info).await?;
 

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -29,6 +29,7 @@ use basalt_protocol::packets::play::world::{
 use basalt_types::{Encode, Position, VarInt, Vec3i16};
 use tokio::sync::broadcast;
 
+use crate::handler::PacketContext;
 use crate::helpers::{RawPayload, angle_to_byte};
 use crate::player::PlayerState;
 use crate::state::{BroadcastMessage, PlayerSnapshot, ServerState};
@@ -200,7 +201,8 @@ async fn play_loop(
                 match result {
                     Ok(packet) => {
                         let action = dispatch_packet(addr, player, packet);
-                        execute_action(conn, player, state, action).await?;
+                        let mut ctx = PacketContext { conn, state, addr };
+                        execute_action(&mut ctx, player, action).await?;
                     }
                     Err(basalt_net::Error::Protocol(
                         basalt_protocol::Error::UnknownPacket { id, .. }
@@ -327,24 +329,23 @@ pub(crate) fn dispatch_packet(
     }
 }
 
-/// Executes the async part of a packet action.
+/// Executes the async part of a packet action using the packet context.
 async fn execute_action(
-    conn: &mut Connection<Play>,
+    ctx: &mut PacketContext<'_>,
     player: &mut PlayerState,
-    state: &Arc<ServerState>,
     action: PacketAction,
 ) -> crate::error::Result<()> {
     match action {
         PacketAction::Handled => {}
         PacketAction::Chat { username, message } => {
             let content = crate::chat::build_chat_component(&username, &message).to_nbt();
-            state.broadcast(BroadcastMessage::Chat { content });
+            ctx.state.broadcast(BroadcastMessage::Chat { content });
         }
         PacketAction::Command { command } => {
-            crate::chat::handle_command(conn, player, &command).await?;
+            crate::chat::handle_command(ctx.conn, player, &command).await?;
         }
         PacketAction::Moved => {
-            state.broadcast(BroadcastMessage::EntityMoved {
+            ctx.state.broadcast(BroadcastMessage::EntityMoved {
                 entity_id: player.entity_id,
                 x: player.x,
                 y: player.y,

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -2,16 +2,16 @@
 //!
 //! `ServerState` is the central shared state passed as `Arc<ServerState>`
 //! to each connection task. It holds the player registry (who's online),
-//! an atomic entity ID counter, and provides methods for broadcasting
+//! an atomic entity ID counter, and a broadcast channel for fan-out
 //! messages to all connected players.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use basalt_types::Uuid;
 use basalt_types::nbt::NbtCompound;
-use tokio::sync::{RwLock, mpsc};
+use dashmap::DashMap;
+use tokio::sync::broadcast;
 
 use crate::skin::ProfileProperty;
 
@@ -19,14 +19,16 @@ use crate::skin::ProfileProperty;
 pub(crate) struct ServerState {
     /// Atomic counter for assigning unique entity IDs.
     next_entity_id: AtomicI32,
-    /// Registry of all connected players, keyed by UUID.
-    players: RwLock<HashMap<Uuid, PlayerHandle>>,
+    /// Lock-free registry of all connected players, keyed by UUID.
+    players: DashMap<Uuid, PlayerHandle>,
+    /// Broadcast channel sender — O(1) fan-out to all subscribers.
+    broadcast_tx: broadcast::Sender<BroadcastMessage>,
 }
 
 /// A handle to a connected player, stored in the server state registry.
 ///
-/// Contains the player's identity info and a channel sender for
-/// delivering broadcast messages to their connection task.
+/// Contains the player's identity info. Broadcast messages are delivered
+/// via the shared `broadcast::Sender` rather than per-player channels.
 #[derive(Debug)]
 pub(crate) struct PlayerHandle {
     /// The player's display name.
@@ -37,8 +39,6 @@ pub(crate) struct PlayerHandle {
     pub entity_id: i32,
     /// Mojang profile properties (skin textures).
     pub skin_properties: Vec<ProfileProperty>,
-    /// Channel for sending broadcast messages to this player's task.
-    pub sender: mpsc::Sender<BroadcastMessage>,
 }
 
 /// A snapshot of a player's state at a point in time.
@@ -69,9 +69,8 @@ pub(crate) struct PlayerSnapshot {
 
 /// A message broadcast from one player's task to all others.
 ///
-/// Sent through the `mpsc` channel stored in each `PlayerHandle`.
-/// The receiving task translates these into the appropriate
-/// clientbound packets.
+/// Sent through the `broadcast::Sender` and received by each player's
+/// `broadcast::Receiver` in their play loop.
 #[derive(Debug, Clone)]
 pub(crate) enum BroadcastMessage {
     /// A chat message to display in all players' chat windows.
@@ -113,11 +112,16 @@ pub(crate) enum BroadcastMessage {
 }
 
 impl ServerState {
-    /// Creates a new empty server state.
+    /// Creates a new empty server state with a broadcast channel.
     pub fn new() -> Arc<Self> {
+        // Buffer size for broadcast — receivers that fall behind lose
+        // old messages. 256 is enough for ~5 seconds of movement
+        // updates from 10 players at 20Hz.
+        let (broadcast_tx, _) = broadcast::channel(256);
         Arc::new(Self {
             next_entity_id: AtomicI32::new(1),
-            players: RwLock::new(HashMap::new()),
+            players: DashMap::new(),
+            broadcast_tx,
         })
     }
 
@@ -126,67 +130,58 @@ impl ServerState {
         self.next_entity_id.fetch_add(1, Ordering::Relaxed)
     }
 
+    /// Subscribes to the broadcast channel. Each player task calls
+    /// this once and polls the receiver in their play loop.
+    pub fn subscribe(&self) -> broadcast::Receiver<BroadcastMessage> {
+        self.broadcast_tx.subscribe()
+    }
+
     /// Registers a player in the server state.
     ///
     /// Returns snapshots of all players who were already connected
     /// (the new player needs to know about them).
-    pub async fn register_player(&self, handle: PlayerHandle) -> Vec<PlayerSnapshot> {
-        let mut players = self.players.write().await;
-        let existing: Vec<PlayerSnapshot> = players
-            .values()
-            .map(|h| PlayerSnapshot {
-                username: h.username.clone(),
-                uuid: h.uuid,
-                entity_id: h.entity_id,
-                // Position is not tracked in the handle — the joining
-                // player will receive SpawnEntity with default coords.
-                // Movement broadcasts update position in real time.
-                x: 0.0,
-                y: 100.0,
-                z: 0.0,
-                yaw: 0.0,
-                pitch: 0.0,
-                skin_properties: h.skin_properties.clone(),
+    pub fn register_player(&self, handle: PlayerHandle) -> Vec<PlayerSnapshot> {
+        let existing: Vec<PlayerSnapshot> = self
+            .players
+            .iter()
+            .map(|entry| {
+                let h = entry.value();
+                PlayerSnapshot {
+                    username: h.username.clone(),
+                    uuid: h.uuid,
+                    entity_id: h.entity_id,
+                    x: 0.0,
+                    y: 100.0,
+                    z: 0.0,
+                    yaw: 0.0,
+                    pitch: 0.0,
+                    skin_properties: h.skin_properties.clone(),
+                }
             })
             .collect();
-        players.insert(handle.uuid, handle);
+        self.players.insert(handle.uuid, handle);
         existing
     }
 
     /// Removes a player from the server state.
-    pub async fn unregister_player(&self, uuid: &Uuid) {
-        self.players.write().await.remove(uuid);
+    pub fn unregister_player(&self, uuid: &Uuid) {
+        self.players.remove(uuid);
     }
 
     /// Broadcasts a message to all connected players.
     ///
-    /// Sends the message to every player's channel. Players whose
-    /// channel is full or closed are silently skipped (they will
-    /// disconnect on their own).
-    pub async fn broadcast(&self, message: BroadcastMessage) {
-        let players = self.players.read().await;
-        for handle in players.values() {
-            let _ = handle.sender.try_send(message.clone());
-        }
-    }
-
-    /// Broadcasts a message to all connected players except one.
-    ///
-    /// Used for movement updates where the moving player should
-    /// not receive their own entity movement packet.
-    pub async fn broadcast_except(&self, message: BroadcastMessage, except: &Uuid) {
-        let players = self.players.read().await;
-        for handle in players.values() {
-            if &handle.uuid != except {
-                let _ = handle.sender.try_send(message.clone());
-            }
-        }
+    /// Uses the broadcast channel for O(1) fan-out. Receivers that
+    /// have fallen behind will miss old messages (acceptable for
+    /// movement updates, chat is rare enough to fit in the buffer).
+    pub fn broadcast(&self, message: BroadcastMessage) {
+        // Ignore send errors — they mean no receivers are listening.
+        let _ = self.broadcast_tx.send(message);
     }
 
     /// Returns the number of currently connected players.
     #[cfg(test)]
-    pub async fn player_count(&self) -> usize {
-        self.players.read().await.len()
+    pub fn player_count(&self) -> usize {
+        self.players.len()
     }
 }
 
@@ -194,149 +189,83 @@ impl ServerState {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn next_entity_id_increments() {
+    #[test]
+    fn next_entity_id_increments() {
         let state = ServerState::new();
         assert_eq!(state.next_entity_id(), 1);
         assert_eq!(state.next_entity_id(), 2);
         assert_eq!(state.next_entity_id(), 3);
     }
 
-    #[tokio::test]
-    async fn register_and_unregister_player() {
+    #[test]
+    fn register_and_unregister_player() {
         let state = ServerState::new();
-        let (tx, _rx) = mpsc::channel(16);
 
         let uuid = Uuid::default();
-        let existing = state
-            .register_player(PlayerHandle {
-                username: "Steve".into(),
-                uuid,
-                entity_id: 1,
-                skin_properties: vec![],
-                sender: tx,
-            })
-            .await;
+        let existing = state.register_player(PlayerHandle {
+            username: "Steve".into(),
+            uuid,
+            entity_id: 1,
+            skin_properties: vec![],
+        });
 
         assert!(existing.is_empty());
-        assert_eq!(state.player_count().await, 1);
+        assert_eq!(state.player_count(), 1);
 
-        state.unregister_player(&uuid).await;
-        assert_eq!(state.player_count().await, 0);
+        state.unregister_player(&uuid);
+        assert_eq!(state.player_count(), 0);
     }
 
-    #[tokio::test]
-    async fn register_returns_existing_players() {
+    #[test]
+    fn register_returns_existing_players() {
         let state = ServerState::new();
-        let (tx1, _rx1) = mpsc::channel(16);
-        let (tx2, _rx2) = mpsc::channel(16);
 
         let uuid1 = Uuid::from_bytes([1; 16]);
         let uuid2 = Uuid::from_bytes([2; 16]);
 
-        state
-            .register_player(PlayerHandle {
-                username: "Alice".into(),
-                uuid: uuid1,
-                entity_id: 1,
-                skin_properties: vec![],
-                sender: tx1,
-            })
-            .await;
+        state.register_player(PlayerHandle {
+            username: "Alice".into(),
+            uuid: uuid1,
+            entity_id: 1,
+            skin_properties: vec![],
+        });
 
-        let existing = state
-            .register_player(PlayerHandle {
-                username: "Bob".into(),
-                uuid: uuid2,
-                entity_id: 2,
-                skin_properties: vec![],
-                sender: tx2,
-            })
-            .await;
+        let existing = state.register_player(PlayerHandle {
+            username: "Bob".into(),
+            uuid: uuid2,
+            entity_id: 2,
+            skin_properties: vec![],
+        });
 
         assert_eq!(existing.len(), 1);
         assert_eq!(existing[0].username, "Alice");
-        assert_eq!(state.player_count().await, 2);
+        assert_eq!(state.player_count(), 2);
     }
 
-    #[tokio::test]
-    async fn broadcast_sends_to_all() {
+    #[test]
+    fn broadcast_delivers_to_subscriber() {
         let state = ServerState::new();
-        let (tx1, mut rx1) = mpsc::channel(16);
-        let (tx2, mut rx2) = mpsc::channel(16);
+        let mut rx = state.subscribe();
 
-        let uuid1 = Uuid::from_bytes([1; 16]);
-        let uuid2 = Uuid::from_bytes([2; 16]);
+        state.broadcast(BroadcastMessage::Chat {
+            content: NbtCompound::new(),
+        });
 
-        state
-            .register_player(PlayerHandle {
-                username: "A".into(),
-                uuid: uuid1,
-                entity_id: 1,
-                skin_properties: vec![],
-                sender: tx1,
-            })
-            .await;
-        state
-            .register_player(PlayerHandle {
-                username: "B".into(),
-                uuid: uuid2,
-                entity_id: 2,
-                skin_properties: vec![],
-                sender: tx2,
-            })
-            .await;
+        let msg = rx.try_recv().unwrap();
+        assert!(matches!(msg, BroadcastMessage::Chat { .. }));
+    }
 
-        state
-            .broadcast(BroadcastMessage::Chat {
-                content: NbtCompound::new(),
-            })
-            .await;
+    #[test]
+    fn broadcast_delivers_to_multiple_subscribers() {
+        let state = ServerState::new();
+        let mut rx1 = state.subscribe();
+        let mut rx2 = state.subscribe();
+
+        state.broadcast(BroadcastMessage::Chat {
+            content: NbtCompound::new(),
+        });
 
         assert!(rx1.try_recv().is_ok());
-        assert!(rx2.try_recv().is_ok());
-    }
-
-    #[tokio::test]
-    async fn broadcast_except_skips_sender() {
-        let state = ServerState::new();
-        let (tx1, mut rx1) = mpsc::channel(16);
-        let (tx2, mut rx2) = mpsc::channel(16);
-
-        let uuid1 = Uuid::from_bytes([1; 16]);
-        let uuid2 = Uuid::from_bytes([2; 16]);
-
-        state
-            .register_player(PlayerHandle {
-                username: "A".into(),
-                uuid: uuid1,
-                entity_id: 1,
-                skin_properties: vec![],
-                sender: tx1,
-            })
-            .await;
-        state
-            .register_player(PlayerHandle {
-                username: "B".into(),
-                uuid: uuid2,
-                entity_id: 2,
-                skin_properties: vec![],
-                sender: tx2,
-            })
-            .await;
-
-        state
-            .broadcast_except(
-                BroadcastMessage::Chat {
-                    content: NbtCompound::new(),
-                },
-                &uuid1,
-            )
-            .await;
-
-        // A should NOT receive it
-        assert!(rx1.try_recv().is_err());
-        // B should receive it
         assert!(rx2.try_recv().is_ok());
     }
 }

--- a/crates/basalt-types/src/lib.rs
+++ b/crates/basalt-types/src/lib.rs
@@ -4,6 +4,7 @@ mod byte_array;
 pub mod error;
 mod identifier;
 pub mod nbt;
+mod opaque;
 mod position;
 mod primitives;
 mod slot;
@@ -19,6 +20,7 @@ pub use bit_set::BitSet;
 pub use error::{Error, Result};
 pub use identifier::Identifier;
 pub use nbt::{NbtCompound, NbtList, NbtTag};
+pub use opaque::OpaqueBytes;
 pub use position::{BlockPosition, ChunkPosition, Position};
 pub use slot::Slot;
 pub use text::{

--- a/crates/basalt-types/src/opaque.rs
+++ b/crates/basalt-types/src/opaque.rs
@@ -1,0 +1,118 @@
+//! Opaque byte buffer for protocol types that can't be parsed.
+//!
+//! `OpaqueBytes` wraps a `Vec<u8>` to distinguish intentionally opaque
+//! protocol data (native types, switch fallbacks) from other byte
+//! vectors that happen to use `Vec<u8>`. It encodes/decodes as a
+//! length-prefixed byte array, same as `Vec<u8>`.
+
+use crate::{Decode, Encode, EncodedSize, Error, Result, VarInt};
+
+/// A byte buffer for protocol data whose internal structure is not
+/// parsed by the codec.
+///
+/// Used for native protocol types (`entityMetadata`, `registryEntryHolder`,
+/// etc.) and switch field fallbacks where the wire format is known
+/// but too complex to represent in the type system.
+///
+/// Unlike raw `Vec<u8>`, `OpaqueBytes` makes the intent explicit:
+/// "this data is intentionally unparsed".
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct OpaqueBytes(pub Vec<u8>);
+
+impl OpaqueBytes {
+    /// Creates an empty opaque buffer.
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Creates an opaque buffer from raw bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns a reference to the inner bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns the number of bytes.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Encode for OpaqueBytes {
+    /// Encodes as a VarInt length prefix followed by the raw bytes.
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        VarInt(self.0.len() as i32).encode(buf)?;
+        buf.extend_from_slice(&self.0);
+        Ok(())
+    }
+}
+
+impl Decode for OpaqueBytes {
+    /// Decodes a VarInt length prefix then reads that many bytes.
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let len = VarInt::decode(buf)?.0 as usize;
+        if buf.len() < len {
+            return Err(Error::BufferUnderflow {
+                needed: len,
+                available: buf.len(),
+            });
+        }
+        let (bytes, rest) = buf.split_at(len);
+        let value = bytes.to_vec();
+        *buf = rest;
+        Ok(Self(value))
+    }
+}
+
+impl EncodedSize for OpaqueBytes {
+    fn encoded_size(&self) -> usize {
+        VarInt(self.0.len() as i32).encoded_size() + self.0.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_roundtrip() {
+        let original = OpaqueBytes::new();
+        let mut buf = Vec::new();
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), 1); // VarInt(0)
+
+        let mut cursor = buf.as_slice();
+        let decoded = OpaqueBytes::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn data_roundtrip() {
+        let original = OpaqueBytes::from_bytes(vec![1, 2, 3, 4, 5]);
+        let mut buf = Vec::with_capacity(original.encoded_size());
+        original.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), original.encoded_size());
+
+        let mut cursor = buf.as_slice();
+        let decoded = OpaqueBytes::decode(&mut cursor).unwrap();
+        assert!(cursor.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn accessors() {
+        let opaque = OpaqueBytes::from_bytes(vec![0xAB, 0xCD]);
+        assert_eq!(opaque.len(), 2);
+        assert!(!opaque.is_empty());
+        assert_eq!(opaque.as_bytes(), &[0xAB, 0xCD]);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining 4 structural improvements from #68:

1. **DashMap + broadcast channel** — player registry uses lock-free DashMap instead of RwLock HashMap. Broadcasting uses tokio::sync::broadcast (O(1) fan-out) instead of per-player mpsc iteration (O(n)). register/unregister/broadcast are now sync.

2. **PacketContext** — bundles connection, server state, and player address into a single struct passed to execute_action. Clean extension point for the future plugin API.

3. **OpaqueBytes** — newtype wrapping Vec u8 for intentionally unparsed protocol data (native types, switch fallbacks). Makes intent explicit at the type level.

4. **PacketWriter trait** — abstracts over writing protocol packets. Connection Play implements it, but tests can provide mock implementations. Enables unit testing of packet-sending logic without TCP.

Combined with PR #69 (which did fixes 1-4: chunk move, server error type, parallel skin, decode context), all 11 structural issues from #68 are addressed (minus #9 which was skipped per user decision).

Closes #68

## Test plan

- [x] `cargo test` — 459 tests pass
- [x] `cargo clippy` clean
- [x] Coverage >= 90% (90.83%)
- [ ] CI passes
- [ ] Manual test: 2 Minecraft clients, same behavior as before
