### PR TITLE
feat(events): event bus crate with staged handler dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,12 @@
 
 ## Architecture
 
-Six crates in a Cargo workspace under `crates/`, plus an `xtask` codegen tool:
+Eight crates in a Cargo workspace under `crates/`, plus an `xtask` codegen tool:
 
 ```
 basalt-types → basalt-derive → basalt-protocol → basalt-net → basalt-server
                                       ↑                            ↑
-                                   xtask (codegen)           basalt-world
+                                   xtask (codegen)     basalt-events, basalt-world
 ```
 
 | Crate | Purpose | Key dependencies |
@@ -25,16 +25,30 @@ basalt-types → basalt-derive → basalt-protocol → basalt-net → basalt-ser
 | `basalt-derive` | Proc macros for `Encode`/`Decode`/`EncodedSize` | `syn`, `quote`, `proc-macro2` |
 | `basalt-protocol` | Packet definitions, version-aware registry, registry data | `basalt-types`, `basalt-derive` |
 | `basalt-net` | Async networking, encryption, compression, connection typestate, middleware pipeline | `basalt-protocol`, `tokio`, `aes`, `cfb8`, `flate2` |
+| `basalt-events` | Generic event bus with staged handler dispatch (Validate → Process → Post) | none |
 | `basalt-world` | World generation, chunk storage, paletted containers, block state registry | `basalt-types`, `basalt-protocol`, `basalt-storage` |
 | `basalt-storage` | BSR region file format with LZ4 compression for chunk persistence | `lz4_flex` |
-| `basalt-server` | Minecraft server: connection lifecycle, play loop, chat, commands, chunk streaming | `basalt-net`, `basalt-world`, `tokio`, `dashmap`, `reqwest` |
+| `basalt-server` | Minecraft server: connection lifecycle, play loop, chat, commands, chunk streaming | `basalt-net`, `basalt-events`, `basalt-world`, `tokio`, `dashmap`, `reqwest` |
 | `xtask` | Code generation from minecraft-data JSON → Rust packet structs | `serde_json` |
 
 - `basalt-types` and `basalt-derive` have no interdependency.
 - `basalt-protocol` depends on both.
 - `basalt-net` depends on `basalt-protocol`.
-- `basalt-server` depends on `basalt-net` — it is the top-level application crate.
+- `basalt-events` has zero external dependencies — pure Rust event infrastructure.
+- `basalt-server` depends on `basalt-net`, `basalt-events`, and `basalt-world` — it is the top-level application crate.
 - `xtask` is a standalone binary that generates code into `basalt-protocol`.
+
+### basalt-events architecture
+
+The event system provides a generic `EventBus` with three execution stages:
+
+1. **Validate** — read-only checks, can cancel (permissions, anti-cheat, protection plugins)
+2. **Process** — state mutation, one logical owner per event (world changes)
+3. **Post** — side effects, no cancel (broadcasting, persistence, logging)
+
+If any Validate handler cancels an event, Process and Post are skipped entirely. Handlers register for specific event types at specific stages with priority ordering. Type erasure via `TypeId` + `Any::downcast_mut` keeps the crate dependency-free.
+
+Server features are implemented as plugin handlers registered on the event bus. Each plugin can be enabled/disabled via server config — zero overhead for disabled features. This enables composable server profiles: an auth server only registers login + commands, a lobby adds read-only world, a game server enables everything.
 
 ### basalt-server structure
 
@@ -121,6 +135,7 @@ basalt/
 │   ├── basalt-protocol/
 │   ├── basalt-net/
 │   ├── basalt-world/          # World generation, chunk cache, paletted containers
+│   ├── basalt-events/         # Event bus with staged handler dispatch (Validate/Process/Post)
 │   ├── basalt-storage/        # BSR region format, LZ4 compression, disk persistence
 │   └── basalt-server/         # Minecraft server: connection lifecycle, play loop, chat, commands
 ├── minecraft-data/           # Git submodule — PrismarineJS/minecraft-data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "basalt-events"
+version = "0.1.0"
+
+[[package]]
 name = "basalt-net"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ basalt-protocol = { path = "crates/basalt-protocol" }
 basalt-net = { path = "crates/basalt-net" }
 basalt-server = { path = "crates/basalt-server" }
 basalt-world = { path = "crates/basalt-world" }
+basalt-events = { path = "crates/basalt-events" }
 basalt-storage = { path = "crates/basalt-storage" }
 
 # Error handling

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -216,6 +216,20 @@ const world = [
   'world/block',
 ];
 
+const events = [
+  // Cross-module changes within basalt-events.
+  // Example: "feat(events): add async handler support"
+  'events',
+
+  // Event trait and Stage enum definitions.
+  // Example: "feat(events/event): add Monitor stage"
+  'events/event',
+
+  // EventBus: handler registration and staged dispatch.
+  // Example: "perf(events/bus): optimize dispatch with pre-sorted entries"
+  'events/bus',
+];
+
 const storage = [
   // Cross-module changes within basalt-storage.
   // Example: "feat(storage): add player data persistence"
@@ -286,7 +300,7 @@ const keywords = [
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...storage, ...keywords]],
+    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...storage, ...keywords]],
     'scope-empty': [2, 'never'],
   },
 };

--- a/crates/basalt-events/Cargo.toml
+++ b/crates/basalt-events/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "basalt-events"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+# No external dependencies — pure Rust event infrastructure.

--- a/crates/basalt-events/src/bus.rs
+++ b/crates/basalt-events/src/bus.rs
@@ -1,0 +1,447 @@
+//! Generic event bus with staged handler dispatch.
+//!
+//! The [`EventBus`] stores handlers indexed by event `TypeId` and
+//! sorted by `(Stage, priority)`. Registration is typed — handlers
+//! receive concrete event and context references. Dispatch is a
+//! single linear pass through pre-sorted handlers, with short-circuit
+//! on cancellation after the Validate stage.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+use crate::event::{Event, Stage};
+
+/// A type-erased handler function stored in the bus.
+///
+/// Takes the event as `&mut dyn Event` and context as `&dyn Any`.
+/// The concrete types are recovered via `downcast_mut`/`downcast_ref`
+/// inside the wrapper closure created by `on()`.
+type ErasedHandler = Box<dyn Fn(&mut dyn Event, &dyn Any) + Send + Sync>;
+
+/// A registered handler with its stage and priority.
+struct HandlerEntry {
+    /// Which stage this handler runs in.
+    stage: Stage,
+    /// Priority within the stage. Lower values run first.
+    priority: i32,
+    /// The type-erased handler function.
+    handler: ErasedHandler,
+}
+
+/// Generic event bus that dispatches events through staged handlers.
+///
+/// Handlers register for specific event types at specific stages.
+/// During dispatch, handlers run in `(Stage, priority)` order.
+/// If any Validate handler cancels the event, Process and Post
+/// handlers are skipped.
+///
+/// The bus is `Send + Sync` and can be shared via `Arc` across
+/// connection tasks. Registration happens at startup; dispatch
+/// happens per-task.
+pub struct EventBus {
+    /// Handlers indexed by the `TypeId` of the concrete event type.
+    /// Each entry list is pre-sorted by `(Stage, priority)`.
+    handlers: HashMap<TypeId, Vec<HandlerEntry>>,
+}
+
+impl EventBus {
+    /// Creates an empty event bus with no registered handlers.
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Registers a handler for a specific event type at a given stage.
+    ///
+    /// The handler receives a mutable reference to the concrete event
+    /// and a shared reference to the context. Lower priority values
+    /// run first within the same stage.
+    ///
+    /// Both `E` (event) and `C` (context) must be `'static` for
+    /// type erasure via `Any`. The handler closure must be `Send +
+    /// Sync` since the bus is shared across connection tasks.
+    pub fn on<E, C>(
+        &mut self,
+        stage: Stage,
+        priority: i32,
+        handler: impl Fn(&mut E, &C) + Send + Sync + 'static,
+    ) where
+        E: Event + 'static,
+        C: 'static,
+    {
+        let type_id = TypeId::of::<E>();
+        let erased: ErasedHandler = Box::new(move |event, ctx_any| {
+            let concrete_event = event.as_any_mut().downcast_mut::<E>().unwrap();
+            let concrete_ctx = ctx_any.downcast_ref::<C>().unwrap();
+            handler(concrete_event, concrete_ctx);
+        });
+
+        let entries = self.handlers.entry(type_id).or_default();
+        entries.push(HandlerEntry {
+            stage,
+            priority,
+            handler: erased,
+        });
+        // Keep entries sorted by (stage, priority) for linear dispatch
+        entries.sort_by_key(|e| (e.stage, e.priority));
+    }
+
+    /// Dispatches a concrete event through all registered handlers.
+    ///
+    /// Runs handlers in `(Stage, priority)` order. If the event is
+    /// cancelled during Validate, Process and Post are skipped.
+    pub fn dispatch<E, C>(&self, event: &mut E, ctx: &C)
+    where
+        E: Event + 'static,
+        C: 'static,
+    {
+        let type_id = TypeId::of::<E>();
+        let Some(entries) = self.handlers.get(&type_id) else {
+            return;
+        };
+
+        for entry in entries {
+            if event.is_cancelled() && entry.stage != Stage::Validate {
+                return;
+            }
+            (entry.handler)(event, ctx);
+        }
+    }
+
+    /// Dispatches a type-erased event using its runtime `TypeId`.
+    ///
+    /// Used when the concrete event type is not known at the call
+    /// site (e.g., `Box<dyn Event>` from `packet_to_event`).
+    pub fn dispatch_dyn<C: 'static>(&self, event: &mut dyn Event, ctx: &C) {
+        let type_id = event.as_any().type_id();
+        let Some(entries) = self.handlers.get(&type_id) else {
+            return;
+        };
+
+        for entry in entries {
+            if event.is_cancelled() && entry.stage != Stage::Validate {
+                return;
+            }
+            (entry.handler)(event, ctx);
+        }
+    }
+
+    /// Returns the number of event types that have registered handlers.
+    pub fn event_type_count(&self) -> usize {
+        self.handlers.len()
+    }
+
+    /// Returns the total number of registered handler entries.
+    pub fn handler_count(&self) -> usize {
+        self.handlers.values().map(|v| v.len()).sum()
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Test event types --
+
+    struct CounterEvent {
+        value: i32,
+        cancelled: bool,
+    }
+
+    impl Event for CounterEvent {
+        fn is_cancelled(&self) -> bool {
+            self.cancelled
+        }
+        fn cancel(&mut self) {
+            self.cancelled = true;
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    struct OtherEvent {
+        tag: String,
+    }
+
+    impl Event for OtherEvent {
+        fn is_cancelled(&self) -> bool {
+            false
+        }
+        fn cancel(&mut self) {}
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    // -- Tests --
+
+    #[test]
+    fn empty_bus_dispatch_does_nothing() {
+        let bus = EventBus::new();
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch(&mut event, &());
+        assert_eq!(event.value, 0);
+    }
+
+    #[test]
+    fn single_handler_modifies_event() {
+        let mut bus = EventBus::new();
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value += 10;
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch(&mut event, &());
+        assert_eq!(event.value, 10);
+    }
+
+    #[test]
+    fn handlers_run_in_stage_order() {
+        let mut bus = EventBus::new();
+
+        // Register in reverse order to verify sorting
+        bus.on::<CounterEvent, ()>(Stage::Post, 0, |event, _| {
+            event.value += 1000;
+        });
+        bus.on::<CounterEvent, ()>(Stage::Validate, 0, |event, _| {
+            event.value += 1;
+        });
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            // Verify Validate already ran
+            assert_eq!(event.value, 1);
+            event.value += 100;
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch(&mut event, &());
+        assert_eq!(event.value, 1101);
+    }
+
+    #[test]
+    fn priority_within_stage() {
+        let mut bus = EventBus::new();
+
+        // Higher priority (lower number) runs first
+        bus.on::<CounterEvent, ()>(Stage::Process, 10, |event, _| {
+            event.value *= 2;
+        });
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value += 5;
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch(&mut event, &());
+        // Priority 0 runs first: 0 + 5 = 5
+        // Priority 10 runs second: 5 * 2 = 10
+        assert_eq!(event.value, 10);
+    }
+
+    #[test]
+    fn validate_cancellation_skips_process_and_post() {
+        let mut bus = EventBus::new();
+
+        bus.on::<CounterEvent, ()>(Stage::Validate, 0, |event, _| {
+            event.cancel();
+        });
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value = 999; // should NOT run
+        });
+        bus.on::<CounterEvent, ()>(Stage::Post, 0, |event, _| {
+            event.value = 888; // should NOT run
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch(&mut event, &());
+
+        assert!(event.is_cancelled());
+        assert_eq!(event.value, 0);
+    }
+
+    #[test]
+    fn cancelled_event_still_runs_remaining_validate_handlers() {
+        let mut bus = EventBus::new();
+
+        bus.on::<CounterEvent, ()>(Stage::Validate, 0, |event, _| {
+            event.cancel();
+        });
+        bus.on::<CounterEvent, ()>(Stage::Validate, 10, |event, _| {
+            // This Validate handler still runs even though cancelled
+            event.value += 1;
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch(&mut event, &());
+        assert!(event.is_cancelled());
+        assert_eq!(event.value, 1);
+    }
+
+    #[test]
+    fn different_event_types_are_independent() {
+        let mut bus = EventBus::new();
+
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value += 1;
+        });
+        bus.on::<OtherEvent, ()>(Stage::Process, 0, |event, _| {
+            event.tag = "modified".into();
+        });
+
+        let mut counter = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        let mut other = OtherEvent {
+            tag: "original".into(),
+        };
+
+        bus.dispatch(&mut counter, &());
+        bus.dispatch(&mut other, &());
+
+        assert_eq!(counter.value, 1);
+        assert_eq!(other.tag, "modified");
+    }
+
+    #[test]
+    fn dispatch_dyn_works() {
+        let mut bus = EventBus::new();
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value += 42;
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        // Use dispatch_dyn with &mut dyn Event
+        bus.dispatch_dyn(&mut event as &mut dyn Event, &());
+        assert_eq!(event.value, 42);
+    }
+
+    #[test]
+    fn dispatch_dyn_respects_cancellation() {
+        let mut bus = EventBus::new();
+        bus.on::<CounterEvent, ()>(Stage::Validate, 0, |event, _| {
+            event.cancel();
+        });
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value = 999;
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch_dyn(&mut event as &mut dyn Event, &());
+        assert!(event.is_cancelled());
+        assert_eq!(event.value, 0);
+    }
+
+    #[test]
+    fn context_is_passed_to_handlers() {
+        struct Ctx {
+            multiplier: i32,
+        }
+
+        let mut bus = EventBus::new();
+        bus.on::<CounterEvent, Ctx>(Stage::Process, 0, |event, ctx| {
+            event.value *= ctx.multiplier;
+        });
+
+        let mut event = CounterEvent {
+            value: 5,
+            cancelled: false,
+        };
+        let ctx = Ctx { multiplier: 3 };
+        bus.dispatch(&mut event, &ctx);
+        assert_eq!(event.value, 15);
+    }
+
+    #[test]
+    fn event_type_count_and_handler_count() {
+        let mut bus = EventBus::new();
+        assert_eq!(bus.event_type_count(), 0);
+        assert_eq!(bus.handler_count(), 0);
+
+        bus.on::<CounterEvent, ()>(Stage::Validate, 0, |_, _| {});
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |_, _| {});
+        bus.on::<OtherEvent, ()>(Stage::Post, 0, |_, _| {});
+
+        assert_eq!(bus.event_type_count(), 2);
+        assert_eq!(bus.handler_count(), 3);
+    }
+
+    #[test]
+    fn multiple_handlers_same_stage_same_priority() {
+        let mut bus = EventBus::new();
+
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value += 1;
+        });
+        bus.on::<CounterEvent, ()>(Stage::Process, 0, |event, _| {
+            event.value += 1;
+        });
+
+        let mut event = CounterEvent {
+            value: 0,
+            cancelled: false,
+        };
+        bus.dispatch(&mut event, &());
+        assert_eq!(event.value, 2);
+    }
+
+    #[test]
+    fn non_cancellable_event_ignores_cancel() {
+        let mut bus = EventBus::new();
+        bus.on::<OtherEvent, ()>(Stage::Validate, 0, |event, _| {
+            event.cancel(); // no-op for OtherEvent
+        });
+        bus.on::<OtherEvent, ()>(Stage::Process, 0, |event, _| {
+            event.tag = "processed".into();
+        });
+
+        let mut event = OtherEvent {
+            tag: "original".into(),
+        };
+        bus.dispatch(&mut event, &());
+        // Process should have run because cancel() was a no-op
+        assert_eq!(event.tag, "processed");
+    }
+
+    #[test]
+    fn default_creates_empty_bus() {
+        let bus = EventBus::default();
+        assert_eq!(bus.event_type_count(), 0);
+    }
+}

--- a/crates/basalt-events/src/event.rs
+++ b/crates/basalt-events/src/event.rs
@@ -1,0 +1,109 @@
+//! Event trait and execution stages.
+//!
+//! Events are typed structs carrying game data (positions, UUIDs,
+//! block states) and a cancellation flag. The `Event` trait provides
+//! type erasure via `Any` so the [`EventBus`](crate::EventBus) can
+//! store handlers for different event types in a single registry.
+
+use std::any::Any;
+
+/// Execution stage for event handlers.
+///
+/// Handlers run in stage order: Validate → Process → Post.
+/// If any Validate handler cancels the event, Process and Post
+/// are skipped entirely.
+///
+/// - **Validate**: read-only checks, can cancel (permissions, anti-cheat)
+/// - **Process**: state mutation, one logical owner (world changes)
+/// - **Post**: side effects, never cancels (broadcast, storage, logging)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Stage {
+    /// Validation stage: read-only, can cancel. Runs first.
+    Validate,
+    /// Processing stage: mutates state. Runs second.
+    Process,
+    /// Post-processing stage: side effects. Runs last.
+    Post,
+}
+
+/// Trait implemented by all game events.
+///
+/// Events carry domain data and support cancellation. The `as_any`
+/// methods enable type erasure inside the `EventBus` — handlers
+/// register for concrete types via `TypeId`, and the bus downcasts
+/// during dispatch.
+///
+/// Not all events are cancellable. For non-cancellable events
+/// (e.g., `PlayerJoinedEvent`), `cancel()` is a no-op and
+/// `is_cancelled()` always returns `false`.
+pub trait Event: Any + Send {
+    /// Whether this event has been cancelled by a Validate handler.
+    fn is_cancelled(&self) -> bool;
+
+    /// Cancels this event. Process and Post handlers will be skipped.
+    ///
+    /// Only meaningful during the Validate stage. Non-cancellable
+    /// events ignore this call.
+    fn cancel(&mut self);
+
+    /// Upcasts to `&dyn Any` for type-erased dispatch.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Upcasts to `&mut dyn Any` for mutable type-erased dispatch.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestEvent {
+        value: i32,
+        cancelled: bool,
+    }
+
+    impl Event for TestEvent {
+        fn is_cancelled(&self) -> bool {
+            self.cancelled
+        }
+        fn cancel(&mut self) {
+            self.cancelled = true;
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn event_cancellation() {
+        let mut event = TestEvent {
+            value: 42,
+            cancelled: false,
+        };
+        assert!(!event.is_cancelled());
+        event.cancel();
+        assert!(event.is_cancelled());
+        assert_eq!(event.value, 42);
+    }
+
+    #[test]
+    fn event_downcast() {
+        let mut event = TestEvent {
+            value: 99,
+            cancelled: false,
+        };
+        let any = event.as_any_mut();
+        let concrete = any.downcast_mut::<TestEvent>().unwrap();
+        concrete.value = 100;
+        assert_eq!(event.value, 100);
+    }
+
+    #[test]
+    fn stage_ordering() {
+        assert!(Stage::Validate < Stage::Process);
+        assert!(Stage::Process < Stage::Post);
+    }
+}

--- a/crates/basalt-events/src/lib.rs
+++ b/crates/basalt-events/src/lib.rs
@@ -1,0 +1,28 @@
+//! Basalt event system with staged handler dispatch.
+//!
+//! Provides a generic [`EventBus`] that dispatches typed events
+//! through prioritized handlers organized in three execution stages:
+//!
+//! 1. **Validate** — read-only checks, can cancel (permissions, anti-cheat)
+//! 2. **Process** — state mutation (world changes, inventory updates)
+//! 3. **Post** — side effects (broadcasting, persistence, logging)
+//!
+//! If any Validate handler cancels an event, Process and Post are
+//! skipped entirely. This enables permission and protection plugins
+//! without modifying game logic.
+//!
+//! # Design
+//!
+//! - **Sync handlers**: all handlers are synchronous. Async work is
+//!   deferred through a response queue in the caller.
+//! - **Type erasure**: handlers register for concrete event types via
+//!   `TypeId`. The bus downcasts during dispatch.
+//! - **Zero dependencies**: this crate has no external dependencies.
+//! - **Generic context**: handlers receive a context reference that
+//!   the caller defines (e.g., `EventContext` in `basalt-server`).
+
+mod bus;
+mod event;
+
+pub use bus::EventBus;
+pub use event::{Event, Stage};


### PR DESCRIPTION
## Summary

- New `basalt-events` crate providing a generic `EventBus` with three execution stages: Validate, Process, Post
- `Event` trait with cancellation support and `Any`-based type erasure
- Typed handler registration via `on::<E, C>()` with stage and priority ordering
- `dispatch()` for concrete types and `dispatch_dyn()` for type-erased `Box<dyn Event>`
- Handlers pre-sorted by `(Stage, priority)` at insertion — dispatch is a single linear pass
- Zero external dependencies — pure Rust infrastructure
- Added `events`, `events/event`, `events/bus` scopes to commitlint

Closes #77

## Test plan

- [x] 17 unit tests covering all core behaviors
- [x] Cancellation: Validate cancel skips Process and Post
- [x] Cancelled events still run remaining Validate handlers
- [x] Non-cancellable events ignore cancel() calls
- [x] Stage ordering: Validate < Process < Post
- [x] Priority ordering within stages
- [x] Different event types are independent
- [x] dispatch_dyn works and respects cancellation
- [x] Context is passed through to handlers
- [x] 90.58% overall coverage maintained
