### PR TITLE
feat(storage): basalt-storage crate with BSR format and chunk persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ docs/superpowers/
 
 ## sniffcraft
 sniffcraft/
+
+## world save data
+world/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ basalt-types → basalt-derive → basalt-protocol → basalt-net → basalt-ser
 | `basalt-derive` | Proc macros for `Encode`/`Decode`/`EncodedSize` | `syn`, `quote`, `proc-macro2` |
 | `basalt-protocol` | Packet definitions, version-aware registry, registry data | `basalt-types`, `basalt-derive` |
 | `basalt-net` | Async networking, encryption, compression, connection typestate, middleware pipeline | `basalt-protocol`, `tokio`, `aes`, `cfb8`, `flate2` |
-| `basalt-world` | World generation, chunk storage, paletted containers, block state registry | `basalt-types`, `basalt-protocol` |
+| `basalt-world` | World generation, chunk storage, paletted containers, block state registry | `basalt-types`, `basalt-protocol`, `basalt-storage` |
+| `basalt-storage` | BSR region file format with LZ4 compression for chunk persistence | `lz4_flex` |
 | `basalt-server` | Minecraft server: connection lifecycle, play loop, chat, commands, chunk streaming | `basalt-net`, `basalt-world`, `tokio`, `dashmap`, `reqwest` |
 | `xtask` | Code generation from minecraft-data JSON → Rust packet structs | `serde_json` |
 
@@ -120,6 +121,7 @@ basalt/
 │   ├── basalt-protocol/
 │   ├── basalt-net/
 │   ├── basalt-world/          # World generation, chunk cache, paletted containers
+│   ├── basalt-storage/        # BSR region format, LZ4 compression, disk persistence
 │   └── basalt-server/         # Minecraft server: connection lifecycle, play loop, chat, commands
 ├── minecraft-data/           # Git submodule — PrismarineJS/minecraft-data
 ├── xtask/                    # Codegen tool

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "basalt-storage"
+version = "0.1.0"
+dependencies = [
+ "lz4_flex",
+ "tempfile",
+]
+
+[[package]]
 name = "basalt-types"
 version = "0.1.0"
 dependencies = [
@@ -120,8 +128,10 @@ name = "basalt-world"
 version = "0.1.0"
 dependencies = [
  "basalt-protocol",
+ "basalt-storage",
  "basalt-types",
  "noise",
+ "tempfile",
 ]
 
 [[package]]
@@ -891,6 +901,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "memchr"
@@ -1740,6 +1759,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ basalt-protocol = { path = "crates/basalt-protocol" }
 basalt-net = { path = "crates/basalt-net" }
 basalt-server = { path = "crates/basalt-server" }
 basalt-world = { path = "crates/basalt-world" }
+basalt-storage = { path = "crates/basalt-storage" }
 
 # Error handling
 thiserror = "2"
@@ -33,6 +34,9 @@ cfb8 = "0.8"
 
 # Compression
 flate2 = "1"
+
+# Compression (storage)
+lz4_flex = "0.11"
 
 # Noise generation
 noise = "0.9"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -216,6 +216,16 @@ const world = [
   'world/block',
 ];
 
+const storage = [
+  // Cross-module changes within basalt-storage.
+  // Example: "feat(storage): add player data persistence"
+  'storage',
+
+  // BSR region file format and LZ4 compression.
+  // Example: "perf(storage/region): optimize offset table reads"
+  'storage/region',
+];
+
 const keywords = [
   // Root workspace configuration: Cargo.toml workspace settings, workspace-wide
   // dependency versions, cross-crate build configuration.
@@ -276,7 +286,7 @@ const keywords = [
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...keywords]],
+    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...storage, ...keywords]],
     'scope-empty': [2, 'never'],
   },
 };

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -124,7 +124,7 @@ impl ServerState {
             next_entity_id: AtomicI32::new(1),
             players: DashMap::new(),
             broadcast_tx,
-            world: basalt_world::World::new(42),
+            world: basalt_world::World::new(42, "world"),
         })
     }
 

--- a/crates/basalt-storage/Cargo.toml
+++ b/crates/basalt-storage/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "basalt-storage"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+lz4_flex = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/basalt-storage/src/lib.rs
+++ b/crates/basalt-storage/src/lib.rs
@@ -1,0 +1,19 @@
+//! Basalt storage with the BSR (Basalt Region) format.
+//!
+//! Provides fast, compact persistence using a custom binary region
+//! format with LZ4 compression. Region files cover 32×32 chunks
+//! with O(1) offset-table lookup.
+//!
+//! The storage is format-agnostic — it stores and retrieves raw
+//! bytes. Chunk serialization/deserialization is handled by the
+//! caller (basalt-world).
+//!
+//! # Format highlights
+//!
+//! - LZ4 compression: 4.4 GB/s decompression, minimal CPU overhead
+//! - Region files with 1024-entry offset table for O(1) access
+//! - Header with magic bytes and version for forward compatibility
+
+mod region;
+
+pub use region::RegionStorage;

--- a/crates/basalt-storage/src/region.rs
+++ b/crates/basalt-storage/src/region.rs
@@ -1,0 +1,267 @@
+//! Region file I/O for the BSR format.
+//!
+//! Each region file covers 32×32 = 1024 chunks and contains an offset
+//! table for O(1) chunk lookup followed by LZ4-compressed data blobs.
+//!
+//! The storage is agnostic about the chunk format — it stores and
+//! retrieves raw bytes. Serialization/deserialization is handled by
+//! the caller (basalt-world).
+
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+/// Magic bytes at the start of every BSR region file.
+const MAGIC: &[u8; 4] = b"BSLT";
+/// Current format version.
+const VERSION: u16 = 1;
+/// Size of the file header in bytes.
+const HEADER_SIZE: u64 = 8;
+/// Number of chunks per region (32×32).
+const CHUNKS_PER_REGION: usize = 1024;
+/// Size of the offset table in bytes.
+const TABLE_SIZE: u64 = (CHUNKS_PER_REGION * 8) as u64;
+
+/// Manages BSR region files on disk.
+///
+/// Region files are stored in a directory with names like `r.0.0.bsr`
+/// where the numbers are region coordinates (chunk coords / 32).
+/// The storage handles LZ4 compression/decompression transparently.
+pub struct RegionStorage {
+    /// Directory containing the region files.
+    directory: PathBuf,
+}
+
+impl RegionStorage {
+    /// Creates a new storage backed by the given directory.
+    ///
+    /// Creates the directory if it doesn't exist.
+    pub fn new(directory: impl Into<PathBuf>) -> io::Result<Self> {
+        let directory = directory.into();
+        fs::create_dir_all(&directory)?;
+        Ok(Self { directory })
+    }
+
+    /// Saves raw chunk data to the appropriate region file.
+    ///
+    /// Compresses with LZ4 before writing. Creates the region file
+    /// if it doesn't exist.
+    pub fn save_raw(&self, chunk_x: i32, chunk_z: i32, data: &[u8]) -> io::Result<()> {
+        let (region_x, region_z) = chunk_to_region(chunk_x, chunk_z);
+        let index = chunk_index_in_region(chunk_x, chunk_z);
+
+        let compressed = lz4_flex::compress_prepend_size(data);
+
+        let path = self.region_path(region_x, region_z);
+        let mut file = self.open_or_create_region(&path)?;
+
+        let mut table = read_offset_table(&mut file)?;
+
+        file.seek(SeekFrom::End(0))?;
+        let offset = file.stream_position()? as u32;
+        file.write_all(&compressed)?;
+
+        table[index] = (offset, compressed.len() as u32);
+        write_offset_table(&mut file, &table)?;
+
+        Ok(())
+    }
+
+    /// Loads raw chunk data from the appropriate region file.
+    ///
+    /// Returns the decompressed bytes, or `None` if the chunk hasn't
+    /// been saved or the region file doesn't exist.
+    pub fn load_raw(&self, chunk_x: i32, chunk_z: i32) -> io::Result<Option<Vec<u8>>> {
+        let (region_x, region_z) = chunk_to_region(chunk_x, chunk_z);
+        let index = chunk_index_in_region(chunk_x, chunk_z);
+
+        let path = self.region_path(region_x, region_z);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let mut file = File::open(&path)?;
+
+        if !verify_header(&mut file)? {
+            return Ok(None);
+        }
+
+        let table = read_offset_table(&mut file)?;
+        let (offset, size) = table[index];
+
+        if offset == 0 && size == 0 {
+            return Ok(None);
+        }
+
+        file.seek(SeekFrom::Start(offset as u64))?;
+        let mut compressed = vec![0u8; size as usize];
+        file.read_exact(&mut compressed)?;
+
+        let raw = lz4_flex::decompress_size_prepended(&compressed)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        Ok(Some(raw))
+    }
+
+    /// Saves multiple chunks in batch, grouped by region.
+    pub fn save_raw_batch(&self, chunks: &[(i32, i32, &[u8])]) -> io::Result<()> {
+        type RegionEntries<'a> = HashMap<(i32, i32), Vec<(usize, &'a [u8])>>;
+        let mut by_region: RegionEntries<'_> = HashMap::new();
+        for &(cx, cz, data) in chunks {
+            let region = chunk_to_region(cx, cz);
+            let index = chunk_index_in_region(cx, cz);
+            by_region.entry(region).or_default().push((index, data));
+        }
+
+        for ((region_x, region_z), entries) in &by_region {
+            let path = self.region_path(*region_x, *region_z);
+            let mut file = self.open_or_create_region(&path)?;
+            let mut table = read_offset_table(&mut file)?;
+
+            for &(index, data) in entries {
+                let compressed = lz4_flex::compress_prepend_size(data);
+                file.seek(SeekFrom::End(0))?;
+                let offset = file.stream_position()? as u32;
+                file.write_all(&compressed)?;
+                table[index] = (offset, compressed.len() as u32);
+            }
+
+            write_offset_table(&mut file, &table)?;
+        }
+
+        Ok(())
+    }
+
+    /// Returns the path for a region file.
+    fn region_path(&self, region_x: i32, region_z: i32) -> PathBuf {
+        self.directory.join(format!("r.{region_x}.{region_z}.bsr"))
+    }
+
+    /// Opens or creates a region file with a valid header and empty table.
+    fn open_or_create_region(&self, path: &Path) -> io::Result<File> {
+        if path.exists() {
+            let mut file = File::options().read(true).write(true).open(path)?;
+            if verify_header(&mut file)? {
+                return Ok(file);
+            }
+        }
+
+        let mut file = File::create(path)?;
+        file.write_all(MAGIC)?;
+        file.write_all(&VERSION.to_le_bytes())?;
+        file.write_all(&[0u8; 2])?;
+        file.write_all(&vec![0u8; TABLE_SIZE as usize])?;
+        file.seek(SeekFrom::Start(0))?;
+
+        File::options().read(true).write(true).open(path)
+    }
+}
+
+/// Converts chunk coordinates to region coordinates.
+fn chunk_to_region(chunk_x: i32, chunk_z: i32) -> (i32, i32) {
+    (chunk_x >> 5, chunk_z >> 5)
+}
+
+/// Returns the index of a chunk within its region (0..1023).
+fn chunk_index_in_region(chunk_x: i32, chunk_z: i32) -> usize {
+    let local_x = chunk_x.rem_euclid(32);
+    let local_z = chunk_z.rem_euclid(32);
+    (local_z * 32 + local_x) as usize
+}
+
+/// Reads the offset table from a region file.
+fn read_offset_table(file: &mut File) -> io::Result<Vec<(u32, u32)>> {
+    file.seek(SeekFrom::Start(HEADER_SIZE))?;
+    let mut buf = vec![0u8; TABLE_SIZE as usize];
+    file.read_exact(&mut buf)?;
+
+    let mut table = Vec::with_capacity(CHUNKS_PER_REGION);
+    for i in 0..CHUNKS_PER_REGION {
+        let offset = u32::from_le_bytes(buf[i * 8..i * 8 + 4].try_into().unwrap());
+        let size = u32::from_le_bytes(buf[i * 8 + 4..i * 8 + 8].try_into().unwrap());
+        table.push((offset, size));
+    }
+    Ok(table)
+}
+
+/// Writes the offset table to a region file.
+fn write_offset_table(file: &mut File, table: &[(u32, u32)]) -> io::Result<()> {
+    file.seek(SeekFrom::Start(HEADER_SIZE))?;
+    let mut buf = Vec::with_capacity(TABLE_SIZE as usize);
+    for &(offset, size) in table {
+        buf.extend_from_slice(&offset.to_le_bytes());
+        buf.extend_from_slice(&size.to_le_bytes());
+    }
+    file.write_all(&buf)?;
+    file.flush()?;
+    Ok(())
+}
+
+/// Verifies the magic bytes and version of a region file.
+fn verify_header(file: &mut File) -> io::Result<bool> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut header = [0u8; 8];
+    if file.read(&mut header)? < 8 {
+        return Ok(false);
+    }
+    Ok(&header[0..4] == MAGIC && u16::from_le_bytes([header[4], header[5]]) == VERSION)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_and_load_raw() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RegionStorage::new(dir.path()).unwrap();
+
+        let data = b"hello chunk data";
+        storage.save_raw(0, 0, data).unwrap();
+
+        let loaded = storage.load_raw(0, 0).unwrap().unwrap();
+        assert_eq!(loaded, data);
+    }
+
+    #[test]
+    fn load_nonexistent_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RegionStorage::new(dir.path()).unwrap();
+        assert!(storage.load_raw(99, 99).unwrap().is_none());
+    }
+
+    #[test]
+    fn multiple_chunks_in_same_region() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RegionStorage::new(dir.path()).unwrap();
+
+        storage.save_raw(0, 0, b"chunk_0_0").unwrap();
+        storage.save_raw(1, 1, b"chunk_1_1").unwrap();
+
+        assert_eq!(storage.load_raw(0, 0).unwrap().unwrap(), b"chunk_0_0");
+        assert_eq!(storage.load_raw(1, 1).unwrap().unwrap(), b"chunk_1_1");
+    }
+
+    #[test]
+    fn negative_coordinates() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RegionStorage::new(dir.path()).unwrap();
+
+        storage.save_raw(-10, -20, b"negative").unwrap();
+        assert_eq!(storage.load_raw(-10, -20).unwrap().unwrap(), b"negative");
+    }
+
+    #[test]
+    fn batch_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RegionStorage::new(dir.path()).unwrap();
+
+        let data: Vec<(i32, i32, &[u8])> = vec![(0, 0, b"a"), (1, 0, b"b"), (2, 0, b"c")];
+        storage.save_raw_batch(&data).unwrap();
+
+        assert_eq!(storage.load_raw(0, 0).unwrap().unwrap(), b"a");
+        assert_eq!(storage.load_raw(1, 0).unwrap().unwrap(), b"b");
+        assert_eq!(storage.load_raw(2, 0).unwrap().unwrap(), b"c");
+    }
+}

--- a/crates/basalt-world/Cargo.toml
+++ b/crates/basalt-world/Cargo.toml
@@ -8,4 +8,8 @@ repository.workspace = true
 [dependencies]
 basalt-types = { workspace = true }
 basalt-protocol = { workspace = true }
+basalt-storage = { workspace = true }
 noise = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/basalt-world/src/chunk.rs
+++ b/crates/basalt-world/src/chunk.rs
@@ -25,7 +25,7 @@ fn build_full_light_mask(count: usize) -> Vec<i64> {
 use crate::palette::PalettedContainer;
 
 /// Number of chunk sections in a standard overworld chunk.
-const SECTIONS_PER_CHUNK: usize = 24;
+pub const SECTIONS_PER_CHUNK: usize = 24;
 
 /// The Y coordinate of the bottom of the world.
 const WORLD_BOTTOM_Y: i32 = -64;
@@ -37,7 +37,8 @@ pub struct ChunkColumn {
     /// Chunk Z coordinate.
     pub z: i32,
     /// The 24 sections from bottom (y=-64) to top (y=319).
-    sections: [PalettedContainer; SECTIONS_PER_CHUNK],
+    /// Boxed to avoid 192KB stack allocation (24 × 8KB per section).
+    pub sections: Box<[PalettedContainer; SECTIONS_PER_CHUNK]>,
 }
 
 impl ChunkColumn {
@@ -46,7 +47,9 @@ impl ChunkColumn {
         Self {
             x,
             z,
-            sections: std::array::from_fn(|_| PalettedContainer::filled(block::AIR)),
+            sections: Box::new(std::array::from_fn(|_| {
+                PalettedContainer::filled(block::AIR)
+            })),
         }
     }
 
@@ -105,7 +108,7 @@ impl ChunkColumn {
     /// Encodes all 24 sections into the wire format.
     fn encode_sections(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        for section in &self.sections {
+        for section in self.sections.iter() {
             // Block count
             section.non_air_count().encode(&mut buf).unwrap();
             // Block states paletted container

--- a/crates/basalt-world/src/format.rs
+++ b/crates/basalt-world/src/format.rs
@@ -1,0 +1,186 @@
+//! BSR (Basalt Region) chunk serialization format.
+//!
+//! Serializes `ChunkColumn` into a compact binary format optimized
+//! for LZ4 compression. Single-value sections (all air, all stone)
+//! are stored as 3 bytes instead of 8KB.
+//!
+//! # Wire format (before compression)
+//!
+//! ```text
+//! section_bitmap: u32          — which sections have data (bit per section)
+//! for each set bit:
+//!   section_type: u8           — 0 = single-value, 1 = paletted
+//!   if single-value:
+//!     block_id: u16            — the single block state (3 bytes total!)
+//!   if paletted:
+//!     block_data: [u16; 4096]  — raw block state IDs (8KB)
+//! ```
+
+use crate::chunk::{ChunkColumn, SECTIONS_PER_CHUNK};
+use crate::palette::PalettedContainer;
+
+/// Section type: all blocks are the same state.
+const SECTION_SINGLE_VALUE: u8 = 0;
+/// Section type: mixed blocks, stored as raw u16 array.
+const SECTION_RAW: u8 = 1;
+
+/// Serializes a `ChunkColumn` into the BSR binary format.
+///
+/// Returns the uncompressed bytes. The caller is responsible for
+/// LZ4 compression before writing to disk.
+pub fn serialize_chunk(chunk: &ChunkColumn) -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    // Section bitmap — which sections have non-air data
+    let mut bitmap: u32 = 0;
+    for (i, section) in chunk.sections.iter().enumerate() {
+        if section.single_value() != Some(crate::block::AIR) {
+            bitmap |= 1 << i;
+        }
+    }
+    buf.extend_from_slice(&bitmap.to_le_bytes());
+
+    // Serialize each present section
+    for (i, section) in chunk.sections.iter().enumerate() {
+        if bitmap & (1 << i) == 0 {
+            continue; // Skip all-air sections
+        }
+
+        if let Some(state) = section.single_value() {
+            // Single-value section: 3 bytes
+            buf.push(SECTION_SINGLE_VALUE);
+            buf.extend_from_slice(&state.to_le_bytes());
+        } else {
+            // Raw section: 1 + 8192 bytes
+            buf.push(SECTION_RAW);
+            for &block in section.blocks() {
+                buf.extend_from_slice(&block.to_le_bytes());
+            }
+        }
+    }
+
+    buf
+}
+
+/// Deserializes a `ChunkColumn` from BSR binary format.
+///
+/// The input should be the uncompressed bytes (after LZ4 decompression).
+pub fn deserialize_chunk(data: &[u8], chunk_x: i32, chunk_z: i32) -> Option<ChunkColumn> {
+    let mut cursor = 0;
+
+    if data.len() < 4 {
+        return None;
+    }
+
+    // Read section bitmap
+    let bitmap = u32::from_le_bytes(data[cursor..cursor + 4].try_into().ok()?);
+    cursor += 4;
+
+    let mut chunk = ChunkColumn::new(chunk_x, chunk_z);
+
+    for i in 0..SECTIONS_PER_CHUNK {
+        if bitmap & (1 << i) == 0 {
+            continue; // Section is all air (already default)
+        }
+
+        if cursor >= data.len() {
+            return None;
+        }
+
+        let section_type = data[cursor];
+        cursor += 1;
+
+        match section_type {
+            SECTION_SINGLE_VALUE => {
+                if cursor + 2 > data.len() {
+                    return None;
+                }
+                let state = u16::from_le_bytes(data[cursor..cursor + 2].try_into().ok()?);
+                cursor += 2;
+                chunk.sections[i] = PalettedContainer::filled(state);
+            }
+            SECTION_RAW => {
+                if cursor + 8192 > data.len() {
+                    return None;
+                }
+                let mut blocks = [0u16; 4096];
+                for (j, block) in blocks.iter_mut().enumerate() {
+                    let offset = cursor + j * 2;
+                    *block = u16::from_le_bytes(data[offset..offset + 2].try_into().ok()?);
+                }
+                cursor += 8192;
+                chunk.sections[i] = PalettedContainer::from_blocks(blocks);
+            }
+            _ => return None, // Unknown section type
+        }
+    }
+
+    Some(chunk)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block;
+
+    #[test]
+    fn empty_chunk_roundtrip() {
+        let chunk = ChunkColumn::new(0, 0);
+        let data = serialize_chunk(&chunk);
+        // All-air chunk: just the bitmap (4 bytes, all zeros)
+        assert_eq!(data.len(), 4);
+        assert_eq!(data, [0, 0, 0, 0]);
+
+        let restored = deserialize_chunk(&data, 0, 0).unwrap();
+        assert_eq!(restored.get_block(0, 0, 0), block::AIR);
+    }
+
+    #[test]
+    fn single_value_section_is_compact() {
+        let mut chunk = ChunkColumn::new(0, 0);
+        // Fill section 0 (y=-64..-48) entirely with stone
+        for x in 0..16 {
+            for z in 0..16 {
+                for y in -64..-48 {
+                    chunk.set_block(x, y, z, block::STONE);
+                }
+            }
+        }
+
+        let data = serialize_chunk(&chunk);
+        // Bitmap (4) + single-value section (1 type + 2 block_id) = 7 bytes
+        assert_eq!(data.len(), 7);
+    }
+
+    #[test]
+    fn mixed_section_roundtrip() {
+        let mut chunk = ChunkColumn::new(3, -5);
+        chunk.set_block(0, -64, 0, block::BEDROCK);
+        chunk.set_block(1, -64, 0, block::STONE);
+        chunk.set_block(8, 64, 8, block::GRASS_BLOCK);
+
+        let data = serialize_chunk(&chunk);
+        let restored = deserialize_chunk(&data, 3, -5).unwrap();
+
+        assert_eq!(restored.get_block(0, -64, 0), block::BEDROCK);
+        assert_eq!(restored.get_block(1, -64, 0), block::STONE);
+        assert_eq!(restored.get_block(8, 64, 8), block::GRASS_BLOCK);
+        assert_eq!(restored.get_block(0, 0, 0), block::AIR);
+    }
+
+    #[test]
+    fn generated_chunk_roundtrip() {
+        let generator = crate::FlatWorldGenerator;
+        let mut chunk = ChunkColumn::new(0, 0);
+        generator.generate(&mut chunk);
+
+        let data = serialize_chunk(&chunk);
+        let restored = deserialize_chunk(&data, 0, 0).unwrap();
+
+        // Verify terrain is identical
+        assert_eq!(restored.get_block(0, -64, 0), block::BEDROCK);
+        assert_eq!(restored.get_block(0, -63, 0), block::DIRT);
+        assert_eq!(restored.get_block(0, -61, 0), block::GRASS_BLOCK);
+        assert_eq!(restored.get_block(0, -60, 0), block::AIR);
+    }
+}

--- a/crates/basalt-world/src/lib.rs
+++ b/crates/basalt-world/src/lib.rs
@@ -2,29 +2,25 @@
 //!
 //! Provides terrain generation, chunk caching, and block storage for
 //! the Minecraft server. The `World` struct is the main entry point —
-//! it lazily generates and caches chunks as they are requested.
-//!
-//! # Architecture
-//!
-//! ```text
-//! World (cache + generator)
-//!   └── ChunkColumn (24 sections)
-//!         └── PalettedContainer (16×16×16 blocks)
-//!               └── Block state IDs
-//! ```
+//! it lazily generates and caches chunks, with optional disk persistence
+//! via `basalt-storage`.
 
 pub mod block;
-mod chunk;
+pub mod chunk;
+pub mod format;
 mod generator;
 mod noise_gen;
-mod palette;
+pub mod palette;
 
 pub use chunk::ChunkColumn;
 pub use generator::FlatWorldGenerator;
 pub use noise_gen::NoiseTerrainGenerator;
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Mutex;
+
+use basalt_storage::RegionStorage;
 
 /// How terrain is generated for new chunks.
 enum Generator {
@@ -34,47 +30,56 @@ enum Generator {
     Noise(Box<NoiseTerrainGenerator>),
 }
 
-/// A Minecraft world with lazy chunk generation and in-memory caching.
+/// A Minecraft world with lazy chunk generation, in-memory caching,
+/// and optional disk persistence.
 ///
-/// Chunks are generated on first access using the configured generator
-/// and stored in a `HashMap` keyed by (chunk_x, chunk_z). All generated
-/// chunks persist in memory for the lifetime of the world.
-///
-/// Thread-safe: the chunk cache is behind a `Mutex` so multiple player
-/// tasks can request chunks concurrently.
+/// Load order: memory cache → disk → generate.
+/// Generated chunks are saved to disk (if storage is configured)
+/// and cached in memory as encoded packets.
 pub struct World {
-    /// Cached encoded packets, keyed by (chunk_x, chunk_z).
-    /// We cache the final packet instead of ChunkColumn to avoid
-    /// re-encoding on every access (palette encoding + heightmap
-    /// computation is expensive).
+    /// Cached encoded packets for fast repeated access.
     packets:
         Mutex<HashMap<(i32, i32), basalt_protocol::packets::play::world::ClientboundPlayMapChunk>>,
     /// The terrain generator used for new chunks.
     generator: Generator,
     /// The Y coordinate where players spawn.
     spawn_y: i32,
+    /// Optional disk storage for chunk persistence.
+    storage: Option<RegionStorage>,
 }
 
 impl World {
-    /// Creates a new world with noise-based terrain generation.
+    /// Creates a new world with noise-based terrain and disk persistence.
     ///
-    /// The seed determines the terrain shape — same seed produces
-    /// the same world every time. No chunks are generated until
-    /// they are requested.
-    pub fn new(seed: u32) -> Self {
+    /// Chunks are saved to `save_dir/regions/` as BSR region files.
+    pub fn new(seed: u32, save_dir: impl Into<PathBuf>) -> Self {
+        let save_path = save_dir.into();
+        let storage = RegionStorage::new(save_path.join("regions")).ok();
         Self {
             packets: Mutex::new(HashMap::new()),
             generator: Generator::Noise(Box::new(NoiseTerrainGenerator::new(seed))),
             spawn_y: NoiseTerrainGenerator::SPAWN_Y,
+            storage,
         }
     }
 
-    /// Creates a new flat world (superflat).
+    /// Creates a new world with noise-based terrain, no persistence.
+    pub fn new_memory(seed: u32) -> Self {
+        Self {
+            packets: Mutex::new(HashMap::new()),
+            generator: Generator::Noise(Box::new(NoiseTerrainGenerator::new(seed))),
+            spawn_y: NoiseTerrainGenerator::SPAWN_Y,
+            storage: None,
+        }
+    }
+
+    /// Creates a new flat world (superflat), no persistence.
     pub fn flat() -> Self {
         Self {
             packets: Mutex::new(HashMap::new()),
             generator: Generator::Flat(FlatWorldGenerator),
             spawn_y: FlatWorldGenerator::SPAWN_Y,
+            storage: None,
         }
     }
 
@@ -85,9 +90,8 @@ impl World {
 
     /// Returns a protocol packet for the chunk at (cx, cz).
     ///
-    /// If the chunk is not yet generated, generates it first and
-    /// stores it in the cache. Subsequent calls for the same
-    /// coordinates return the cached version.
+    /// Load order: memory cache → disk → generate.
+    /// Newly generated chunks are saved to disk and cached in memory.
     pub fn get_chunk_packet(
         &self,
         cx: i32,
@@ -97,22 +101,38 @@ impl World {
         cache
             .entry((cx, cz))
             .or_insert_with(|| {
+                // Try loading from disk first
+                if let Some(storage) = &self.storage
+                    && let Ok(Some(data)) = storage.load_raw(cx, cz)
+                    && let Some(col) = format::deserialize_chunk(&data, cx, cz)
+                {
+                    return col.to_packet();
+                }
+
+                // Generate new chunk
                 let mut col = ChunkColumn::new(cx, cz);
                 match &self.generator {
                     Generator::Flat(g) => g.generate(&mut col),
                     Generator::Noise(g) => g.generate(&mut col),
                 }
+
+                // Save to disk
+                if let Some(storage) = &self.storage {
+                    let data = format::serialize_chunk(&col);
+                    let _ = storage.save_raw(cx, cz, &data);
+                }
+
                 col.to_packet()
             })
             .clone()
     }
 
-    /// Returns true if the chunk at (cx, cz) has been generated.
+    /// Returns true if the chunk at (cx, cz) is in the memory cache.
     pub fn is_chunk_loaded(&self, cx: i32, cz: i32) -> bool {
         self.packets.lock().unwrap().contains_key(&(cx, cz))
     }
 
-    /// Returns the number of chunks currently cached.
+    /// Returns the number of chunks currently in the memory cache.
     pub fn chunk_count(&self) -> usize {
         self.packets.lock().unwrap().len()
     }
@@ -120,7 +140,7 @@ impl World {
 
 impl Default for World {
     fn default() -> Self {
-        Self::new(0)
+        Self::new_memory(0)
     }
 }
 
@@ -130,7 +150,7 @@ mod tests {
 
     #[test]
     fn world_generates_on_first_access() {
-        let world = World::new(42);
+        let world = World::new_memory(42);
         assert!(!world.is_chunk_loaded(0, 0));
 
         let packet = world.get_chunk_packet(0, 0);
@@ -141,15 +161,15 @@ mod tests {
 
     #[test]
     fn world_caches_chunks() {
-        let world = World::new(42);
+        let world = World::new_memory(42);
         world.get_chunk_packet(0, 0);
-        world.get_chunk_packet(0, 0); // should not regenerate
+        world.get_chunk_packet(0, 0);
         assert_eq!(world.chunk_count(), 1);
     }
 
     #[test]
     fn world_generates_different_coords() {
-        let world = World::new(42);
+        let world = World::new_memory(42);
         world.get_chunk_packet(0, 0);
         world.get_chunk_packet(1, 0);
         world.get_chunk_packet(0, 1);
@@ -158,7 +178,23 @@ mod tests {
 
     #[test]
     fn spawn_y_is_above_ground() {
-        let world = World::new(42);
+        let world = World::new_memory(42);
         assert_eq!(world.spawn_y(), NoiseTerrainGenerator::SPAWN_Y as f64);
+    }
+
+    #[test]
+    fn world_with_persistence() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = World::new(42, dir.path());
+
+        // Generate and save
+        world.get_chunk_packet(0, 0);
+        world.get_chunk_packet(1, 1);
+
+        // Create a new world from the same directory — should load from disk
+        let world2 = World::new(42, dir.path());
+        assert!(!world2.is_chunk_loaded(0, 0)); // not in memory yet
+        world2.get_chunk_packet(0, 0); // loads from disk
+        assert!(world2.is_chunk_loaded(0, 0));
     }
 }

--- a/crates/basalt-world/src/palette.rs
+++ b/crates/basalt-world/src/palette.rs
@@ -14,7 +14,7 @@ use basalt_types::{Encode, VarInt};
 ///
 /// Blocks are stored as raw state IDs. The palette is computed
 /// during encoding to determine the optimal bits-per-entry.
-pub(crate) struct PalettedContainer {
+pub struct PalettedContainer {
     /// Block state IDs in XZY order (x varies fastest, then z, then y).
     /// Length must be 4096 (16×16×16).
     blocks: [u16; 4096],
@@ -47,6 +47,31 @@ impl PalettedContainer {
             .iter()
             .filter(|&&state| state != crate::block::AIR)
             .count() as i16
+    }
+
+    /// Returns true if all blocks are the same state (single-value).
+    pub fn is_single_value(&self) -> bool {
+        let first = self.blocks[0];
+        self.blocks.iter().all(|&b| b == first)
+    }
+
+    /// Returns the single block state if this container is homogeneous.
+    pub fn single_value(&self) -> Option<u16> {
+        if self.is_single_value() {
+            Some(self.blocks[0])
+        } else {
+            None
+        }
+    }
+
+    /// Returns a reference to the raw block state array.
+    pub fn blocks(&self) -> &[u16; 4096] {
+        &self.blocks
+    }
+
+    /// Creates a container from a raw block state array.
+    pub fn from_blocks(blocks: [u16; 4096]) -> Self {
+        Self { blocks }
     }
 
     /// Encodes this container into the Minecraft wire format.


### PR DESCRIPTION
## Summary

Introduces basalt-storage for disk persistence and integrates it with basalt-world.

### basalt-storage crate
- BSR region format: 32x32 chunk regions with 8KB offset table for O(1) lookup
- LZ4 compression: 4.4 GB/s decompression, minimal CPU overhead
- Format-agnostic API: save_raw/load_raw work with raw bytes
- Batch save groups chunks by region for efficient disk I/O

### basalt-world integration
- Chunk serialization (format.rs): section bitmap + single-value optimization
- World::new(seed, save_dir) enables persistence, World::new_memory(seed) for tests
- Load order: memory cache then disk then generate
- ChunkColumn.sections boxed to avoid 192KB stack overflow

Closes #73

## Test plan

- [x] cargo test -- all tests pass
- [x] cargo clippy clean
- [x] Coverage >= 90% (90.50%)
- [ ] CI passes
- [ ] Manual test: start server, explore, restart -- chunks load from disk
