### PR TITLE
feat(api): centralized command registration and DeclareCommands

### DIFF
--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -42,7 +42,7 @@ pub mod plugin;
 // Re-export core types at crate root for convenience.
 pub use broadcast::{BroadcastMessage, PlayerSnapshot, ProfileProperty};
 pub use context::{Response, ServerContext};
-pub use plugin::{EventRegistrar, Plugin, PluginMetadata};
+pub use plugin::{CommandEntry, Plugin, PluginMetadata, PluginRegistrar};
 
 // Re-export basalt-events types that plugins need.
 pub use basalt_events::{Event, EventBus, Stage};
@@ -59,6 +59,6 @@ pub mod prelude {
         BlockBrokenEvent, BlockPlacedEvent, ChatMessageEvent, CommandEvent, PlayerJoinedEvent,
         PlayerLeftEvent, PlayerMovedEvent,
     };
-    pub use crate::plugin::{EventRegistrar, Plugin, PluginMetadata};
+    pub use crate::plugin::{Plugin, PluginMetadata, PluginRegistrar};
     pub use basalt_events::Stage;
 }

--- a/crates/basalt-api/src/plugin.rs
+++ b/crates/basalt-api/src/plugin.rs
@@ -56,7 +56,7 @@ pub trait Plugin: Send + Sync + 'static {
     /// The `registrar` provides typed methods for subscribing to events
     /// at specific stages with priority ordering. This is the only way
     /// to register handlers.
-    fn on_enable(&self, registrar: &mut EventRegistrar);
+    fn on_enable(&self, registrar: &mut PluginRegistrar);
 
     /// Called when the plugin is disabled (server shutdown).
     ///
@@ -87,38 +87,42 @@ pub struct PluginMetadata {
     pub dependencies: &'static [&'static str],
 }
 
-/// Typed registration interface for event handlers.
-///
-/// Wraps [`EventBus`] and locks the context type to [`ServerContext`].
-/// Plugins use this to subscribe handlers without accessing the bus
-/// directly, which prevents registering handlers with a wrong context
-/// type.
-pub struct EventRegistrar<'a> {
-    bus: &'a mut EventBus,
+/// Handler function type for commands.
+pub type CommandHandler = Box<dyn Fn(&str, &ServerContext) + Send + Sync>;
+
+/// A registered command entry (name, description, handler).
+pub struct CommandEntry {
+    /// Command name without the leading `/`.
+    pub name: String,
+    /// Short description for help listing.
+    pub description: String,
+    /// The command handler function.
+    pub handler: CommandHandler,
 }
 
-impl<'a> EventRegistrar<'a> {
-    /// Creates a new registrar wrapping the given event bus.
-    pub fn new(bus: &'a mut EventBus) -> Self {
-        Self { bus }
+/// Plugin registration interface for events and commands.
+///
+/// Passed to [`Plugin::on_enable`] at startup. Plugins use it to
+/// register event handlers and commands. After all plugins are
+/// enabled, the server collects registered commands to build the
+/// `DeclareCommands` packet and the command dispatch table.
+pub struct PluginRegistrar<'a> {
+    bus: &'a mut EventBus,
+    commands: &'a mut Vec<CommandEntry>,
+}
+
+impl<'a> PluginRegistrar<'a> {
+    /// Creates a new registrar wrapping the given event bus and
+    /// command list.
+    pub fn new(bus: &'a mut EventBus, commands: &'a mut Vec<CommandEntry>) -> Self {
+        Self { bus, commands }
     }
 
-    /// Registers a handler for event type `E` at the given stage.
+    /// Registers an event handler for event type `E` at the given stage.
     ///
     /// Lower priority values run first within the same stage.
     /// The handler receives a mutable reference to the event and
     /// a shared reference to [`ServerContext`].
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// registrar.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, ctx| {
-    ///     // Check permissions, optionally cancel
-    ///     if !can_build(ctx.player_uuid()) {
-    ///         event.cancel();
-    ///     }
-    /// });
-    /// ```
     pub fn on<E>(
         &mut self,
         stage: Stage,
@@ -129,7 +133,37 @@ impl<'a> EventRegistrar<'a> {
     {
         self.bus.on::<E, ServerContext>(stage, priority, handler);
     }
+
+    /// Registers a command that players can invoke with `/<name>`.
+    ///
+    /// The handler receives the argument string (everything after
+    /// the command name) and the server context.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// registrar.register_command("home", "Teleport to spawn", |args, ctx| {
+    ///     ctx.teleport(0.0, 64.0, 0.0, 0.0, 0.0);
+    ///     ctx.send_message("Teleported home!");
+    /// });
+    /// ```
+    pub fn register_command(
+        &mut self,
+        name: &str,
+        description: &str,
+        handler: impl Fn(&str, &ServerContext) + Send + Sync + 'static,
+    ) {
+        self.commands.push(CommandEntry {
+            name: name.to_string(),
+            description: description.to_string(),
+            handler: Box::new(handler),
+        });
+    }
 }
+
+/// Backward-compatible alias.
+#[deprecated(note = "renamed to PluginRegistrar")]
+pub type EventRegistrar<'a> = PluginRegistrar<'a>;
 
 #[cfg(test)]
 mod tests {
@@ -147,7 +181,7 @@ mod tests {
             }
         }
 
-        fn on_enable(&self, _registrar: &mut EventRegistrar) {
+        fn on_enable(&self, _registrar: &mut PluginRegistrar) {
             // no-op for metadata test
         }
     }
@@ -173,10 +207,24 @@ mod tests {
         use crate::events::ChatMessageEvent;
 
         let mut bus = EventBus::new();
+        let mut commands = Vec::new();
         {
-            let mut registrar = EventRegistrar::new(&mut bus);
+            let mut registrar = PluginRegistrar::new(&mut bus, &mut commands);
             registrar.on::<ChatMessageEvent>(Stage::Post, 0, |_event, _ctx| {});
         }
         assert_eq!(bus.handler_count(), 1);
+    }
+
+    #[test]
+    fn registrar_registers_command() {
+        let mut bus = EventBus::new();
+        let mut commands = Vec::new();
+        {
+            let mut registrar = PluginRegistrar::new(&mut bus, &mut commands);
+            registrar.register_command("test", "A test command", |_args, _ctx| {});
+        }
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "test");
+        assert_eq!(commands[0].description, "A test command");
     }
 }

--- a/crates/basalt-command/Cargo.toml
+++ b/crates/basalt-command/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 
 [dependencies]
 basalt-api = { workspace = true }
+basalt-types = { workspace = true }
 
 [dev-dependencies]
-basalt-types = { workspace = true }
 basalt-world = { workspace = true }

--- a/crates/basalt-server/src/config.rs
+++ b/crates/basalt-server/src/config.rs
@@ -274,7 +274,6 @@ impl ServerConfig {
         if self.plugins.block {
             plugins.push(Box::new(basalt_plugin_block::BlockPlugin));
         }
-        // StoragePlugin is only active in read-write mode
         if self.plugins.block && self.world.storage == StorageMode::ReadWrite {
             plugins.push(Box::new(basalt_plugin_storage::StoragePlugin));
         }

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -11,7 +11,9 @@ use std::time::Instant;
 
 use basalt_net::connection::{Connection, Play};
 use basalt_protocol::packets::play::ServerboundPlayPacket;
-use basalt_protocol::packets::play::chat::ClientboundPlaySystemChat;
+use basalt_protocol::packets::play::chat::{
+    ClientboundPlayDeclareCommands, ClientboundPlaySystemChat,
+};
 use basalt_protocol::packets::play::entity::{
     ClientboundPlayEntityDestroy, ClientboundPlayEntityHeadRotation, ClientboundPlaySpawnEntity,
     ClientboundPlaySyncEntityPosition,
@@ -49,6 +51,7 @@ pub(crate) async fn run_play_loop(
     existing_players: &[PlayerSnapshot],
 ) -> crate::error::Result<()> {
     send_initial_world(&mut conn, addr, player, state).await?;
+    send_declare_commands(&mut conn, addr, state).await?;
 
     // Send the player's own PlayerInfo so they appear in their own Tab list
     let self_snapshot = PlayerSnapshot {
@@ -162,6 +165,26 @@ async fn send_initial_world(
         .await?;
     log::debug!(target: "basalt::play", "[{addr}] -> Position ({}, {}, {})", player.x, player.y, player.z);
 
+    Ok(())
+}
+
+/// Sends the DeclareCommands packet for client tab-completion.
+///
+/// Skipped if no commands are registered (command plugin disabled).
+async fn send_declare_commands(
+    conn: &mut Connection<Play>,
+    addr: SocketAddr,
+    state: &Arc<ServerState>,
+) -> crate::error::Result<()> {
+    if state.declare_commands.is_empty() {
+        return Ok(());
+    }
+    conn.write_packet_typed(
+        ClientboundPlayDeclareCommands::PACKET_ID,
+        &RawPayload(state.declare_commands.clone()),
+    )
+    .await?;
+    log::debug!(target: "basalt::play", "[{addr}] -> DeclareCommands");
     Ok(())
 }
 

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -26,6 +26,8 @@ pub(crate) struct ServerState {
     pub world: basalt_world::World,
     /// Event bus with registered plugin handlers.
     pub event_bus: EventBus,
+    /// Pre-built DeclareCommands packet payload (empty if no commands).
+    pub declare_commands: Vec<u8>,
 }
 
 /// A handle to a connected player, stored in the server state registry.
@@ -54,24 +56,62 @@ impl ServerState {
 
     /// Creates a server state with a given world and plugin set.
     ///
-    /// Each plugin's `on_enable` is called with an `EventRegistrar`
-    /// to register its event handlers on the bus.
+    /// Each plugin's `on_enable` is called with a `PluginRegistrar`
+    /// to register event handlers and commands. After all plugins
+    /// are enabled, the collected commands are used to build the
+    /// `DeclareCommands` packet and the command dispatch handler.
     pub fn with_world_and_plugins(
         world: basalt_world::World,
         plugins: Vec<Box<dyn basalt_api::Plugin>>,
     ) -> Arc<Self> {
         let (broadcast_tx, _) = broadcast::channel(256);
         let mut event_bus = EventBus::new();
-        let mut registrar = basalt_api::EventRegistrar::new(&mut event_bus);
-        for plugin in &plugins {
-            log::info!(target: "basalt::plugin", "Enabling {} v{}", plugin.metadata().name, plugin.metadata().version);
-            plugin.on_enable(&mut registrar);
+        let mut commands = Vec::new();
+        {
+            let mut registrar = basalt_api::PluginRegistrar::new(&mut event_bus, &mut commands);
+            for plugin in &plugins {
+                log::info!(target: "basalt::plugin", "Enabling {} v{}", plugin.metadata().name, plugin.metadata().version);
+                plugin.on_enable(&mut registrar);
+            }
         }
+
+        // Build DeclareCommands packet from all registered commands
+        let declare_commands = build_declare_commands(&commands);
+
+        // Register command dispatch handler on the event bus
+        if !commands.is_empty() {
+            let commands: Vec<basalt_api::CommandEntry> = commands.into_iter().collect();
+            let commands = std::sync::Arc::new(commands);
+            event_bus.on::<basalt_api::events::CommandEvent, basalt_api::context::ServerContext>(
+                basalt_events::Stage::Process,
+                -100, // high priority — runs before other Process handlers
+                move |event, ctx| {
+                    let parts: Vec<&str> = event.command.splitn(2, ' ').collect();
+                    let cmd = parts[0];
+                    let args = parts.get(1).copied().unwrap_or("");
+                    let found = commands.iter().find(|c| c.name == cmd);
+                    if let Some(entry) = found {
+                        (entry.handler)(args, ctx);
+                    } else {
+                        ctx.send_message_component(
+                            &basalt_types::TextComponent::text(format!("Unknown command: /{cmd}"))
+                                .color(basalt_types::TextColor::Named(
+                                    basalt_types::NamedColor::Red,
+                                )),
+                        );
+                    }
+                },
+            );
+        }
+
+        log::info!(target: "basalt::server", "Registered {} commands", declare_commands.1);
+
         Arc::new(Self {
             next_entity_id: AtomicI32::new(1),
             players: DashMap::new(),
             broadcast_tx,
             world,
+            declare_commands: declare_commands.0,
             event_bus,
         })
     }
@@ -134,6 +174,48 @@ impl ServerState {
     pub fn player_count(&self) -> usize {
         self.players.len()
     }
+}
+
+/// Builds the raw DeclareCommands packet payload from registered commands.
+///
+/// Returns (payload_bytes, command_count). The Brigadier tree has a root
+/// node with one literal child per command, all marked as executable.
+fn build_declare_commands(commands: &[basalt_api::CommandEntry]) -> (Vec<u8>, usize) {
+    use basalt_types::{Encode, VarInt};
+
+    let count = commands.len();
+    if count == 0 {
+        return (Vec::new(), 0);
+    }
+
+    let mut buf = Vec::new();
+
+    // Total nodes = 1 root + N literals
+    VarInt((count + 1) as i32).encode(&mut buf).unwrap();
+
+    // Node 0: root (type=0, children=[1..=N])
+    0u8.encode(&mut buf).unwrap(); // flags = root
+    VarInt(count as i32).encode(&mut buf).unwrap();
+    for i in 1..=count {
+        VarInt(i as i32).encode(&mut buf).unwrap();
+    }
+
+    // Nodes 1..N: literal nodes, sorted by name
+    let mut names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+    names.sort();
+    for name in names {
+        let flags: u8 = 0x01 | 0x04; // type=literal, executable
+        flags.encode(&mut buf).unwrap();
+        VarInt(0).encode(&mut buf).unwrap(); // no children
+        // Minecraft string: VarInt length + UTF-8 bytes
+        VarInt(name.len() as i32).encode(&mut buf).unwrap();
+        buf.extend_from_slice(name.as_bytes());
+    }
+
+    // root_index = 0
+    VarInt(0).encode(&mut buf).unwrap();
+
+    (buf, count)
 }
 
 #[cfg(test)]

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for BlockPlugin {
         }
     }
 
-    fn on_enable(&self, registrar: &mut EventRegistrar) {
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
         // Process: mutate world state
         registrar.on::<BlockBrokenEvent>(Stage::Process, 0, |event, ctx| {
             ctx.world()
@@ -85,7 +85,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         BlockPlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 
@@ -119,7 +120,8 @@ mod tests {
 
         let mut bus = EventBus::new();
         // Validate handler cancels
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         registrar.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, _| {
             event.cancel();
         });

--- a/plugins/chat/src/lib.rs
+++ b/plugins/chat/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for ChatPlugin {
         }
     }
 
-    fn on_enable(&self, registrar: &mut EventRegistrar) {
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<ChatMessageEvent>(Stage::Post, 0, |event, ctx| {
             let component = build_chat_component(&event.username, &event.message);
             ctx.broadcast_message_component(&component);
@@ -61,7 +61,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         ChatPlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -9,10 +9,8 @@ pub mod commands;
 
 use std::sync::Arc;
 
-use basalt_api::events::CommandEvent;
 use basalt_api::prelude::*;
 use basalt_command::CommandRegistry;
-use basalt_types::{NamedColor, TextColor, TextComponent};
 
 use commands::{
     GamemodeCommand, HelpCommand, KickCommand, ListCommand, SayCommand, StopCommand, TpCommand,
@@ -96,20 +94,19 @@ impl Plugin for CommandPlugin {
         }
     }
 
-    fn on_enable(&self, registrar: &mut EventRegistrar) {
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
+        // Register each command from the internal registry
+        // on the plugin registrar so the server collects them all.
         let registry = Arc::clone(&self.registry);
-        registrar.on::<CommandEvent>(Stage::Process, 0, move |event, ctx| {
-            let parts: Vec<&str> = event.command.splitn(2, ' ').collect();
-            let cmd = parts[0];
-            let args = parts.get(1).copied().unwrap_or("");
-
-            if !registry.execute(cmd, args, ctx) {
-                ctx.send_message_component(
-                    &TextComponent::text(format!("Unknown command: /{cmd}"))
-                        .color(TextColor::Named(NamedColor::Red)),
-                );
-            }
-        });
+        for cmd in registry.commands() {
+            let name = cmd.name();
+            let desc = cmd.description();
+            let reg = Arc::clone(&registry);
+            let cmd_name = name.to_string();
+            registrar.register_command(name, desc, move |args, ctx| {
+                reg.execute(&cmd_name, args, ctx);
+            });
+        }
     }
 }
 
@@ -133,17 +130,24 @@ mod tests {
 
     fn dispatch_command(cmd: &str) -> Vec<Response> {
         let ctx = test_ctx();
-        let mut event = CommandEvent {
-            command: cmd.into(),
-            player_uuid: Uuid::default(),
-            cancelled: false,
-        };
 
+        // Collect commands from the plugin
         let plugin = CommandPlugin::new();
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
-        plugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
+        let mut cmds = Vec::new();
+        {
+            let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
+            plugin.on_enable(&mut registrar);
+        }
+
+        // Dispatch like the server does: find and call the handler
+        let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
+        let name = parts[0];
+        let args = parts.get(1).copied().unwrap_or("");
+        let entry = cmds.iter().find(|c| c.name == name);
+        if let Some(entry) = entry {
+            (entry.handler)(args, &ctx);
+        }
         ctx.drain_responses()
     }
 
@@ -183,10 +187,11 @@ mod tests {
     }
 
     #[test]
-    fn unknown_command() {
+    fn unknown_command_returns_empty() {
+        // Unknown command handling is done by the server, not the plugin.
+        // The plugin only registers known commands.
         let responses = dispatch_command("foobar");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+        assert!(responses.is_empty());
     }
 
     #[test]

--- a/plugins/lifecycle/src/lib.rs
+++ b/plugins/lifecycle/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for LifecyclePlugin {
         }
     }
 
-    fn on_enable(&self, registrar: &mut EventRegistrar) {
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<PlayerJoinedEvent>(Stage::Post, 0, |event, ctx| {
             ctx.broadcast(BroadcastMessage::PlayerJoined {
                 info: event.info.clone(),
@@ -70,7 +70,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         LifecyclePlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 
@@ -92,7 +93,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         LifecyclePlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 

--- a/plugins/movement/src/lib.rs
+++ b/plugins/movement/src/lib.rs
@@ -20,7 +20,7 @@ impl Plugin for MovementPlugin {
         }
     }
 
-    fn on_enable(&self, registrar: &mut EventRegistrar) {
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<PlayerMovedEvent>(Stage::Post, 0, |event, ctx| {
             ctx.broadcast(BroadcastMessage::EntityMoved {
                 entity_id: event.entity_id,
@@ -65,7 +65,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         MovementPlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 

--- a/plugins/storage/src/lib.rs
+++ b/plugins/storage/src/lib.rs
@@ -26,7 +26,7 @@ impl Plugin for StoragePlugin {
         }
     }
 
-    fn on_enable(&self, registrar: &mut EventRegistrar) {
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<BlockBrokenEvent>(Stage::Post, 10, |event, ctx| {
             ctx.world().persist_chunk(event.x >> 4, event.z >> 4);
         });
@@ -62,7 +62,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         // Block plugin sets the block, storage plugin persists
         basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
         StoragePlugin.on_enable(&mut registrar);

--- a/plugins/world/src/lib.rs
+++ b/plugins/world/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for WorldPlugin {
         }
     }
 
-    fn on_enable(&self, registrar: &mut EventRegistrar) {
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<PlayerMovedEvent>(Stage::Process, 0, |event, ctx| {
             let new_cx = (event.x as i32) >> 4;
             let new_cz = (event.z as i32) >> 4;
@@ -62,7 +62,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         WorldPlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 
@@ -93,7 +94,8 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        let mut registrar = EventRegistrar::new(&mut bus);
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
         WorldPlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 


### PR DESCRIPTION
## Summary

- Rename `EventRegistrar` to `PluginRegistrar` — it now handles both events and commands
- Add `register_command(name, description, handler)` to `PluginRegistrar` — any plugin can register commands
- Server collects ALL registered commands after plugin init, builds a unified `CommandEvent` dispatch handler and a `DeclareCommands` Brigadier packet
- `send_declare_commands()` sends the packet to clients during play init for tab-completion
- `CommandPlugin` now uses `register_command()` instead of directly registering event handlers
- Any external plugin can register commands that automatically get tab-completion

Architecture: commands registered via `PluginRegistrar` → server collects → builds DeclareCommands tree + dispatch handler → client gets tab-completion, server dispatches on CommandEvent

Closes #56

## Test plan

- [x] PluginRegistrar registers commands and events
- [x] CommandPlugin commands work through the new dispatch path
- [x] All 579 workspace tests passing
- [x] 90.72% coverage
- [ ] Manual: connect with Minecraft 1.21.4, verify tab-completion shows all commands
