### PR TITLE
feat(server): add StorageHandler plugin for chunk persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -20,3 +20,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = "3"

--- a/crates/basalt-server/src/handlers/mod.rs
+++ b/crates/basalt-server/src/handlers/mod.rs
@@ -9,12 +9,14 @@ mod block;
 mod chat;
 mod lifecycle;
 mod movement;
+mod storage;
 mod world;
 
 pub use block::BlockInteractionHandler;
 pub use chat::ChatHandler;
 pub use lifecycle::LifecycleHandler;
 pub use movement::PlayerInputHandler;
+pub use storage::StorageHandler;
 pub use world::WorldHandler;
 
 use basalt_events::EventBus;
@@ -30,4 +32,5 @@ pub fn register_all(bus: &mut EventBus) {
     PlayerInputHandler::register(bus);
     WorldHandler::register(bus);
     BlockInteractionHandler::register(bus);
+    StorageHandler::register(bus);
 }

--- a/crates/basalt-server/src/handlers/storage.rs
+++ b/crates/basalt-server/src/handlers/storage.rs
@@ -1,0 +1,105 @@
+//! Storage handler plugin.
+//!
+//! Persists modified chunks to disk after block changes. When this
+//! plugin is disabled, block changes exist only in memory and are
+//! lost on server restart — useful for lobby servers with read-only
+//! worlds.
+
+use basalt_events::{EventBus, Stage};
+
+use crate::context::EventContext;
+use crate::events::{BlockBrokenEvent, BlockPlacedEvent};
+
+/// Persists chunks to disk after block modifications.
+///
+/// - **Post BlockBrokenEvent**: persists the affected chunk
+/// - **Post BlockPlacedEvent**: persists the affected chunk
+///
+/// Disabling this handler means no disk I/O on block changes.
+pub struct StorageHandler;
+
+impl StorageHandler {
+    /// Registers storage handlers on the event bus.
+    pub fn register(bus: &mut EventBus) {
+        bus.on::<BlockBrokenEvent, EventContext>(Stage::Post, 10, |event, ctx| {
+            let cx = event.x >> 4;
+            let cz = event.z >> 4;
+            ctx.state.world.persist_chunk(cx, cz);
+        });
+
+        bus.on::<BlockPlacedEvent, EventContext>(Stage::Post, 10, |event, ctx| {
+            let cx = event.x >> 4;
+            let cz = event.z >> 4;
+            ctx.state.world.persist_chunk(cx, cz);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use basalt_types::Uuid;
+
+    use super::*;
+    use crate::handlers::BlockInteractionHandler;
+    use crate::state::ServerState;
+
+    #[test]
+    fn block_change_persists_with_storage_handler() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Create a server state with disk persistence
+        let state = ServerState::new_with_world(basalt_world::World::new(42, dir.path()));
+        let ctx = EventContext::new(Arc::clone(&state));
+
+        let mut event = BlockPlacedEvent {
+            x: 5,
+            y: 100,
+            z: 3,
+            block_state: basalt_world::block::STONE,
+            sequence: 1,
+            player_uuid: Uuid::default(),
+            cancelled: false,
+        };
+
+        let mut bus = EventBus::new();
+        BlockInteractionHandler::register(&mut bus);
+        StorageHandler::register(&mut bus);
+        bus.dispatch(&mut event, &ctx);
+
+        // Verify it was persisted — load from a fresh world
+        let world2 = basalt_world::World::new(42, dir.path());
+        assert_eq!(world2.get_block(5, 100, 3), basalt_world::block::STONE);
+    }
+
+    #[test]
+    fn block_change_without_storage_handler_is_memory_only() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let state = ServerState::new_with_world(basalt_world::World::new(42, dir.path()));
+        let ctx = EventContext::new(Arc::clone(&state));
+
+        let mut event = BlockPlacedEvent {
+            x: 5,
+            y: 100,
+            z: 3,
+            block_state: basalt_world::block::STONE,
+            sequence: 1,
+            player_uuid: Uuid::default(),
+            cancelled: false,
+        };
+
+        // Only BlockInteractionHandler, no StorageHandler
+        let mut bus = EventBus::new();
+        BlockInteractionHandler::register(&mut bus);
+        bus.dispatch(&mut event, &ctx);
+
+        // Block is in memory
+        assert_eq!(state.world.get_block(5, 100, 3), basalt_world::block::STONE);
+
+        // But NOT on disk
+        let world2 = basalt_world::World::new(42, dir.path());
+        assert_ne!(world2.get_block(5, 100, 3), basalt_world::block::STONE);
+    }
+}

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -145,6 +145,24 @@ impl ServerState {
         })
     }
 
+    /// Creates a server state with a custom world instance.
+    ///
+    /// Used in tests to provide a world with specific configuration
+    /// (e.g., disk persistence for storage handler tests).
+    #[cfg(test)]
+    pub fn new_with_world(world: basalt_world::World) -> Arc<Self> {
+        let (broadcast_tx, _) = broadcast::channel(256);
+        let mut event_bus = EventBus::new();
+        crate::handlers::register_all(&mut event_bus);
+        Arc::new(Self {
+            next_entity_id: AtomicI32::new(1),
+            players: DashMap::new(),
+            broadcast_tx,
+            world,
+            event_bus,
+        })
+    }
+
     /// Allocates a unique entity ID for a new player.
     pub fn next_entity_id(&self) -> i32 {
         self.next_entity_id.fetch_add(1, Ordering::Relaxed)

--- a/crates/basalt-world/src/lib.rs
+++ b/crates/basalt-world/src/lib.rs
@@ -186,8 +186,8 @@ impl World {
     ///
     /// Loads the chunk if it isn't already in memory. Invalidates the
     /// packet cache for the affected chunk so the next `get_chunk_packet`
-    /// call re-encodes it. Persists the modified chunk to disk if
-    /// storage is configured.
+    /// call re-encodes it. Does NOT persist to disk — call
+    /// `persist_chunk()` separately (the `StorageHandler` does this).
     pub fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
         let cx = x >> 4;
         let cz = z >> 4;
@@ -205,10 +205,19 @@ impl World {
 
         // Invalidate cached packet
         store.packets.remove(&(cx, cz));
+    }
 
-        // Persist to disk
-        if let Some(s) = &self.storage {
-            let data = format::serialize_chunk(&store.chunks[&(cx, cz)]);
+    /// Persists a chunk to disk via the storage backend.
+    ///
+    /// Serializes the chunk at (cx, cz) and writes it to the BSR
+    /// region file. No-op if storage is not configured or the chunk
+    /// is not loaded. Called by the `StorageHandler` after block changes.
+    pub fn persist_chunk(&self, cx: i32, cz: i32) {
+        let store = self.store.lock().unwrap();
+        if let Some(s) = &self.storage
+            && let Some(chunk) = store.chunks.get(&(cx, cz))
+        {
+            let data = format::serialize_chunk(chunk);
             let _ = s.save_raw(cx, cz, &data);
         }
     }
@@ -344,13 +353,26 @@ mod tests {
     }
 
     #[test]
-    fn set_block_persists_to_disk() {
+    fn persist_chunk_writes_to_disk() {
         let dir = tempfile::tempdir().unwrap();
         let world = World::new(42, dir.path());
         world.set_block(0, 100, 0, block::STONE);
+        world.persist_chunk(0, 0);
 
         // Load from fresh world — should read from disk
         let world2 = World::new(42, dir.path());
         assert_eq!(world2.get_block(0, 100, 0), block::STONE);
+    }
+
+    #[test]
+    fn set_block_without_persist_is_memory_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = World::new(42, dir.path());
+        world.set_block(0, 100, 0, block::STONE);
+        // No persist_chunk call
+
+        // Fresh world should NOT see the change
+        let world2 = World::new(42, dir.path());
+        assert_ne!(world2.get_block(0, 100, 0), block::STONE);
     }
 }


### PR DESCRIPTION
## Summary

- Separate `World::set_block()` from disk persistence: mutation is now memory-only, new `persist_chunk(cx, cz)` method for explicit disk writes
- New `StorageHandler` plugin that persists modified chunks in the Post stage of `BlockBrokenEvent` and `BlockPlacedEvent`
- Disabling StorageHandler = zero disk I/O on block changes (lobby/auth server profile)
- Test proves the architecture: with StorageHandler, changes survive restart; without it, they're memory-only

## Test plan

- [x] `persist_chunk_writes_to_disk`: set_block + persist → fresh world reads it
- [x] `set_block_without_persist_is_memory_only`: set_block alone → fresh world doesn't see it
- [x] `block_change_persists_with_storage_handler`: full pipeline with both handlers → disk write verified
- [x] `block_change_without_storage_handler_is_memory_only`: only BlockInteractionHandler → no disk write
- [x] All 72 server tests + 43 world tests passing
- [x] 91.43% coverage
