### PR TITLE
feat(world): noise-based terrain with hills, water, beaches and snow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ version = "0.1.0"
 dependencies = [
  "basalt-protocol",
  "basalt-types",
+ "noise",
 ]
 
 [[package]]
@@ -919,6 +920,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "noise"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "rand_xorshift 0.3.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,9 +1061,9 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.3",
  "rand_chacha",
- "rand_xorshift",
+ "rand_xorshift 0.4.0",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
@@ -1093,7 +1105,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1142,12 +1154,21 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1157,8 +1178,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1171,11 +1198,20 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ cfb8 = "0.8"
 # Compression
 flate2 = "1"
 
+# Noise generation
+noise = "0.9"
+
 # Concurrent data structures
 dashmap = "6"
 

--- a/crates/basalt-server/src/player.rs
+++ b/crates/basalt-server/src/player.rs
@@ -59,7 +59,7 @@ impl PlayerState {
             entity_id,
             skin_properties,
             x: 0.0,
-            y: basalt_world::FlatWorldGenerator::SPAWN_Y as f64,
+            y: basalt_world::NoiseTerrainGenerator::SPAWN_Y as f64,
             z: 0.0,
             yaw: 0.0,
             pitch: 0.0,
@@ -105,7 +105,7 @@ mod tests {
     fn new_player_has_default_spawn() {
         let p = test_player();
         assert_eq!(p.x, 0.0);
-        assert_eq!(p.y, basalt_world::FlatWorldGenerator::SPAWN_Y as f64);
+        assert_eq!(p.y, basalt_world::NoiseTerrainGenerator::SPAWN_Y as f64);
         assert_eq!(p.z, 0.0);
         assert_eq!(p.yaw, 0.0);
         assert_eq!(p.pitch, 0.0);

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -124,7 +124,7 @@ impl ServerState {
             next_entity_id: AtomicI32::new(1),
             players: DashMap::new(),
             broadcast_tx,
-            world: basalt_world::World::new(),
+            world: basalt_world::World::new(42),
         })
     }
 
@@ -154,7 +154,7 @@ impl ServerState {
                     uuid: h.uuid,
                     entity_id: h.entity_id,
                     x: 0.0,
-                    y: basalt_world::FlatWorldGenerator::SPAWN_Y as f64,
+                    y: basalt_world::NoiseTerrainGenerator::SPAWN_Y as f64,
                     z: 0.0,
                     yaw: 0.0,
                     pitch: 0.0,

--- a/crates/basalt-world/Cargo.toml
+++ b/crates/basalt-world/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 [dependencies]
 basalt-types = { workspace = true }
 basalt-protocol = { workspace = true }
+noise = { workspace = true }

--- a/crates/basalt-world/src/block.rs
+++ b/crates/basalt-world/src/block.rs
@@ -18,3 +18,16 @@ pub const GRASS_BLOCK: u16 = 8;
 
 /// Bedrock — indestructible bottom layer.
 pub const BEDROCK: u16 = 85;
+
+/// Water — still water (default state, level 0).
+pub const WATER: u16 = 86;
+
+/// Sand — beach and desert block.
+pub const SAND: u16 = 118;
+
+/// Gravel — underwater floor block.
+pub const GRAVEL: u16 = 124;
+
+/// Snow block — covers high-altitude terrain.
+/// Snow block — covers high-altitude terrain tops.
+pub const SNOW_BLOCK: u16 = 5950;

--- a/crates/basalt-world/src/lib.rs
+++ b/crates/basalt-world/src/lib.rs
@@ -16,13 +16,23 @@
 pub mod block;
 mod chunk;
 mod generator;
+mod noise_gen;
 mod palette;
 
 pub use chunk::ChunkColumn;
 pub use generator::FlatWorldGenerator;
+pub use noise_gen::NoiseTerrainGenerator;
 
 use std::collections::HashMap;
 use std::sync::Mutex;
+
+/// How terrain is generated for new chunks.
+enum Generator {
+    /// Superflat world: bedrock + dirt + grass.
+    Flat(FlatWorldGenerator),
+    /// Noise-based terrain with hills, water, beaches.
+    Noise(Box<NoiseTerrainGenerator>),
+}
 
 /// A Minecraft world with lazy chunk generation and in-memory caching.
 ///
@@ -36,24 +46,37 @@ pub struct World {
     /// In-memory chunk cache, keyed by (chunk_x, chunk_z).
     chunks: Mutex<HashMap<(i32, i32), ChunkColumn>>,
     /// The terrain generator used for new chunks.
-    generator: FlatWorldGenerator,
+    generator: Generator,
+    /// The Y coordinate where players spawn.
+    spawn_y: i32,
 }
 
 impl World {
-    /// Creates a new world with the flat world generator.
+    /// Creates a new world with noise-based terrain generation.
     ///
-    /// No chunks are generated until they are requested via
-    /// `get_or_generate_chunk`.
-    pub fn new() -> Self {
+    /// The seed determines the terrain shape — same seed produces
+    /// the same world every time. No chunks are generated until
+    /// they are requested.
+    pub fn new(seed: u32) -> Self {
         Self {
             chunks: Mutex::new(HashMap::new()),
-            generator: FlatWorldGenerator,
+            generator: Generator::Noise(Box::new(NoiseTerrainGenerator::new(seed))),
+            spawn_y: NoiseTerrainGenerator::SPAWN_Y,
+        }
+    }
+
+    /// Creates a new flat world (superflat).
+    pub fn flat() -> Self {
+        Self {
+            chunks: Mutex::new(HashMap::new()),
+            generator: Generator::Flat(FlatWorldGenerator),
+            spawn_y: FlatWorldGenerator::SPAWN_Y,
         }
     }
 
     /// The Y coordinate where players should spawn.
     pub fn spawn_y(&self) -> f64 {
-        FlatWorldGenerator::SPAWN_Y as f64
+        self.spawn_y as f64
     }
 
     /// Returns a protocol packet for the chunk at (cx, cz).
@@ -69,7 +92,10 @@ impl World {
         let mut cache = self.chunks.lock().unwrap();
         let chunk = cache.entry((cx, cz)).or_insert_with(|| {
             let mut col = ChunkColumn::new(cx, cz);
-            self.generator.generate(&mut col);
+            match &self.generator {
+                Generator::Flat(g) => g.generate(&mut col),
+                Generator::Noise(g) => g.generate(&mut col),
+            }
             col
         });
         chunk.to_packet()
@@ -88,7 +114,7 @@ impl World {
 
 impl Default for World {
     fn default() -> Self {
-        Self::new()
+        Self::new(0)
     }
 }
 
@@ -98,7 +124,7 @@ mod tests {
 
     #[test]
     fn world_generates_on_first_access() {
-        let world = World::new();
+        let world = World::new(42);
         assert!(!world.is_chunk_loaded(0, 0));
 
         let packet = world.get_chunk_packet(0, 0);
@@ -109,7 +135,7 @@ mod tests {
 
     #[test]
     fn world_caches_chunks() {
-        let world = World::new();
+        let world = World::new(42);
         world.get_chunk_packet(0, 0);
         world.get_chunk_packet(0, 0); // should not regenerate
         assert_eq!(world.chunk_count(), 1);
@@ -117,7 +143,7 @@ mod tests {
 
     #[test]
     fn world_generates_different_coords() {
-        let world = World::new();
+        let world = World::new(42);
         world.get_chunk_packet(0, 0);
         world.get_chunk_packet(1, 0);
         world.get_chunk_packet(0, 1);
@@ -126,7 +152,7 @@ mod tests {
 
     #[test]
     fn spawn_y_is_above_ground() {
-        let world = World::new();
-        assert_eq!(world.spawn_y(), -60.0);
+        let world = World::new(42);
+        assert_eq!(world.spawn_y(), NoiseTerrainGenerator::SPAWN_Y as f64);
     }
 }

--- a/crates/basalt-world/src/noise_gen.rs
+++ b/crates/basalt-world/src/noise_gen.rs
@@ -1,0 +1,250 @@
+//! Noise-based terrain generator.
+//!
+//! Uses layered Perlin noise to create natural-looking terrain with
+//! hills, valleys, beaches, and underwater areas. The terrain has
+//! biome-like variation based on altitude:
+//!
+//! - Deep underwater: gravel floor
+//! - Shallow water: sand floor
+//! - Beach (near sea level): sand
+//! - Plains: grass + dirt
+//! - Hills: grass + stone
+//! - Mountains: stone + snow caps
+
+use noise::{NoiseFn, Perlin};
+
+use crate::block;
+use crate::chunk::ChunkColumn;
+
+/// Sea level Y coordinate — water fills up to this level.
+const SEA_LEVEL: i32 = 62;
+
+/// The base terrain height before noise is applied.
+const BASE_HEIGHT: f64 = 64.0;
+
+/// Maximum height variation from noise (±).
+const HEIGHT_AMPLITUDE: f64 = 32.0;
+
+/// Noise frequency — lower values produce smoother, larger features.
+const FREQUENCY: f64 = 0.01;
+
+/// Secondary noise frequency for detail variation.
+const DETAIL_FREQUENCY: f64 = 0.05;
+
+/// Amplitude of the detail noise layer.
+const DETAIL_AMPLITUDE: f64 = 8.0;
+
+/// Generates terrain using layered Perlin noise.
+///
+/// The generator uses two noise layers:
+/// 1. A low-frequency layer for large terrain features (hills, valleys)
+/// 2. A high-frequency layer for small surface detail
+///
+/// Block placement depends on altitude relative to sea level:
+/// - Below sea level: water fills empty space, gravel/sand on the floor
+/// - At sea level ±2: sand (beaches)
+/// - Above sea level: grass on top, dirt underneath
+/// - High altitude (>90): stone with snow caps
+pub struct NoiseTerrainGenerator {
+    /// Primary terrain shape noise.
+    terrain_noise: Perlin,
+    /// Secondary detail noise for surface variation.
+    detail_noise: Perlin,
+}
+
+impl NoiseTerrainGenerator {
+    /// Creates a new noise generator with the given seed.
+    pub fn new(seed: u32) -> Self {
+        Self {
+            terrain_noise: Perlin::new(seed),
+            detail_noise: Perlin::new(seed.wrapping_add(1)),
+        }
+    }
+
+    /// The Y coordinate where players should spawn (above sea level).
+    pub const SPAWN_Y: i32 = 80;
+
+    /// Computes the terrain height at the given world (x, z) coordinates.
+    fn height_at(&self, world_x: i32, world_z: i32) -> i32 {
+        let x = world_x as f64;
+        let z = world_z as f64;
+
+        // Large-scale terrain shape
+        let base = self.terrain_noise.get([x * FREQUENCY, z * FREQUENCY]);
+        // Small-scale surface detail
+        let detail = self
+            .detail_noise
+            .get([x * DETAIL_FREQUENCY, z * DETAIL_FREQUENCY]);
+
+        let height = BASE_HEIGHT + base * HEIGHT_AMPLITUDE + detail * DETAIL_AMPLITUDE;
+        height as i32
+    }
+
+    /// Populates a chunk column with noise-based terrain.
+    pub fn generate(&self, chunk: &mut ChunkColumn) {
+        for local_x in 0..16 {
+            for local_z in 0..16 {
+                let world_x = chunk.x * 16 + local_x as i32;
+                let world_z = chunk.z * 16 + local_z as i32;
+                let height = self.height_at(world_x, world_z);
+
+                self.generate_column(chunk, local_x, local_z, height);
+            }
+        }
+    }
+
+    /// Fills a single (x, z) column from bedrock to the surface.
+    fn generate_column(&self, chunk: &mut ChunkColumn, x: usize, z: usize, surface_y: i32) {
+        // Bedrock at the very bottom
+        chunk.set_block(x, -64, z, block::BEDROCK);
+
+        // Stone from -63 up to a few blocks below surface
+        for y in -63..=(surface_y - 4) {
+            chunk.set_block(x, y, z, block::STONE);
+        }
+
+        // Surface layers depend on altitude
+        if surface_y < SEA_LEVEL - 3 {
+            // Deep underwater — gravel floor
+            for y in (surface_y - 3)..=surface_y {
+                chunk.set_block(x, y, z, block::GRAVEL);
+            }
+        } else if surface_y < SEA_LEVEL {
+            // Shallow underwater or beach — sand
+            for y in (surface_y - 3)..=surface_y {
+                chunk.set_block(x, y, z, block::SAND);
+            }
+        } else if surface_y < SEA_LEVEL + 3 {
+            // Beach area — sand on top
+            for y in (surface_y - 3)..surface_y {
+                chunk.set_block(x, y, z, block::SAND);
+            }
+            chunk.set_block(x, surface_y, z, block::SAND);
+        } else if surface_y > 90 {
+            // High altitude — stone with snow cap
+            for y in (surface_y - 3)..surface_y {
+                chunk.set_block(x, y, z, block::STONE);
+            }
+            chunk.set_block(x, surface_y, z, block::SNOW_BLOCK);
+        } else {
+            // Normal terrain — dirt with grass on top
+            for y in (surface_y - 3)..surface_y {
+                chunk.set_block(x, y, z, block::DIRT);
+            }
+            chunk.set_block(x, surface_y, z, block::GRASS_BLOCK);
+        }
+
+        // Fill water from surface up to sea level
+        if surface_y < SEA_LEVEL {
+            for y in (surface_y + 1)..=SEA_LEVEL {
+                chunk.set_block(x, y, z, block::WATER);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_terrain_with_variation() {
+        let generator = NoiseTerrainGenerator::new(42);
+        let mut chunk = ChunkColumn::new(0, 0);
+        generator.generate(&mut chunk);
+
+        // Should have bedrock at bottom
+        assert_eq!(chunk.get_block(0, -64, 0), block::BEDROCK);
+
+        // Should have some non-air blocks above bedrock
+        let mut has_surface = false;
+        for y in -63..128 {
+            if chunk.get_block(8, y, 8) != block::AIR && chunk.get_block(8, y, 8) != block::WATER {
+                has_surface = true;
+                break;
+            }
+        }
+        assert!(has_surface, "terrain should have solid blocks");
+    }
+
+    #[test]
+    fn same_seed_same_terrain() {
+        let gen1 = NoiseTerrainGenerator::new(123);
+        let gen2 = NoiseTerrainGenerator::new(123);
+
+        let mut chunk1 = ChunkColumn::new(5, -3);
+        let mut chunk2 = ChunkColumn::new(5, -3);
+        gen1.generate(&mut chunk1);
+        gen2.generate(&mut chunk2);
+
+        // Same seed + same coords = same terrain
+        for x in 0..16 {
+            for z in 0..16 {
+                for y in -64..128 {
+                    assert_eq!(
+                        chunk1.get_block(x, y, z),
+                        chunk2.get_block(x, y, z),
+                        "mismatch at ({x}, {y}, {z})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn different_seeds_different_terrain() {
+        let gen1 = NoiseTerrainGenerator::new(1);
+        let gen2 = NoiseTerrainGenerator::new(999);
+
+        // Check multiple points — at least one should differ
+        let mut any_different = false;
+        for x in 0..50 {
+            if gen1.height_at(x * 16, 0) != gen2.height_at(x * 16, 0) {
+                any_different = true;
+                break;
+            }
+        }
+        assert!(
+            any_different,
+            "different seeds should produce different terrain"
+        );
+    }
+
+    #[test]
+    fn height_varies_across_terrain() {
+        let generator = NoiseTerrainGenerator::new(42);
+
+        let mut heights = Vec::new();
+        for x in 0..100 {
+            heights.push(generator.height_at(x * 16, 0));
+        }
+
+        let min = *heights.iter().min().unwrap();
+        let max = *heights.iter().max().unwrap();
+
+        // Terrain should have at least some variation
+        assert!(max - min > 5, "terrain should vary: min={min}, max={max}");
+    }
+
+    #[test]
+    fn underwater_has_water() {
+        let generator = NoiseTerrainGenerator::new(42);
+
+        // Find a spot that's below sea level by checking many positions
+        let mut found_water = false;
+        for x in 0..200 {
+            let h = generator.height_at(x, 0);
+            if h < SEA_LEVEL {
+                let mut chunk = ChunkColumn::new(x / 16, 0);
+                generator.generate(&mut chunk);
+                let local_x = (x % 16) as usize;
+                // Water should be between surface and sea level
+                if chunk.get_block(local_x, SEA_LEVEL, 0) == block::WATER {
+                    found_water = true;
+                    break;
+                }
+            }
+        }
+        assert!(found_water, "should find water somewhere below sea level");
+    }
+}


### PR DESCRIPTION
## Summary

Adds noise-based terrain generation to basalt-world using layered Perlin noise:

- **Two noise layers**: low-frequency for hills/valleys, high-frequency for surface detail
- **Altitude-based biomes**: gravel underwater, sand beaches, grass plains, stone+snow mountains
- **Water**: fills to sea level (y=62) with proper underwater floor blocks
- **Deterministic**: same seed = same world, World::new(42) in the server
- **World::flat()** still available for superflat worlds

Server updated to spawn at y=80 (above noise terrain).

5 new tests for noise terrain (variation, seed determinism, water generation).

## Test plan

- [x] `cargo test` — 477 tests pass
- [x] `cargo clippy` clean
- [x] Coverage >= 90% (90.16%)
- [ ] CI passes
- [ ] Manual test: connect and explore — hills, water, beaches, snow peaks
