### PR TITLE
feat(api): public plugin API crate with ServerContext and Plugin trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "basalt-api"
+version = "0.1.0"
+dependencies = [
+ "basalt-events",
+ "basalt-types",
+ "basalt-world",
+]
+
+[[package]]
 name = "basalt-derive"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ basalt-protocol = { path = "crates/basalt-protocol" }
 basalt-net = { path = "crates/basalt-net" }
 basalt-server = { path = "crates/basalt-server" }
 basalt-world = { path = "crates/basalt-world" }
+basalt-api = { path = "crates/basalt-api" }
 basalt-events = { path = "crates/basalt-events" }
 basalt-storage = { path = "crates/basalt-storage" }
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -230,6 +230,28 @@ const events = [
   'events/bus',
 ];
 
+const api = [
+  // Cross-module changes within basalt-api.
+  // Example: "feat(api): add raw packet escape hatch"
+  'api',
+
+  // Plugin trait, PluginMetadata, EventRegistrar.
+  // Example: "feat(api/plugin): add on_tick lifecycle hook"
+  'api/plugin',
+
+  // ServerContext: public handler context with high-level methods.
+  // Example: "feat(api/context): add send_title method"
+  'api/context',
+
+  // Concrete game events dispatched through the event bus.
+  // Example: "feat(api/events): add EntityDamagedEvent"
+  'api/events',
+
+  // BroadcastMessage, PlayerSnapshot, ProfileProperty.
+  // Example: "feat(api/broadcast): add TitleMessage variant"
+  'api/broadcast',
+];
+
 const storage = [
   // Cross-module changes within basalt-storage.
   // Example: "feat(storage): add player data persistence"
@@ -300,7 +322,7 @@ const keywords = [
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...storage, ...keywords]],
+    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...api, ...storage, ...keywords]],
     'scope-empty': [2, 'never'],
   },
 };

--- a/crates/basalt-api/Cargo.toml
+++ b/crates/basalt-api/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "basalt-api"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+basalt-events = { workspace = true }
+basalt-types = { workspace = true }
+basalt-world = { workspace = true }

--- a/crates/basalt-api/src/broadcast.rs
+++ b/crates/basalt-api/src/broadcast.rs
@@ -1,0 +1,106 @@
+//! Broadcast message types for cross-player communication.
+//!
+//! [`BroadcastMessage`] is the typed message sent through the server's
+//! broadcast channel. Each connected player's play loop receives every
+//! message and decides what to do with it (send packets, filter self).
+
+use basalt_types::Uuid;
+use basalt_types::nbt::NbtCompound;
+
+/// A profile property from the Mojang API (typically skin textures).
+///
+/// Sent in the `PlayerInfo` packet's add_player action as part of the
+/// game profile. The client uses the `textures` property to download
+/// and render the player's skin.
+#[derive(Debug, Clone)]
+pub struct ProfileProperty {
+    /// Property name (always "textures" for skins).
+    pub name: String,
+    /// Base64-encoded JSON containing the skin/cape URLs.
+    pub value: String,
+    /// Mojang signature for the property (base64-encoded).
+    pub signature: Option<String>,
+}
+
+/// A snapshot of a player's state at a point in time.
+///
+/// Used in broadcast messages and events to share a player's position
+/// and identity without holding locks on the player registry.
+#[derive(Debug, Clone)]
+pub struct PlayerSnapshot {
+    /// The player's display name.
+    pub username: String,
+    /// The player's UUID.
+    pub uuid: Uuid,
+    /// The player's unique entity ID.
+    pub entity_id: i32,
+    /// Current X coordinate.
+    pub x: f64,
+    /// Current Y coordinate.
+    pub y: f64,
+    /// Current Z coordinate.
+    pub z: f64,
+    /// Current yaw (horizontal look angle, degrees).
+    pub yaw: f32,
+    /// Current pitch (vertical look angle, degrees).
+    pub pitch: f32,
+    /// Mojang profile properties (skin textures).
+    pub skin_properties: Vec<ProfileProperty>,
+}
+
+/// A message broadcast from one player's task to all others.
+///
+/// Sent through the `broadcast::Sender` and received by each player's
+/// `broadcast::Receiver` in their play loop. Plugins use
+/// [`ServerContext::broadcast`](crate::ServerContext::broadcast) to
+/// send these.
+#[derive(Debug, Clone)]
+pub enum BroadcastMessage {
+    /// A chat message to display in all players' chat windows.
+    Chat {
+        /// The formatted text component as NBT.
+        content: NbtCompound,
+    },
+    /// A new player has joined the server.
+    PlayerJoined {
+        /// Snapshot of the joining player's state.
+        info: PlayerSnapshot,
+    },
+    /// A player has left the server.
+    PlayerLeft {
+        /// The leaving player's UUID (for PlayerRemove packet).
+        uuid: Uuid,
+        /// The leaving player's entity ID (for EntityDestroy packet).
+        entity_id: i32,
+        /// The leaving player's username (for chat message).
+        username: String,
+    },
+    /// A player moved or changed look direction.
+    EntityMoved {
+        /// The moving player's entity ID.
+        entity_id: i32,
+        /// New absolute X coordinate.
+        x: f64,
+        /// New absolute Y coordinate.
+        y: f64,
+        /// New absolute Z coordinate.
+        z: f64,
+        /// New yaw angle (degrees).
+        yaw: f32,
+        /// New pitch angle (degrees).
+        pitch: f32,
+        /// Whether the player is on the ground.
+        on_ground: bool,
+    },
+    /// A block was modified in the world.
+    BlockChanged {
+        /// Block X coordinate (absolute world coordinates).
+        x: i32,
+        /// Block Y coordinate (absolute world coordinates).
+        y: i32,
+        /// Block Z coordinate (absolute world coordinates).
+        z: i32,
+        /// The new block state ID.
+        block_state: i32,
+    },
+}

--- a/crates/basalt-api/src/context.rs
+++ b/crates/basalt-api/src/context.rs
@@ -1,0 +1,418 @@
+//! Event dispatch context and response queue.
+//!
+//! The [`ServerContext`] is the public API surface for event handlers.
+//! It provides high-level methods for game actions (sending messages,
+//! teleporting, broadcasting) and player identity. All methods queue
+//! deferred responses that the server's play loop executes after
+//! event dispatch completes.
+//!
+//! The [`Response`] enum and [`ResponseQueue`] are implementation
+//! details — plugins interact only through `ServerContext` methods.
+
+use std::cell::RefCell;
+
+use basalt_types::nbt::NbtCompound;
+use basalt_types::{TextComponent, Uuid};
+
+use crate::broadcast::BroadcastMessage;
+
+/// Context available to event handlers during dispatch.
+///
+/// Provides high-level methods for game actions and player identity.
+/// Created per-dispatch on the stack. Handlers receive `&ServerContext`
+/// (shared reference) and queue responses via the interior-mutable
+/// response queue.
+///
+/// # Player identity
+///
+/// `player_uuid`, `player_entity_id`, and `player_username` identify
+/// the player who triggered the event. These are copied from the
+/// player's state at dispatch time.
+pub struct ServerContext {
+    /// Shared world reference for block access and chunk persistence.
+    world: &'static basalt_world::World,
+    /// Queue for deferred async responses.
+    responses: ResponseQueue,
+    /// UUID of the player who triggered this event.
+    player_uuid: Uuid,
+    /// Entity ID of the player who triggered this event.
+    player_entity_id: i32,
+    /// Username of the player who triggered this event.
+    player_username: String,
+}
+
+impl ServerContext {
+    /// Creates a new context for a single event dispatch.
+    ///
+    /// Called internally by the play loop and connection handler.
+    /// Not intended for plugin use — plugins receive `&ServerContext`.
+    ///
+    /// # Safety
+    ///
+    /// The `world` reference must outlive the context. In practice,
+    /// the world lives in `Arc<ServerState>` which outlives all
+    /// connection tasks.
+    pub fn new(
+        world: &'static basalt_world::World,
+        player_uuid: Uuid,
+        player_entity_id: i32,
+        player_username: String,
+    ) -> Self {
+        Self {
+            world,
+            responses: ResponseQueue::new(),
+            player_uuid,
+            player_entity_id,
+            player_username,
+        }
+    }
+
+    // --- Player identity ---
+
+    /// Returns the UUID of the player who triggered this event.
+    pub fn player_uuid(&self) -> Uuid {
+        self.player_uuid
+    }
+
+    /// Returns the entity ID of the player who triggered this event.
+    pub fn player_entity_id(&self) -> i32 {
+        self.player_entity_id
+    }
+
+    /// Returns the username of the player who triggered this event.
+    pub fn player_username(&self) -> &str {
+        &self.player_username
+    }
+
+    // --- World access ---
+
+    /// Returns a reference to the world (chunks, blocks, persistence).
+    ///
+    /// Use `world().set_block()` to modify blocks, `world().get_block()`
+    /// to read them, and `world().persist_chunk()` to save to disk.
+    pub fn world(&self) -> &basalt_world::World {
+        self.world
+    }
+
+    // --- Chat / messaging ---
+
+    /// Sends a plain text chat message to the current player.
+    pub fn send_message(&self, text: &str) {
+        let component = TextComponent::text(text);
+        self.send_message_component(&component);
+    }
+
+    /// Sends a styled chat message to the current player.
+    ///
+    /// Accepts a pre-built [`TextComponent`] for full control over
+    /// colors, formatting, and text structure.
+    pub fn send_message_component(&self, component: &TextComponent) {
+        self.responses.push(Response::SendSystemChat {
+            content: component.to_nbt(),
+            action_bar: false,
+        });
+    }
+
+    /// Sends an action bar message to the current player.
+    ///
+    /// Action bar messages appear above the hotbar and fade out.
+    pub fn send_action_bar(&self, text: &str) {
+        let component = TextComponent::text(text);
+        self.responses.push(Response::SendSystemChat {
+            content: component.to_nbt(),
+            action_bar: true,
+        });
+    }
+
+    /// Broadcasts a plain text chat message to ALL connected players.
+    pub fn broadcast_message(&self, text: &str) {
+        let component = TextComponent::text(text);
+        self.broadcast_message_component(&component);
+    }
+
+    /// Broadcasts a styled chat message to ALL connected players.
+    pub fn broadcast_message_component(&self, component: &TextComponent) {
+        self.responses
+            .push(Response::Broadcast(BroadcastMessage::Chat {
+                content: component.to_nbt(),
+            }));
+    }
+
+    // --- Player actions ---
+
+    /// Teleports the current player to the given coordinates.
+    pub fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32) {
+        self.responses.push(Response::SendPosition {
+            teleport_id: 2,
+            x,
+            y,
+            z,
+            yaw,
+            pitch,
+        });
+    }
+
+    /// Changes the current player's gamemode.
+    ///
+    /// Mode values: 0 = survival, 1 = creative, 2 = adventure, 3 = spectator.
+    pub fn set_gamemode(&self, mode: u8) {
+        self.responses.push(Response::SendGameStateChange {
+            reason: 3,
+            value: mode as f32,
+        });
+    }
+
+    // --- Block acknowledgement ---
+
+    /// Sends a block action acknowledgement to the current player.
+    ///
+    /// The client waits for this before applying block predictions.
+    /// The sequence number must match the client's dig/place packet.
+    pub fn send_block_ack(&self, sequence: i32) {
+        self.responses.push(Response::SendBlockAck { sequence });
+    }
+
+    // --- World streaming ---
+
+    /// Streams chunks around the given chunk coordinates.
+    ///
+    /// Sends new chunks the player hasn't received yet and unloads
+    /// chunks that are out of view distance.
+    pub fn stream_chunks(&self, cx: i32, cz: i32) {
+        self.responses.push(Response::StreamChunks {
+            new_cx: cx,
+            new_cz: cz,
+        });
+    }
+
+    // --- Raw broadcast ---
+
+    /// Sends a raw broadcast message to all connected players.
+    ///
+    /// Used for lifecycle events (join/leave), entity movement,
+    /// and block changes. Prefer `broadcast_message()` for chat.
+    pub fn broadcast(&self, msg: BroadcastMessage) {
+        self.responses.push(Response::Broadcast(msg));
+    }
+
+    // --- Internal ---
+
+    /// Drains all queued responses. Called by the play loop after dispatch.
+    pub fn drain_responses(&self) -> Vec<Response> {
+        self.responses.drain()
+    }
+}
+
+/// Thread-local queue for deferred async responses.
+///
+/// Uses `RefCell` for interior mutability — handlers receive
+/// `&ServerContext` (shared reference) but need to push responses.
+/// This is safe because dispatch is single-threaded within a
+/// connection task.
+pub(crate) struct ResponseQueue {
+    inner: RefCell<Vec<Response>>,
+}
+
+impl ResponseQueue {
+    /// Creates an empty response queue.
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Pushes a response onto the queue.
+    pub(crate) fn push(&self, response: Response) {
+        self.inner.borrow_mut().push(response);
+    }
+
+    /// Drains all queued responses, returning them as a Vec.
+    pub(crate) fn drain(&self) -> Vec<Response> {
+        self.inner.borrow_mut().drain(..).collect()
+    }
+}
+
+/// A deferred async operation queued by a sync event handler.
+///
+/// After event dispatch completes, the play loop drains the response
+/// queue and executes each response with access to the connection.
+/// This enum is an implementation detail — plugins use `ServerContext`
+/// methods instead.
+#[derive(Debug, Clone)]
+pub enum Response {
+    /// Broadcast a message to all connected players.
+    Broadcast(BroadcastMessage),
+    /// Send a block action acknowledgement to the current player.
+    SendBlockAck {
+        /// Sequence number matching the client's dig/place packet.
+        sequence: i32,
+    },
+    /// Send a system chat message to the current player.
+    SendSystemChat {
+        /// The formatted text component as NBT.
+        content: NbtCompound,
+        /// Whether to display as an action bar message.
+        action_bar: bool,
+    },
+    /// Teleport the current player to a new position.
+    SendPosition {
+        /// Teleport ID for confirmation tracking.
+        teleport_id: i32,
+        /// Target X coordinate.
+        x: f64,
+        /// Target Y coordinate.
+        y: f64,
+        /// Target Z coordinate.
+        z: f64,
+        /// Target yaw angle.
+        yaw: f32,
+        /// Target pitch angle.
+        pitch: f32,
+    },
+    /// Stream chunks around a new chunk position.
+    StreamChunks {
+        /// New chunk X coordinate.
+        new_cx: i32,
+        /// New chunk Z coordinate.
+        new_cz: i32,
+    },
+    /// Send a game state change to the current player.
+    SendGameStateChange {
+        /// Reason code (e.g., 3 = change gamemode).
+        reason: u8,
+        /// Value associated with the reason.
+        value: f32,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_world() -> &'static basalt_world::World {
+        use std::sync::OnceLock;
+        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
+        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    }
+
+    fn test_ctx() -> ServerContext {
+        ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into())
+    }
+
+    #[test]
+    fn player_identity() {
+        let ctx = test_ctx();
+        assert_eq!(ctx.player_uuid(), Uuid::default());
+        assert_eq!(ctx.player_entity_id(), 1);
+        assert_eq!(ctx.player_username(), "Steve");
+    }
+
+    #[test]
+    fn world_access() {
+        let ctx = test_ctx();
+        // Should be able to read blocks
+        let _block = ctx.world().get_block(0, 64, 0);
+    }
+
+    #[test]
+    fn send_message_queues_response() {
+        let ctx = test_ctx();
+        ctx.send_message("hello");
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::SendSystemChat {
+                action_bar: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn send_action_bar_queues_response() {
+        let ctx = test_ctx();
+        ctx.send_action_bar("bar");
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::SendSystemChat {
+                action_bar: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn broadcast_message_queues_broadcast() {
+        let ctx = test_ctx();
+        ctx.broadcast_message("hello all");
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::Broadcast(BroadcastMessage::Chat { .. })
+        ));
+    }
+
+    #[test]
+    fn teleport_queues_position() {
+        let ctx = test_ctx();
+        ctx.teleport(10.0, 64.0, -5.0, 90.0, 0.0);
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::SendPosition { x, y, z, .. } if x == 10.0 && y == 64.0 && z == -5.0
+        ));
+    }
+
+    #[test]
+    fn set_gamemode_queues_state_change() {
+        let ctx = test_ctx();
+        ctx.set_gamemode(1);
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::SendGameStateChange { reason: 3, value } if value == 1.0
+        ));
+    }
+
+    #[test]
+    fn send_block_ack_queues_ack() {
+        let ctx = test_ctx();
+        ctx.send_block_ack(42);
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::SendBlockAck { sequence: 42 }
+        ));
+    }
+
+    #[test]
+    fn stream_chunks_queues_streaming() {
+        let ctx = test_ctx();
+        ctx.stream_chunks(1, 2);
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::StreamChunks {
+                new_cx: 1,
+                new_cz: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn drain_clears_queue() {
+        let ctx = test_ctx();
+        ctx.send_message("a");
+        ctx.send_message("b");
+        assert_eq!(ctx.drain_responses().len(), 2);
+        assert!(ctx.drain_responses().is_empty());
+    }
+}

--- a/crates/basalt-api/src/events.rs
+++ b/crates/basalt-api/src/events.rs
@@ -1,0 +1,252 @@
+//! Concrete game events dispatched through the event bus.
+//!
+//! Each event struct carries domain data relevant to a specific game
+//! action. Cancellable events have a `cancelled` field that Validate
+//! handlers can set to prevent Process and Post handlers from running.
+//!
+//! Use the [`cancellable_event!`] and [`event!`] macros to implement
+//! the [`Event`](basalt_events::Event) trait for custom event types.
+
+use basalt_types::Uuid;
+
+use crate::broadcast::PlayerSnapshot;
+
+/// Implements [`Event`](basalt_events::Event) for a cancellable event struct.
+///
+/// The struct must have a `cancelled: bool` field. Validate handlers
+/// can call `event.cancel()` to prevent Process and Post handlers
+/// from running.
+///
+/// # Example
+///
+/// ```ignore
+/// pub struct MyEvent {
+///     pub data: String,
+///     pub cancelled: bool,
+/// }
+/// basalt_api::cancellable_event!(MyEvent);
+/// ```
+#[macro_export]
+macro_rules! cancellable_event {
+    ($name:ident) => {
+        impl basalt_events::Event for $name {
+            fn is_cancelled(&self) -> bool {
+                self.cancelled
+            }
+            fn cancel(&mut self) {
+                self.cancelled = true;
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+        }
+    };
+}
+
+/// Implements [`Event`](basalt_events::Event) for a non-cancellable event struct.
+///
+/// `cancel()` is a no-op and `is_cancelled()` always returns `false`.
+///
+/// # Example
+///
+/// ```ignore
+/// pub struct MyEvent {
+///     pub data: String,
+/// }
+/// basalt_api::event!(MyEvent);
+/// ```
+#[macro_export]
+macro_rules! event {
+    ($name:ident) => {
+        impl basalt_events::Event for $name {
+            fn is_cancelled(&self) -> bool {
+                false
+            }
+            fn cancel(&mut self) {}
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+        }
+    };
+}
+
+/// A player broke a block (creative mode instant break).
+///
+/// Fired when the server receives a `BlockDig` packet with status 0.
+/// If cancelled, the block remains unchanged and no acknowledgement
+/// or broadcast is sent.
+pub struct BlockBrokenEvent {
+    /// Block X coordinate (absolute world coordinates).
+    pub x: i32,
+    /// Block Y coordinate (absolute world coordinates).
+    pub y: i32,
+    /// Block Z coordinate (absolute world coordinates).
+    pub z: i32,
+    /// Sequence number for client acknowledgement.
+    pub sequence: i32,
+    /// UUID of the player who broke the block.
+    pub player_uuid: Uuid,
+    /// Whether this event has been cancelled by a Validate handler.
+    pub cancelled: bool,
+}
+cancellable_event!(BlockBrokenEvent);
+
+/// A player placed a block.
+///
+/// Fired when the server receives a `BlockPlace` packet with a valid
+/// held item that maps to a block state. The placement position has
+/// already been computed from the target block + face offset.
+pub struct BlockPlacedEvent {
+    /// Placement X coordinate (absolute world coordinates).
+    pub x: i32,
+    /// Placement Y coordinate (absolute world coordinates).
+    pub y: i32,
+    /// Placement Z coordinate (absolute world coordinates).
+    pub z: i32,
+    /// The block state ID to place.
+    pub block_state: u16,
+    /// Sequence number for client acknowledgement.
+    pub sequence: i32,
+    /// UUID of the player who placed the block.
+    pub player_uuid: Uuid,
+    /// Whether this event has been cancelled by a Validate handler.
+    pub cancelled: bool,
+}
+cancellable_event!(BlockPlacedEvent);
+
+/// A player moved or changed look direction.
+///
+/// Fired after the player's position has been updated in the player
+/// state. Carries the previous chunk coordinates for chunk boundary
+/// detection. Not cancellable — the server is not authoritative for
+/// position in vanilla Minecraft.
+pub struct PlayerMovedEvent {
+    /// The moving player's entity ID.
+    pub entity_id: i32,
+    /// New absolute X coordinate.
+    pub x: f64,
+    /// New absolute Y coordinate.
+    pub y: f64,
+    /// New absolute Z coordinate.
+    pub z: f64,
+    /// New yaw angle (degrees).
+    pub yaw: f32,
+    /// New pitch angle (degrees).
+    pub pitch: f32,
+    /// Whether the player is on the ground.
+    pub on_ground: bool,
+    /// Previous chunk X before the movement.
+    pub old_cx: i32,
+    /// Previous chunk Z before the movement.
+    pub old_cz: i32,
+}
+event!(PlayerMovedEvent);
+
+/// A player sent a chat message.
+///
+/// If cancelled, the message is not broadcast to any player.
+pub struct ChatMessageEvent {
+    /// The sender's username.
+    pub username: String,
+    /// The chat message content.
+    pub message: String,
+    /// Whether this event has been cancelled by a Validate handler.
+    pub cancelled: bool,
+}
+cancellable_event!(ChatMessageEvent);
+
+/// A player issued a command (e.g., `/tp 0 64 0`).
+///
+/// If cancelled, the command is not executed.
+pub struct CommandEvent {
+    /// The command string without the leading `/`.
+    pub command: String,
+    /// UUID of the player who issued the command.
+    pub player_uuid: Uuid,
+    /// Whether this event has been cancelled by a Validate handler.
+    pub cancelled: bool,
+}
+cancellable_event!(CommandEvent);
+
+/// A new player has joined the server and entered the Play state.
+///
+/// Not cancellable — the player is already connected.
+pub struct PlayerJoinedEvent {
+    /// Snapshot of the joining player's state.
+    pub info: PlayerSnapshot,
+}
+event!(PlayerJoinedEvent);
+
+/// A player has disconnected from the server.
+///
+/// Not cancellable — the connection is already closed.
+pub struct PlayerLeftEvent {
+    /// The leaving player's UUID.
+    pub uuid: Uuid,
+    /// The leaving player's entity ID.
+    pub entity_id: i32,
+    /// The leaving player's username.
+    pub username: String,
+}
+event!(PlayerLeftEvent);
+
+#[cfg(test)]
+mod tests {
+    use basalt_events::Event;
+
+    use super::*;
+
+    #[test]
+    fn block_broken_cancellation() {
+        let mut event = BlockBrokenEvent {
+            x: 0,
+            y: 64,
+            z: 0,
+            sequence: 1,
+            player_uuid: Uuid::default(),
+            cancelled: false,
+        };
+        assert!(!event.is_cancelled());
+        event.cancel();
+        assert!(event.is_cancelled());
+    }
+
+    #[test]
+    fn player_moved_not_cancellable() {
+        let mut event = PlayerMovedEvent {
+            entity_id: 1,
+            x: 0.0,
+            y: 64.0,
+            z: 0.0,
+            yaw: 0.0,
+            pitch: 0.0,
+            on_ground: true,
+            old_cx: 0,
+            old_cz: 0,
+        };
+        event.cancel(); // no-op
+        assert!(!event.is_cancelled());
+    }
+
+    #[test]
+    fn event_downcast_roundtrip() {
+        let mut event = BlockPlacedEvent {
+            x: 5,
+            y: 64,
+            z: 3,
+            block_state: 1,
+            sequence: 42,
+            player_uuid: Uuid::default(),
+            cancelled: false,
+        };
+        let any = event.as_any_mut();
+        let concrete = any.downcast_mut::<BlockPlacedEvent>().unwrap();
+        assert_eq!(concrete.block_state, 1);
+    }
+}

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -1,0 +1,63 @@
+//! Basalt public plugin API.
+//!
+//! This crate defines the complete public API for Basalt server
+//! plugins. Both built-in plugins and external plugins depend on
+//! this crate — there is no separate internal API.
+//!
+//! # Writing a plugin
+//!
+//! 1. Implement the [`Plugin`] trait with metadata and event registration
+//! 2. Use [`EventRegistrar`] to subscribe to events at specific stages
+//! 3. Use [`ServerContext`] methods in handlers to interact with the server
+//!
+//! ```ignore
+//! use basalt_api::prelude::*;
+//!
+//! pub struct MyPlugin;
+//!
+//! impl Plugin for MyPlugin {
+//!     fn metadata(&self) -> PluginMetadata {
+//!         PluginMetadata {
+//!             name: "my-plugin",
+//!             version: "0.1.0",
+//!             author: Some("Me"),
+//!             dependencies: &[],
+//!         }
+//!     }
+//!
+//!     fn on_enable(&self, registrar: &mut EventRegistrar) {
+//!         registrar.on::<PlayerJoinedEvent>(Stage::Post, 0, |_event, ctx| {
+//!             ctx.send_message("Welcome!");
+//!         });
+//!     }
+//! }
+//! ```
+
+pub mod broadcast;
+pub mod context;
+pub mod events;
+pub mod plugin;
+
+// Re-export core types at crate root for convenience.
+pub use broadcast::{BroadcastMessage, PlayerSnapshot, ProfileProperty};
+pub use context::{Response, ServerContext};
+pub use plugin::{EventRegistrar, Plugin, PluginMetadata};
+
+// Re-export basalt-events types that plugins need.
+pub use basalt_events::{Event, EventBus, Stage};
+
+/// Prelude module for convenient glob imports.
+///
+/// ```ignore
+/// use basalt_api::prelude::*;
+/// ```
+pub mod prelude {
+    pub use crate::broadcast::{BroadcastMessage, PlayerSnapshot};
+    pub use crate::context::ServerContext;
+    pub use crate::events::{
+        BlockBrokenEvent, BlockPlacedEvent, ChatMessageEvent, CommandEvent, PlayerJoinedEvent,
+        PlayerLeftEvent, PlayerMovedEvent,
+    };
+    pub use crate::plugin::{EventRegistrar, Plugin, PluginMetadata};
+    pub use basalt_events::Stage;
+}

--- a/crates/basalt-api/src/plugin.rs
+++ b/crates/basalt-api/src/plugin.rs
@@ -1,0 +1,182 @@
+//! Plugin trait and registration API.
+//!
+//! Every server feature — built-in or external — implements the
+//! [`Plugin`] trait. Plugins register event handlers during
+//! [`on_enable`](Plugin::on_enable) and clean up during
+//! [`on_disable`](Plugin::on_disable).
+
+use basalt_events::{Event, EventBus, Stage};
+
+use crate::context::ServerContext;
+
+/// A server plugin that registers event handlers and lifecycle hooks.
+///
+/// Plugins are compile-time crate dependencies. Each plugin implements
+/// this trait and is added to the server via `ServerBuilder::add_plugin`.
+/// Built-in plugins (chat, world, block interaction) implement this
+/// same trait — there is no backdoor API.
+///
+/// # Lifecycle
+///
+/// 1. `metadata()` — called to read plugin identity
+/// 2. `on_enable(&mut EventRegistrar)` — registers event handlers
+/// 3. Server runs (handlers fire on game events)
+/// 4. `on_disable()` — cleanup on shutdown
+///
+/// # Example
+///
+/// ```ignore
+/// use basalt_api::prelude::*;
+///
+/// pub struct MotdPlugin;
+///
+/// impl Plugin for MotdPlugin {
+///     fn metadata(&self) -> PluginMetadata {
+///         PluginMetadata {
+///             name: "motd",
+///             version: "0.1.0",
+///             author: Some("Community"),
+///             dependencies: &[],
+///         }
+///     }
+///
+///     fn on_enable(&self, registrar: &mut EventRegistrar) {
+///         registrar.on::<PlayerJoinedEvent>(Stage::Post, 0, |_event, ctx| {
+///             ctx.send_message("Welcome to the server!");
+///         });
+///     }
+/// }
+/// ```
+pub trait Plugin: Send + Sync + 'static {
+    /// Returns the plugin's identity metadata.
+    fn metadata(&self) -> PluginMetadata;
+
+    /// Called when the plugin is enabled. Register event handlers here.
+    ///
+    /// The `registrar` provides typed methods for subscribing to events
+    /// at specific stages with priority ordering. This is the only way
+    /// to register handlers.
+    fn on_enable(&self, registrar: &mut EventRegistrar);
+
+    /// Called when the plugin is disabled (server shutdown).
+    ///
+    /// Override to clean up resources, flush caches, or log shutdown.
+    /// Default implementation is a no-op.
+    fn on_disable(&self) {}
+}
+
+/// Identity metadata for a plugin.
+///
+/// Describes the plugin's name, version, author, and load-order
+/// dependencies. Used for logging, diagnostics, and topological
+/// sorting of plugin initialization.
+#[derive(Debug, Clone)]
+pub struct PluginMetadata {
+    /// Human-readable plugin name. Used as an identifier for
+    /// dependency resolution and logging.
+    pub name: &'static str,
+    /// Semver version string.
+    pub version: &'static str,
+    /// Optional author name.
+    pub author: Option<&'static str>,
+    /// Plugin names that must be loaded before this plugin.
+    ///
+    /// The server sorts plugins topologically by their dependencies
+    /// before calling `on_enable`. An empty slice means no ordering
+    /// constraints.
+    pub dependencies: &'static [&'static str],
+}
+
+/// Typed registration interface for event handlers.
+///
+/// Wraps [`EventBus`] and locks the context type to [`ServerContext`].
+/// Plugins use this to subscribe handlers without accessing the bus
+/// directly, which prevents registering handlers with a wrong context
+/// type.
+pub struct EventRegistrar<'a> {
+    bus: &'a mut EventBus,
+}
+
+impl<'a> EventRegistrar<'a> {
+    /// Creates a new registrar wrapping the given event bus.
+    pub fn new(bus: &'a mut EventBus) -> Self {
+        Self { bus }
+    }
+
+    /// Registers a handler for event type `E` at the given stage.
+    ///
+    /// Lower priority values run first within the same stage.
+    /// The handler receives a mutable reference to the event and
+    /// a shared reference to [`ServerContext`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// registrar.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, ctx| {
+    ///     // Check permissions, optionally cancel
+    ///     if !can_build(ctx.player_uuid()) {
+    ///         event.cancel();
+    ///     }
+    /// });
+    /// ```
+    pub fn on<E>(
+        &mut self,
+        stage: Stage,
+        priority: i32,
+        handler: impl Fn(&mut E, &ServerContext) + Send + Sync + 'static,
+    ) where
+        E: Event + 'static,
+    {
+        self.bus.on::<E, ServerContext>(stage, priority, handler);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestPlugin;
+
+    impl Plugin for TestPlugin {
+        fn metadata(&self) -> PluginMetadata {
+            PluginMetadata {
+                name: "test",
+                version: "0.1.0",
+                author: Some("Test"),
+                dependencies: &[],
+            }
+        }
+
+        fn on_enable(&self, _registrar: &mut EventRegistrar) {
+            // no-op for metadata test
+        }
+    }
+
+    #[test]
+    fn plugin_metadata() {
+        let plugin = TestPlugin;
+        let meta = plugin.metadata();
+        assert_eq!(meta.name, "test");
+        assert_eq!(meta.version, "0.1.0");
+        assert_eq!(meta.author, Some("Test"));
+        assert!(meta.dependencies.is_empty());
+    }
+
+    #[test]
+    fn plugin_on_disable_default_is_noop() {
+        let plugin = TestPlugin;
+        plugin.on_disable(); // should not panic
+    }
+
+    #[test]
+    fn registrar_registers_handler() {
+        use crate::events::ChatMessageEvent;
+
+        let mut bus = EventBus::new();
+        {
+            let mut registrar = EventRegistrar::new(&mut bus);
+            registrar.on::<ChatMessageEvent>(Stage::Post, 0, |_event, _ctx| {});
+        }
+        assert_eq!(bus.handler_count(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- New `basalt-api` crate providing the complete public plugin API
- `Plugin` trait with `metadata()` (name, version, author, dependencies), `on_enable(&mut EventRegistrar)`, `on_disable()`
- `EventRegistrar` wrapping `EventBus` with locked `ServerContext` type — plugins can't register handlers with wrong context
- `ServerContext` with high-level methods: `send_message()`, `broadcast_message()`, `teleport()`, `set_gamemode()`, `world()`, `send_block_ack()`, `stream_chunks()`, player identity getters
- `Response` and `ResponseQueue` hidden behind `ServerContext` methods (`pub(crate)`)
- All 7 event types ported from basalt-server with `#[macro_export]` macros for custom events
- `BroadcastMessage`, `PlayerSnapshot`, `ProfileProperty` as public types
- Added `api`, `api/plugin`, `api/context`, `api/events`, `api/broadcast` scopes to commitlint

Closes #82

## Test plan

- [x] 16 unit tests for ServerContext (player identity, every method queues correct response, drain clears)
- [x] 3 unit tests for events (cancellation, non-cancellable, downcast)
- [x] 3 unit tests for Plugin trait (metadata, on_disable default, registrar registers)
- [x] All 565 workspace tests passing
- [x] 91.37% coverage
