### PR TITLE
feat(server): config-driven plugin registration via basalt.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -1563,6 +1564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1776,47 @@ dependencies = [
  "rustls",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2237,6 +2288,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ lz4_flex = "0.11"
 # Noise generation
 noise = "0.9"
 
+# Configuration
+toml = "0.8"
+
 # Concurrent data structures
 dashmap = "6"
 

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -22,6 +22,7 @@ basalt-plugin-lifecycle = { path = "../../plugins/lifecycle" }
 basalt-plugin-movement = { path = "../../plugins/movement" }
 
 tokio = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
 dashmap = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/basalt-server/examples/server.rs
+++ b/crates/basalt-server/examples/server.rs
@@ -1,8 +1,8 @@
 //! Minimal Basalt server launcher.
 //!
-//! Starts a Minecraft 1.21.4 server on `localhost:25565` that accepts
-//! clients into a void world. All server logic lives in the
-//! `basalt-server` crate — this is just the entry point.
+//! Loads configuration from `basalt.toml` (or uses defaults) and
+//! starts a Minecraft 1.21.4 server. Plugins, bind address, world
+//! seed, and storage mode are all configurable.
 //!
 //! Usage: `cargo run --package basalt-server --example server`
 
@@ -10,6 +10,6 @@ use basalt_server::Server;
 
 #[tokio::main]
 async fn main() {
-    let server = Server::new("0.0.0.0:25565");
+    let server = Server::new();
     server.run().await;
 }

--- a/crates/basalt-server/src/config.rs
+++ b/crates/basalt-server/src/config.rs
@@ -1,0 +1,295 @@
+//! Server configuration loaded from `basalt.toml`.
+//!
+//! The config controls the bind address, world settings (seed, storage
+//! mode), and which plugins are enabled. Missing fields use sensible
+//! defaults — a missing `basalt.toml` runs a full game server.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// Top-level server configuration.
+///
+/// Loaded from `basalt.toml` at startup. All fields have defaults
+/// so a missing or partial config file works out of the box.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    /// Network and server identity settings.
+    pub server: ServerSection,
+    /// World generation and storage settings.
+    pub world: WorldSection,
+    /// Plugin enable/disable flags.
+    pub plugins: PluginsSection,
+}
+
+/// Network settings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ServerSection {
+    /// Address to bind the TCP listener to.
+    pub bind: String,
+}
+
+/// World generation and storage settings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct WorldSection {
+    /// Terrain generation seed.
+    pub seed: u32,
+    /// Storage mode: how chunks are persisted to disk.
+    pub storage: StorageMode,
+}
+
+/// How chunks are persisted to disk.
+///
+/// - `none` — no disk access, chunks exist only in memory
+/// - `read-only` — load pre-built maps from disk, never write
+/// - `read-write` — load from disk and save modifications
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageMode {
+    /// No disk access. Chunks generated in memory only.
+    None,
+    /// Load chunks from disk, never write back.
+    ReadOnly,
+    /// Load from disk and save modifications.
+    #[default]
+    ReadWrite,
+}
+
+/// Plugin enable/disable flags.
+///
+/// Each flag controls whether the corresponding plugin is registered
+/// on the event bus at startup. Disabled plugins have zero overhead.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct PluginsSection {
+    /// Chat messages and slash commands.
+    pub chat: bool,
+    /// Block breaking and placing.
+    pub block: bool,
+    /// Chunk streaming on movement.
+    pub world: bool,
+    /// Player join/leave broadcasts.
+    pub lifecycle: bool,
+    /// Player movement broadcasts.
+    pub movement: bool,
+}
+
+impl Default for ServerSection {
+    fn default() -> Self {
+        Self {
+            bind: "0.0.0.0:25565".into(),
+        }
+    }
+}
+
+impl Default for WorldSection {
+    fn default() -> Self {
+        Self {
+            seed: 42,
+            storage: StorageMode::ReadWrite,
+        }
+    }
+}
+
+impl Default for PluginsSection {
+    fn default() -> Self {
+        Self {
+            chat: true,
+            block: true,
+            world: true,
+            lifecycle: true,
+            movement: true,
+        }
+    }
+}
+
+impl ServerConfig {
+    /// Loads the config from `basalt.toml` in the current directory.
+    ///
+    /// Returns the default config if the file doesn't exist.
+    /// Panics if the file exists but contains invalid TOML.
+    pub fn load() -> Self {
+        Self::load_from(Path::new("basalt.toml"))
+    }
+
+    /// Loads the config from the given path.
+    ///
+    /// Returns the default config if the file doesn't exist.
+    pub fn load_from(path: &Path) -> Self {
+        match std::fs::read_to_string(path) {
+            Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
+                panic!("Failed to parse {}: {e}", path.display());
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                println!("[config] No basalt.toml found, using defaults");
+                Self::default()
+            }
+            Err(e) => {
+                panic!("Failed to read {}: {e}", path.display());
+            }
+        }
+    }
+
+    /// Creates the world based on the config settings.
+    ///
+    /// - `none` → in-memory world, no disk
+    /// - `read-only` → loads from `world/`, no writes
+    /// - `read-write` → loads from `world/`, writes back
+    pub fn create_world(&self) -> basalt_world::World {
+        match self.world.storage {
+            StorageMode::None => {
+                println!("[world] Memory-only (no persistence)");
+                basalt_world::World::new_memory(self.world.seed)
+            }
+            StorageMode::ReadOnly | StorageMode::ReadWrite => {
+                println!(
+                    "[world] Storage: {:?}, seed: {}, dir: world/",
+                    self.world.storage, self.world.seed
+                );
+                basalt_world::World::new(self.world.seed, "world")
+            }
+        }
+    }
+
+    /// Returns the list of plugins to register based on the config.
+    pub fn create_plugins(&self) -> Vec<Box<dyn basalt_api::Plugin>> {
+        let mut plugins: Vec<Box<dyn basalt_api::Plugin>> = Vec::new();
+
+        if self.plugins.lifecycle {
+            plugins.push(Box::new(basalt_plugin_lifecycle::LifecyclePlugin));
+        }
+        if self.plugins.chat {
+            plugins.push(Box::new(basalt_plugin_chat::ChatPlugin));
+        }
+        if self.plugins.movement {
+            plugins.push(Box::new(basalt_plugin_movement::MovementPlugin));
+        }
+        if self.plugins.world {
+            plugins.push(Box::new(basalt_plugin_world::WorldPlugin));
+        }
+        if self.plugins.block {
+            plugins.push(Box::new(basalt_plugin_block::BlockPlugin));
+        }
+        // StoragePlugin is only active in read-write mode
+        if self.plugins.block && self.world.storage == StorageMode::ReadWrite {
+            plugins.push(Box::new(basalt_plugin_storage::StoragePlugin));
+        }
+
+        plugins
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = ServerConfig::default();
+        assert_eq!(config.server.bind, "0.0.0.0:25565");
+        assert_eq!(config.world.seed, 42);
+        assert_eq!(config.world.storage, StorageMode::ReadWrite);
+        assert!(config.plugins.chat);
+        assert!(config.plugins.block);
+        assert!(config.plugins.world);
+        assert!(config.plugins.lifecycle);
+        assert!(config.plugins.movement);
+    }
+
+    #[test]
+    fn parse_full_config() {
+        let toml = r#"
+[server]
+bind = "127.0.0.1:25566"
+
+[world]
+seed = 123
+storage = "read-only"
+
+[plugins]
+chat = true
+block = false
+world = true
+lifecycle = true
+movement = false
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.server.bind, "127.0.0.1:25566");
+        assert_eq!(config.world.seed, 123);
+        assert_eq!(config.world.storage, StorageMode::ReadOnly);
+        assert!(config.plugins.chat);
+        assert!(!config.plugins.block);
+        assert!(config.plugins.world);
+        assert!(config.plugins.lifecycle);
+        assert!(!config.plugins.movement);
+    }
+
+    #[test]
+    fn parse_partial_config() {
+        let toml = r#"
+[world]
+seed = 99
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.server.bind, "0.0.0.0:25565"); // default
+        assert_eq!(config.world.seed, 99);
+        assert_eq!(config.world.storage, StorageMode::ReadWrite); // default
+        assert!(config.plugins.chat); // default
+    }
+
+    #[test]
+    fn parse_empty_config() {
+        let config: ServerConfig = toml::from_str("").unwrap();
+        assert_eq!(config.server.bind, "0.0.0.0:25565");
+        assert_eq!(config.world.seed, 42);
+    }
+
+    #[test]
+    fn storage_none_mode() {
+        let toml = r#"
+[world]
+storage = "none"
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.world.storage, StorageMode::None);
+    }
+
+    #[test]
+    fn create_plugins_all_enabled() {
+        let config = ServerConfig::default();
+        let plugins = config.create_plugins();
+        // 6 plugins: lifecycle, chat, movement, world, block, storage
+        assert_eq!(plugins.len(), 6);
+    }
+
+    #[test]
+    fn create_plugins_read_only_no_storage() {
+        let mut config = ServerConfig::default();
+        config.world.storage = StorageMode::ReadOnly;
+        let plugins = config.create_plugins();
+        // 5 plugins: no StoragePlugin
+        assert_eq!(plugins.len(), 5);
+        assert!(plugins.iter().all(|p| p.metadata().name != "storage"));
+    }
+
+    #[test]
+    fn create_plugins_none_disabled() {
+        let mut config = ServerConfig::default();
+        config.plugins.chat = false;
+        config.plugins.block = false;
+        config.plugins.world = false;
+        config.plugins.lifecycle = false;
+        config.plugins.movement = false;
+        let plugins = config.create_plugins();
+        assert!(plugins.is_empty());
+    }
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let config = ServerConfig::load_from(Path::new("nonexistent.toml"));
+        assert_eq!(config.server.bind, "0.0.0.0:25565");
+    }
+}

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -2,8 +2,7 @@
 //!
 //! A lightweight Minecraft 1.21.4 server built on the Basalt protocol
 //! library. Handles the full client lifecycle from handshake through
-//! play, with support for multi-player, chat broadcast, commands,
-//! and player position tracking.
+//! play, with plugin-based game logic loaded from `basalt.toml`.
 //!
 //! # Usage
 //!
@@ -12,12 +11,13 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let server = Server::new("0.0.0.0:25565");
+//!     let server = Server::new();
 //!     server.run().await;
 //! }
 //! ```
 
 mod chat;
+pub mod config;
 mod connection;
 pub mod error;
 mod helpers;
@@ -28,31 +28,34 @@ mod state;
 
 use std::sync::Arc;
 
+use config::ServerConfig;
 use tokio::net::TcpListener;
 
 use state::ServerState;
 
 /// A Basalt Minecraft server instance.
 ///
-/// Listens for incoming TCP connections and spawns a task for each
-/// client. All connection tasks share a `ServerState` that tracks
-/// who is online, assigns unique entity IDs, and routes broadcast
-/// messages between players.
+/// Loads configuration from `basalt.toml` (or defaults), registers
+/// plugins, and listens for incoming TCP connections.
 pub struct Server {
-    /// The address to bind the TCP listener to.
-    bind_addr: String,
+    /// Server configuration loaded from `basalt.toml`.
+    config: ServerConfig,
 }
 
 impl Server {
-    /// Creates a new server that will listen on the given address.
+    /// Creates a new server with configuration loaded from `basalt.toml`.
     ///
-    /// The address is not bound until `run()` is called. Use
-    /// `"0.0.0.0:25565"` to listen on all interfaces on the default
-    /// Minecraft port.
-    pub fn new(bind_addr: &str) -> Self {
+    /// If `basalt.toml` doesn't exist, sensible defaults are used
+    /// (all plugins enabled, read-write storage, seed 42).
+    pub fn new() -> Self {
         Self {
-            bind_addr: bind_addr.to_string(),
+            config: ServerConfig::load(),
         }
+    }
+
+    /// Creates a new server with the given configuration.
+    pub fn with_config(config: ServerConfig) -> Self {
+        Self { config }
     }
 
     /// Starts the server and listens for connections indefinitely.
@@ -60,19 +63,31 @@ impl Server {
     /// Each incoming connection is handled in its own Tokio task.
     /// This method never returns under normal operation.
     pub async fn run(&self) {
-        let listener = TcpListener::bind(&self.bind_addr).await.unwrap();
-        println!("Basalt server listening on {}", self.bind_addr);
-        Self::accept_loop(listener).await;
+        let listener = TcpListener::bind(&self.config.server.bind).await.unwrap();
+        println!("Basalt server listening on {}", self.config.server.bind);
+
+        let world = self.config.create_world();
+        let plugins = self.config.create_plugins();
+        let state = ServerState::with_world_and_plugins(world, plugins);
+
+        Self::accept_loop_with_state(listener, state).await;
     }
 
-    /// Accepts connections on the given listener until it is dropped.
+    /// Accepts connections on the given listener with default config.
     ///
-    /// Creates a shared `ServerState` and passes it to every connection
-    /// task. Exposed for testing — tests can bind to port 0 and pass
-    /// the listener directly, avoiding port conflicts.
+    /// Exposed for testing — tests can bind to port 0 and pass the
+    /// listener directly, avoiding port conflicts.
     pub async fn accept_loop(listener: TcpListener) {
-        let state = ServerState::new();
+        let config = ServerConfig::default();
+        let world = config.create_world();
+        let plugins = config.create_plugins();
+        let state = ServerState::with_world_and_plugins(world, plugins);
 
+        Self::accept_loop_with_state(listener, state).await;
+    }
+
+    /// Accepts connections with an existing server state.
+    async fn accept_loop_with_state(listener: TcpListener, state: Arc<ServerState>) {
         loop {
             let (stream, addr) = listener.accept().await.unwrap();
             println!("[{addr}] Connection accepted");
@@ -85,5 +100,11 @@ impl Server {
                 println!("[{addr}] Connection closed");
             });
         }
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -45,16 +45,21 @@ pub(crate) struct PlayerHandle {
 }
 
 impl ServerState {
-    /// Creates a new server state with default built-in plugins.
+    /// Creates a new server state with default config (all plugins, read-write).
+    #[cfg(test)]
     pub fn new() -> Arc<Self> {
-        Self::with_plugins(default_plugins())
+        let config = crate::config::ServerConfig::default();
+        Self::with_world_and_plugins(config.create_world(), config.create_plugins())
     }
 
-    /// Creates a server state with the given plugins registered.
+    /// Creates a server state with a given world and plugin set.
     ///
     /// Each plugin's `on_enable` is called with an `EventRegistrar`
     /// to register its event handlers on the bus.
-    pub fn with_plugins(plugins: Vec<Box<dyn basalt_api::Plugin>>) -> Arc<Self> {
+    pub fn with_world_and_plugins(
+        world: basalt_world::World,
+        plugins: Vec<Box<dyn basalt_api::Plugin>>,
+    ) -> Arc<Self> {
         let (broadcast_tx, _) = broadcast::channel(256);
         let mut event_bus = EventBus::new();
         let mut registrar = basalt_api::EventRegistrar::new(&mut event_bus);
@@ -70,7 +75,7 @@ impl ServerState {
             next_entity_id: AtomicI32::new(1),
             players: DashMap::new(),
             broadcast_tx,
-            world: basalt_world::World::new(42, "world"),
+            world,
             event_bus,
         })
     }
@@ -133,21 +138,6 @@ impl ServerState {
     pub fn player_count(&self) -> usize {
         self.players.len()
     }
-}
-
-/// Returns the default set of built-in plugins.
-///
-/// These cover all core server functionality: lifecycle, chat,
-/// movement, world streaming, block interaction, and storage.
-pub(crate) fn default_plugins() -> Vec<Box<dyn basalt_api::Plugin>> {
-    vec![
-        Box::new(basalt_plugin_lifecycle::LifecyclePlugin),
-        Box::new(basalt_plugin_chat::ChatPlugin),
-        Box::new(basalt_plugin_movement::MovementPlugin),
-        Box::new(basalt_plugin_world::WorldPlugin),
-        Box::new(basalt_plugin_block::BlockPlugin),
-        Box::new(basalt_plugin_storage::StoragePlugin),
-    ]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- New `config.rs` module loading `basalt.toml` at startup with serde deserialization
- Plugin enable/disable flags: `plugins.chat`, `plugins.block`, `plugins.world`, `plugins.lifecycle`, `plugins.movement`
- World storage mode: `none` (memory-only), `read-only` (load, no write), `read-write` (load + StoragePlugin)
- Missing `basalt.toml` uses sensible defaults (all plugins, read-write, seed 42, bind 0.0.0.0:25565)
- `Server::new()` loads config automatically; `Server::with_config(config)` for explicit control
- `ServerState::with_world_and_plugins(world, plugins)` replaces the old `new()` / `with_plugins()`

Example `basalt.toml` for a lobby server:
```toml
[world]
storage = "read-only"

[plugins]
block = false
```

## Test plan

- [x] 10 config unit tests: defaults, full parse, partial parse, empty, storage modes, plugin creation, missing file
- [x] All 567 workspace tests passing
- [x] 91.44% coverage
- [ ] Manual: run without basalt.toml (defaults), run with custom config
