### PR TITLE
feat(server): structured logging with log crate and PluginLogger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ sniffcraft/
 
 ## world save data (runtime-generated, not the plugin crate)
 /world/
+crates/basalt-server/world/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,10 +35,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -65,6 +109,7 @@ dependencies = [
  "basalt-events",
  "basalt-types",
  "basalt-world",
+ "log",
 ]
 
 [[package]]
@@ -176,6 +221,8 @@ dependencies = [
  "basalt-types",
  "basalt-world",
  "dashmap",
+ "env_logger",
+ "log",
  "reqwest",
  "serde",
  "serde_json",
@@ -342,6 +389,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +519,29 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -909,6 +985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1004,30 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1043,6 +1149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1221,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1941,6 +2068,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ lz4_flex = "0.11"
 # Noise generation
 noise = "0.9"
 
+# Logging
+log = "0.4"
+env_logger = "0.11"
+
 # Configuration
 toml = "0.8"
 

--- a/crates/basalt-api/Cargo.toml
+++ b/crates/basalt-api/Cargo.toml
@@ -9,3 +9,4 @@ repository.workspace = true
 basalt-events = { workspace = true }
 basalt-types = { workspace = true }
 basalt-world = { workspace = true }
+log = { workspace = true }

--- a/crates/basalt-api/src/context.rs
+++ b/crates/basalt-api/src/context.rs
@@ -39,6 +39,8 @@ pub struct ServerContext {
     player_entity_id: i32,
     /// Username of the player who triggered this event.
     player_username: String,
+    /// Name of the plugin currently being dispatched.
+    plugin_name: RefCell<String>,
 }
 
 impl ServerContext {
@@ -64,7 +66,16 @@ impl ServerContext {
             player_uuid,
             player_entity_id,
             player_username,
+            plugin_name: RefCell::new(String::new()),
         }
+    }
+
+    /// Sets the plugin name for logger context.
+    ///
+    /// Called internally before each handler runs so `logger()`
+    /// returns the correct target.
+    pub fn set_plugin_name(&self, name: &str) {
+        *self.plugin_name.borrow_mut() = name.to_string();
     }
 
     // --- Player identity ---
@@ -82,6 +93,16 @@ impl ServerContext {
     /// Returns the username of the player who triggered this event.
     pub fn player_username(&self) -> &str {
         &self.player_username
+    }
+
+    // --- Logger ---
+
+    /// Returns a logger scoped to the current plugin.
+    ///
+    /// Messages are logged with target `basalt::plugin::<name>`,
+    /// making them easy to filter in log output.
+    pub fn logger(&self) -> crate::logger::PluginLogger {
+        crate::logger::PluginLogger::new(&self.plugin_name.borrow())
     }
 
     // --- World access ---

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -36,6 +36,7 @@
 pub mod broadcast;
 pub mod context;
 pub mod events;
+pub mod logger;
 pub mod plugin;
 
 // Re-export core types at crate root for convenience.

--- a/crates/basalt-api/src/logger.rs
+++ b/crates/basalt-api/src/logger.rs
@@ -1,0 +1,80 @@
+//! Plugin logger with automatic target prefixing.
+//!
+//! The [`PluginLogger`] wraps the `log` crate and automatically
+//! sets the log target to `basalt::plugin::<name>`, ensuring
+//! consistent, filterable log output across all plugins.
+
+/// A logger scoped to a specific plugin.
+///
+/// Obtained via [`ServerContext::logger()`](crate::ServerContext::logger).
+/// All messages are logged with target `basalt::plugin::<name>`,
+/// making them easy to filter in log output.
+///
+/// # Example
+///
+/// ```ignore
+/// registrar.on::<PlayerJoinedEvent>(Stage::Post, 0, |event, ctx| {
+///     let log = ctx.logger();
+///     log.info(&format!("{} joined", event.info.username));
+///     log.debug("sending welcome message");
+/// });
+/// ```
+pub struct PluginLogger {
+    target: String,
+}
+
+impl PluginLogger {
+    /// Creates a new logger for the given plugin name.
+    pub(crate) fn new(plugin_name: &str) -> Self {
+        Self {
+            target: format!("basalt::plugin::{plugin_name}"),
+        }
+    }
+
+    /// Logs at ERROR level.
+    pub fn error(&self, msg: &str) {
+        log::log!(target: &self.target, log::Level::Error, "{msg}");
+    }
+
+    /// Logs at WARN level.
+    pub fn warn(&self, msg: &str) {
+        log::log!(target: &self.target, log::Level::Warn, "{msg}");
+    }
+
+    /// Logs at INFO level.
+    pub fn info(&self, msg: &str) {
+        log::log!(target: &self.target, log::Level::Info, "{msg}");
+    }
+
+    /// Logs at DEBUG level.
+    pub fn debug(&self, msg: &str) {
+        log::log!(target: &self.target, log::Level::Debug, "{msg}");
+    }
+
+    /// Logs at TRACE level.
+    pub fn trace(&self, msg: &str) {
+        log::log!(target: &self.target, log::Level::Trace, "{msg}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logger_target_format() {
+        let logger = PluginLogger::new("chat");
+        assert_eq!(logger.target, "basalt::plugin::chat");
+    }
+
+    #[test]
+    fn logger_does_not_panic() {
+        let logger = PluginLogger::new("test");
+        // These should not panic even without a logger initialized
+        logger.error("test error");
+        logger.warn("test warn");
+        logger.info("test info");
+        logger.debug("test debug");
+        logger.trace("test trace");
+    }
+}

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -23,6 +23,8 @@ basalt-plugin-movement = { path = "../../plugins/movement" }
 
 tokio = { workspace = true }
 toml = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
 thiserror = { workspace = true }
 dashmap = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/basalt-server/src/config.rs
+++ b/crates/basalt-server/src/config.rs
@@ -29,6 +29,54 @@ pub struct ServerConfig {
 pub struct ServerSection {
     /// Address to bind the TCP listener to.
     pub bind: String,
+    /// Log level: trace, debug, info, warn, error.
+    pub log_level: LogLevel,
+    /// Log format: pretty (human-readable) or json (structured).
+    pub log_format: LogFormat,
+}
+
+/// Log output format.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    /// Human-readable format with colors and aligned fields.
+    #[default]
+    Pretty,
+    /// Structured JSON, one object per line.
+    Json,
+}
+
+/// Log verbosity level.
+///
+/// Maps directly to `log::LevelFilter`. Configurable via `basalt.toml`
+/// and overridable via the `RUST_LOG` environment variable.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// Very verbose: keep-alive RTT, chunk counts, unhandled packets.
+    Trace,
+    /// Protocol flow: packets sent/received, state transitions.
+    Debug,
+    /// Important events: server start, player join/leave, plugins loaded.
+    #[default]
+    Info,
+    /// Non-critical problems: skin fetch failure, keep-alive mismatch.
+    Warn,
+    /// Connection errors and fatal issues.
+    Error,
+}
+
+impl LogLevel {
+    /// Converts to `log::LevelFilter` for logger initialization.
+    pub fn to_level_filter(self) -> log::LevelFilter {
+        match self {
+            Self::Trace => log::LevelFilter::Trace,
+            Self::Debug => log::LevelFilter::Debug,
+            Self::Info => log::LevelFilter::Info,
+            Self::Warn => log::LevelFilter::Warn,
+            Self::Error => log::LevelFilter::Error,
+        }
+    }
 }
 
 /// World generation and storage settings.
@@ -81,6 +129,8 @@ impl Default for ServerSection {
     fn default() -> Self {
         Self {
             bind: "0.0.0.0:25565".into(),
+            log_level: LogLevel::Info,
+            log_format: LogFormat::Pretty,
         }
     }
 }
@@ -115,6 +165,47 @@ impl ServerConfig {
         Self::load_from(Path::new("basalt.toml"))
     }
 
+    /// Initializes the logger based on the config's log level and format.
+    ///
+    /// Uses `env_logger` with the configured level as default.
+    /// The `RUST_LOG` environment variable overrides the config
+    /// if set, allowing runtime adjustment without editing the file.
+    ///
+    /// Formats:
+    /// - `pretty`: `[2026-04-14 10:32:01] INFO  [basalt::server] message`
+    /// - `json`: `{"ts":"2026-04-14T10:32:01Z","level":"INFO","target":"basalt::server","msg":"message"}`
+    pub fn init_logger(&self) {
+        use std::io::Write;
+
+        let format = self.server.log_format;
+        env_logger::Builder::new()
+            .filter_level(self.server.log_level.to_level_filter())
+            .parse_default_env()
+            .format(move |buf, record| match format {
+                LogFormat::Pretty => {
+                    let level = record.level();
+                    let target = record.target();
+                    writeln!(
+                        buf,
+                        "{} {level:<5} [{target}] {}",
+                        buf.timestamp(),
+                        record.args()
+                    )
+                }
+                LogFormat::Json => {
+                    writeln!(
+                        buf,
+                        r#"{{"ts":"{}","level":"{}","target":"{}","msg":"{}"}}"#,
+                        buf.timestamp(),
+                        record.level(),
+                        record.target(),
+                        record.args()
+                    )
+                }
+            })
+            .init();
+    }
+
     /// Loads the config from the given path.
     ///
     /// Returns the default config if the file doesn't exist.
@@ -124,7 +215,7 @@ impl ServerConfig {
                 panic!("Failed to parse {}: {e}", path.display());
             }),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                println!("[config] No basalt.toml found, using defaults");
+                log::info!("No basalt.toml found, using defaults");
                 Self::default()
             }
             Err(e) => {
@@ -141,13 +232,17 @@ impl ServerConfig {
     pub fn create_world(&self) -> basalt_world::World {
         match self.world.storage {
             StorageMode::None => {
-                println!("[world] Memory-only (no persistence)");
+                log::info!(
+                    "World: memory-only (no persistence), seed {}",
+                    self.world.seed
+                );
                 basalt_world::World::new_memory(self.world.seed)
             }
             StorageMode::ReadOnly | StorageMode::ReadWrite => {
-                println!(
-                    "[world] Storage: {:?}, seed: {}, dir: world/",
-                    self.world.storage, self.world.seed
+                log::info!(
+                    "World: {:?} storage, seed {}, dir world/",
+                    self.world.storage,
+                    self.world.seed
                 );
                 basalt_world::World::new(self.world.seed, "world")
             }

--- a/crates/basalt-server/src/connection.rs
+++ b/crates/basalt-server/src/connection.rs
@@ -56,17 +56,11 @@ pub(crate) async fn handle_connection(
 
     match conn.read_handshake().await? {
         HandshakeResult::Status(conn, handshake) => {
-            println!(
-                "[{addr}] Status request (protocol {})",
-                handshake.protocol_version
-            );
+            log::debug!(target: "basalt::connection", "[{addr}] Status request (protocol {})", handshake.protocol_version);
             handle_status(conn, addr).await
         }
         HandshakeResult::Login(conn, handshake) => {
-            println!(
-                "[{addr}] Login request (protocol {})",
-                handshake.protocol_version
-            );
+            log::info!(target: "basalt::connection", "[{addr}] Login (protocol {})", handshake.protocol_version);
             handle_login(conn, addr, state).await
         }
     }
@@ -79,21 +73,21 @@ async fn handle_status(
 ) -> crate::error::Result<()> {
     let packet = conn.read_packet().await?;
     if let ServerboundStatusPacket::PingStart(_) = packet {
-        println!("[{addr}] <- StatusRequest");
+        log::debug!(target: "basalt::connection", "[{addr}] <- StatusRequest");
     }
 
     let response = ClientboundStatusServerInfo {
         response: SERVER_STATUS.into(),
     };
     conn.write_status_response(&response).await?;
-    println!("[{addr}] -> StatusResponse");
+    log::debug!(target: "basalt::connection", "[{addr}] -> StatusResponse");
 
     let packet = conn.read_packet().await?;
     if let ServerboundStatusPacket::Ping(ping) = packet {
-        println!("[{addr}] <- Ping (time={})", ping.time);
+        log::debug!(target: "basalt::connection", "[{addr}] <- Ping (time={})", ping.time);
         let pong = ClientboundStatusPing { time: ping.time };
         conn.write_ping_response(&pong).await?;
-        println!("[{addr}] -> Pong");
+        log::debug!(target: "basalt::connection", "[{addr}] -> Pong");
     }
 
     Ok(())
@@ -109,14 +103,11 @@ async fn handle_login(
 ) -> crate::error::Result<()> {
     let (username, player_uuid) = match conn.read_packet().await? {
         ServerboundLoginPacket::LoginStart(login) => {
-            println!(
-                "[{addr}] <- LoginStart (username={}, uuid={})",
-                login.username, login.player_uuid
-            );
+            log::info!(target: "basalt::connection", "[{addr}] {}: LoginStart", login.username);
             (login.username, login.player_uuid)
         }
         _ => {
-            println!("[{addr}] <- Unexpected packet, expected LoginStart");
+            log::warn!(target: "basalt::connection", "[{addr}] Unexpected packet, expected LoginStart");
             return Ok(());
         }
     };
@@ -126,9 +117,9 @@ async fn handle_login(
         username: username.clone(),
         properties: vec![],
     };
-    println!("[{addr}] -> LoginSuccess");
+    log::debug!(target: "basalt::connection", "[{addr}] -> LoginSuccess");
     let conn = conn.send_login_success(&success).await?;
-    println!("[{addr}] <- LoginAcknowledged → Configuration");
+    log::debug!(target: "basalt::connection", "[{addr}] Login → Configuration");
 
     handle_configuration(conn, addr, &username, player_uuid, state).await
 }
@@ -152,11 +143,11 @@ async fn handle_configuration(
     for reg in &registries {
         conn.write_packet_typed(ClientboundConfigurationRegistryData::PACKET_ID, reg)
             .await?;
-        println!("[{addr}] -> RegistryData ({})", reg.id);
+        log::trace!(target: "basalt::connection", "[{addr}] -> RegistryData ({})", reg.id);
     }
 
     let conn = conn.finish_configuration().await?;
-    println!("[{addr}] <- FinishConfiguration → Play");
+    log::debug!(target: "basalt::connection", "[{addr}] Configuration → Play");
 
     // Collect skin result — the fetch ran during the config exchange
     let skin_properties = skin_task.await.unwrap_or_default();

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -63,8 +63,10 @@ impl Server {
     /// Each incoming connection is handled in its own Tokio task.
     /// This method never returns under normal operation.
     pub async fn run(&self) {
+        self.config.init_logger();
+
         let listener = TcpListener::bind(&self.config.server.bind).await.unwrap();
-        println!("Basalt server listening on {}", self.config.server.bind);
+        log::info!(target: "basalt::server", "Listening on {}", self.config.server.bind);
 
         let world = self.config.create_world();
         let plugins = self.config.create_plugins();
@@ -90,14 +92,14 @@ impl Server {
     async fn accept_loop_with_state(listener: TcpListener, state: Arc<ServerState>) {
         loop {
             let (stream, addr) = listener.accept().await.unwrap();
-            println!("[{addr}] Connection accepted");
+            log::debug!(target: "basalt::connection", "[{addr}] Accepted");
 
             let state = Arc::clone(&state);
             tokio::spawn(async move {
                 if let Err(e) = connection::handle_connection(stream, addr, state).await {
-                    println!("[{addr}] Error: {e}");
+                    log::error!(target: "basalt::connection", "[{addr}] {e}");
                 }
-                println!("[{addr}] Connection closed");
+                log::debug!(target: "basalt::connection", "[{addr}] Closed");
             });
         }
     }

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -72,10 +72,7 @@ pub(crate) async fn run_play_loop(
 
     crate::chat::send_welcome(&mut conn, &player.username).await?;
 
-    println!(
-        "[{addr}] {} joined the void world! Starting play loop.",
-        player.username
-    );
+    log::info!(target: "basalt::play", "[{addr}] {} joined, starting play loop", player.username);
 
     play_loop(&mut conn, addr, player, state, rx).await
 }
@@ -117,7 +114,7 @@ async fn send_initial_world(
     };
     conn.write_packet_typed(ClientboundPlayLogin::PACKET_ID, &login)
         .await?;
-    println!("[{addr}] -> Login (Play)");
+    log::debug!(target: "basalt::play", "[{addr}] -> Login (Play)");
 
     let spawn_y = state.world.spawn_y() as i32;
     let spawn = ClientboundPlaySpawnPosition {
@@ -126,7 +123,7 @@ async fn send_initial_world(
     };
     conn.write_packet_typed(ClientboundPlaySpawnPosition::PACKET_ID, &spawn)
         .await?;
-    println!("[{addr}] -> SpawnPosition");
+    log::debug!(target: "basalt::play", "[{addr}] -> SpawnPosition");
 
     let game_event = ClientboundPlayGameStateChange {
         reason: 13,
@@ -134,7 +131,7 @@ async fn send_initial_world(
     };
     conn.write_packet_typed(ClientboundPlayGameStateChange::PACKET_ID, &game_event)
         .await?;
-    println!("[{addr}] -> GameEvent (start waiting for chunks)");
+    log::debug!(target: "basalt::play", "[{addr}] -> GameEvent (wait for chunks)");
 
     // Tell the client where to center its chunk rendering
     let spawn_cx = (player.x as i32) >> 4;
@@ -147,7 +144,7 @@ async fn send_initial_world(
         .await?;
     let chunk_count =
         send_chunks_around(conn, state, player, spawn_cx, spawn_cz, VIEW_RADIUS).await?;
-    println!("[{addr}] -> ChunkData ({chunk_count} chunks, radius {VIEW_RADIUS})");
+    log::debug!(target: "basalt::play", "[{addr}] -> {chunk_count} chunks (radius {VIEW_RADIUS})");
 
     let position = ClientboundPlayPosition {
         teleport_id: 1,
@@ -163,10 +160,7 @@ async fn send_initial_world(
     };
     conn.write_packet_typed(ClientboundPlayPosition::PACKET_ID, &position)
         .await?;
-    println!(
-        "[{addr}] -> PlayerPosition ({}, {}, {})",
-        player.x, player.y, player.z
-    );
+    log::debug!(target: "basalt::play", "[{addr}] -> Position ({}, {}, {})", player.x, player.y, player.z);
 
     Ok(())
 }
@@ -219,10 +213,10 @@ async fn play_loop(
                         // Common packets (settings, plugin channels) are
                         // skipped by the codegen and produce UnknownPacket.
                         // Ignore them silently.
-                        println!("[{addr}] {} sent unknown packet 0x{id:02x}, ignoring", player.username);
+                        log::trace!(target: "basalt::play", "[{addr}] {} unknown packet 0x{id:02x}", player.username);
                     }
                     Err(e) => {
-                        println!("[{addr}] {} disconnected: {e}", player.username);
+                        log::info!(target: "basalt::play", "[{addr}] {} disconnected: {e}", player.username);
                         break;
                     }
                 }
@@ -251,29 +245,19 @@ fn packet_to_event(
         ServerboundPlayPacket::KeepAlive(ka) => {
             if ka.keep_alive_id == player.last_keep_alive_id {
                 let rtt = player.last_keep_alive_sent.elapsed();
-                println!(
-                    "[{addr}] {} keep-alive OK (RTT: {}ms)",
-                    player.username,
-                    rtt.as_millis()
-                );
+                log::trace!(target: "basalt::play", "[{addr}] {} keep-alive OK (RTT: {}ms)", player.username, rtt.as_millis());
             } else {
-                println!(
-                    "[{addr}] {} keep-alive mismatch: expected {}, got {}",
-                    player.username, player.last_keep_alive_id, ka.keep_alive_id
-                );
+                log::warn!(target: "basalt::play", "[{addr}] {} keep-alive mismatch: expected {}, got {}", player.username, player.last_keep_alive_id, ka.keep_alive_id);
             }
             None
         }
         ServerboundPlayPacket::TeleportConfirm(tc) => {
-            println!(
-                "[{addr}] {} confirmed teleport (id={})",
-                player.username, tc.teleport_id
-            );
+            log::trace!(target: "basalt::play", "[{addr}] {} teleport confirmed (id={})", player.username, tc.teleport_id);
             player.teleport_confirmed = true;
             None
         }
         ServerboundPlayPacket::PlayerLoaded(_) => {
-            println!("[{addr}] {} finished loading", player.username);
+            log::debug!(target: "basalt::play", "[{addr}] {} finished loading", player.username);
             player.loaded = true;
             None
         }
@@ -334,7 +318,7 @@ fn packet_to_event(
             None
         }
         ServerboundPlayPacket::ChatMessage(msg) => {
-            println!("[{addr}] <{}> {}", player.username, msg.message);
+            log::info!(target: "basalt::play", "[{addr}] <{}> {}", player.username, msg.message);
             Some(Box::new(ChatMessageEvent {
                 username: player.username.clone(),
                 message: msg.message,
@@ -342,10 +326,7 @@ fn packet_to_event(
             }))
         }
         ServerboundPlayPacket::ChatCommand(cmd) => {
-            println!(
-                "[{addr}] {} issued command: /{}",
-                player.username, cmd.command
-            );
+            log::info!(target: "basalt::play", "[{addr}] {} issued /{}", player.username, cmd.command);
             Some(Box::new(CommandEvent {
                 command: cmd.command,
                 player_uuid: player.uuid,
@@ -355,10 +336,7 @@ fn packet_to_event(
         ServerboundPlayPacket::BlockDig(dig) => {
             let pos = dig.location;
             if dig.status == 0 {
-                println!(
-                    "[{addr}] {} broke block at ({}, {}, {})",
-                    player.username, pos.x, pos.y, pos.z
-                );
+                log::debug!(target: "basalt::play", "[{addr}] {} broke block ({}, {}, {})", player.username, pos.x, pos.y, pos.z);
                 Some(Box::new(BlockBrokenEvent {
                     x: pos.x,
                     y: pos.y,
@@ -380,10 +358,7 @@ fn packet_to_event(
             if let Some(item_id) = item.item_id
                 && let Some(block_state) = basalt_world::block::item_to_default_block_state(item_id)
             {
-                println!(
-                    "[{addr}] {} placed block at ({px}, {py}, {pz}) state={block_state}",
-                    player.username
-                );
+                log::debug!(target: "basalt::play", "[{addr}] {} placed block ({px}, {py}, {pz}) state={block_state}", player.username);
                 Some(Box::new(BlockPlacedEvent {
                     x: px,
                     y: py,
@@ -418,11 +393,7 @@ fn packet_to_event(
         | ServerboundPlayPacket::UseItem(_)
         | ServerboundPlayPacket::ArmAnimation(_) => None,
         other => {
-            println!(
-                "[{addr}] {} sent unhandled packet: {:?}",
-                player.username,
-                std::mem::discriminant(&other)
-            );
+            log::trace!(target: "basalt::play", "[{addr}] {} unhandled packet: {:?}", player.username, std::mem::discriminant(&other));
             None
         }
     }

--- a/crates/basalt-server/src/skin.rs
+++ b/crates/basalt-server/src/skin.rs
@@ -60,11 +60,11 @@ struct ProfileResponse {
 pub(crate) async fn fetch_skin_properties(username: &str) -> Vec<ProfileProperty> {
     match fetch_skin_inner(username).await {
         Ok(props) => {
-            println!("[skin] Fetched {} properties for {username}", props.len());
+            log::debug!(target: "basalt::skin", "Fetched {} properties for {username}", props.len());
             props
         }
         Err(e) => {
-            println!("[skin] Failed to fetch skin for {username}: {e}");
+            log::warn!(target: "basalt::skin", "Failed to fetch skin for {username}: {e}");
             Vec::new()
         }
     }

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -64,11 +64,7 @@ impl ServerState {
         let mut event_bus = EventBus::new();
         let mut registrar = basalt_api::EventRegistrar::new(&mut event_bus);
         for plugin in &plugins {
-            println!(
-                "[plugins] Enabling {} v{}",
-                plugin.metadata().name,
-                plugin.metadata().version
-            );
+            log::info!(target: "basalt::plugin", "Enabling {} v{}", plugin.metadata().name, plugin.metadata().version);
             plugin.on_enable(&mut registrar);
         }
         Arc::new(Self {


### PR DESCRIPTION
## Summary

- Replace all ~40 `println!` in basalt-server with structured `log` macros (info/debug/trace/warn/error)
- Add `PluginLogger` to basalt-api: `ctx.logger()` returns a logger scoped to `basalt::plugin::<name>`
- Add `log_level` and `log_format` to basalt.toml `[server]` section
- Two log formats: `pretty` (human-readable with timestamps) and `json` (structured, one object per line)
- `RUST_LOG` env var overrides config for runtime adjustment

Log targets:
- `basalt::server` — server lifecycle (listening, startup)
- `basalt::connection` — protocol state machine (login, config, play transitions)
- `basalt::play` — play loop (join, disconnect, packets, blocks, chat)
- `basalt::skin` — Mojang API skin fetching
- `basalt::plugin` — plugin registration at startup
- `basalt::plugin::<name>` — per-plugin logs via PluginLogger

Log level assignment:
- `info` — server start, player join/leave, chat messages, commands, plugin loaded
- `debug` — protocol flow (Login/Config/Play), block break/place, chunk streaming, skin fetch
- `trace` — keep-alive RTT, teleport confirm, unknown packets, unhandled packets
- `warn` — skin fetch failure, keep-alive mismatch
- `error` — connection errors

## Test plan

- [x] 569 tests passing, 90.73% coverage
- [x] Zero println! remaining in basalt-server
- [x] PluginLogger unit tests (target format, no-panic on all levels)
- [x] Config tests for log_level and log_format parsing
- [ ] Manual: run server, verify log output in pretty and json formats
