### PR TITLE
fix: quick bugfixes from codebase review

### DIFF
--- a/crates/basalt-net/src/compression.rs
+++ b/crates/basalt-net/src/compression.rs
@@ -25,7 +25,8 @@ pub fn compress_packet(data: &[u8], threshold: usize) -> Result<Vec<u8>> {
             .encode(&mut result)
             .map_err(|e| Error::Protocol(basalt_protocol::Error::Type(e)))?;
 
-        let mut encoder = ZlibEncoder::new(&mut result, Compression::default());
+        // Level 3 favors speed over ratio — better for game server latency
+        let mut encoder = ZlibEncoder::new(&mut result, Compression::new(3));
         encoder.write_all(data).map_err(Error::Io)?;
         encoder.finish().map_err(Error::Io)?;
     } else {

--- a/crates/basalt-net/src/connection.rs
+++ b/crates/basalt-net/src/connection.rs
@@ -152,15 +152,23 @@ impl Connection<Login> {
         self.write_packet(ClientboundLoginSuccess::PACKET_ID, success)
             .await?;
 
-        // Read packets until LoginAcknowledged
+        // Read packets until LoginAcknowledged, with a limit to prevent
+        // malicious clients from stalling the server indefinitely
+        let mut attempts = 0;
         loop {
             let raw = self.read_raw().await?;
+            attempts += 1;
+            if attempts > 100 {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "client did not send LoginAcknowledged after 100 packets",
+                )));
+            }
             let mut cursor = raw.payload.as_slice();
             let packet = ServerboundLoginPacket::decode_by_id(raw.id, &mut cursor)?;
             if let ServerboundLoginPacket::LoginAcknowledged(_) = packet {
                 return Ok(self.transition());
             }
-            // Ignore other login packets
         }
     }
 
@@ -215,8 +223,12 @@ impl Connection<Configuration> {
                 Ok(ServerboundConfigurationPacket::FinishConfiguration(_)) => {
                     return Ok(self.transition());
                 }
-                Ok(_) => {}  // Ignore known non-finish packets
-                Err(_) => {} // Ignore unknown/common packets (settings, brand, etc.)
+                Ok(_) => {} // Ignore known non-finish packets
+                Err(_) => {
+                    // Unknown or common packets (settings, brand, resource packs)
+                    // are expected here — the client sends optional config data
+                    // that our codegen may not cover
+                }
             }
         }
     }

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -65,7 +65,13 @@ impl Server {
     pub async fn run(&self) {
         self.config.init_logger();
 
-        let listener = TcpListener::bind(&self.config.server.bind).await.unwrap();
+        let listener = match TcpListener::bind(&self.config.server.bind).await {
+            Ok(l) => l,
+            Err(e) => {
+                log::error!(target: "basalt::server", "Failed to bind {}: {e}", self.config.server.bind);
+                return;
+            }
+        };
         log::info!(target: "basalt::server", "Listening on {}", self.config.server.bind);
 
         let world = self.config.create_world();
@@ -91,7 +97,13 @@ impl Server {
     /// Accepts connections with an existing server state.
     async fn accept_loop_with_state(listener: TcpListener, state: Arc<ServerState>) {
         loop {
-            let (stream, addr) = listener.accept().await.unwrap();
+            let (stream, addr) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    log::error!(target: "basalt::connection", "Accept failed: {e}");
+                    continue;
+                }
+            };
             log::debug!(target: "basalt::connection", "[{addr}] Accepted");
 
             let state = Arc::clone(&state);

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -338,8 +338,14 @@ async fn play_loop(
                     }
                 }
             }
-            Ok(msg) = rx.recv() => {
-                handle_broadcast(conn, player, msg).await?;
+            result = rx.recv() => {
+                match result {
+                    Ok(msg) => handle_broadcast(conn, player, msg).await?,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        log::warn!(target: "basalt::play", "[{addr}] {} missed {n} broadcast messages", player.username);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
             }
         }
     }

--- a/crates/basalt-server/src/skin.rs
+++ b/crates/basalt-server/src/skin.rs
@@ -70,11 +70,15 @@ pub(crate) async fn fetch_skin_properties(username: &str) -> Vec<ProfileProperty
     }
 }
 
+/// Shared HTTP client to avoid allocating a connection pool per request.
+static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
+    std::sync::LazyLock::new(reqwest::Client::new);
+
 /// Inner implementation that returns Result for error handling.
 async fn fetch_skin_inner(
     username: &str,
 ) -> Result<Vec<ProfileProperty>, Box<dyn std::error::Error>> {
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
 
     // Step 1: username → UUID
     let url = format!("https://api.mojang.com/users/profiles/minecraft/{username}");

--- a/crates/basalt-types/src/byte_array.rs
+++ b/crates/basalt-types/src/byte_array.rs
@@ -27,7 +27,13 @@ impl Decode for Vec<u8> {
     /// Fails with `Error::BufferUnderflow` if the buffer is shorter
     /// than the declared length.
     fn decode(buf: &mut &[u8]) -> Result<Self> {
-        let len = VarInt::decode(buf)?.0 as usize;
+        let raw_len = VarInt::decode(buf)?.0;
+        if raw_len < 0 {
+            return Err(Error::InvalidData(format!(
+                "negative byte array length: {raw_len}"
+            )));
+        }
+        let len = raw_len as usize;
         if buf.len() < len {
             return Err(Error::BufferUnderflow {
                 needed: len,

--- a/crates/basalt-types/src/opaque.rs
+++ b/crates/basalt-types/src/opaque.rs
@@ -58,7 +58,13 @@ impl Encode for OpaqueBytes {
 impl Decode for OpaqueBytes {
     /// Decodes a VarInt length prefix then reads that many bytes.
     fn decode(buf: &mut &[u8]) -> Result<Self> {
-        let len = VarInt::decode(buf)?.0 as usize;
+        let raw_len = VarInt::decode(buf)?.0;
+        if raw_len < 0 {
+            return Err(Error::InvalidData(format!(
+                "negative opaque length: {raw_len}"
+            )));
+        }
+        let len = raw_len as usize;
         if buf.len() < len {
             return Err(Error::BufferUnderflow {
                 needed: len,

--- a/crates/basalt-types/src/string.rs
+++ b/crates/basalt-types/src/string.rs
@@ -41,7 +41,13 @@ impl Decode for String {
     /// the declared length, or `Error::InvalidUtf8` if the bytes are not
     /// valid UTF-8.
     fn decode(buf: &mut &[u8]) -> Result<Self> {
-        let len = VarInt::decode(buf)?.0 as usize;
+        let raw_len = VarInt::decode(buf)?.0;
+        if raw_len < 0 {
+            return Err(Error::InvalidData(format!(
+                "negative string length: {raw_len}"
+            )));
+        }
+        let len = raw_len as usize;
         if len > MAX_STRING_BYTES {
             return Err(Error::StringTooLong {
                 len,

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -277,6 +277,44 @@ mod tests {
     }
 
     #[test]
+    fn stop_command() {
+        let responses = dispatch_command("stop");
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::Broadcast(basalt_api::BroadcastMessage::Chat { .. })
+        ));
+    }
+
+    #[test]
+    fn kick_command() {
+        let responses = dispatch_command("kick Steve");
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+    }
+
+    #[test]
+    fn list_command() {
+        let responses = dispatch_command("list");
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+    }
+
+    #[test]
+    fn tp_invalid_coords() {
+        let responses = dispatch_command("tp abc def ghi");
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+    }
+
+    #[test]
+    fn gamemode_survival() {
+        let responses = dispatch_command("gamemode survival");
+        assert_eq!(responses.len(), 2);
+        assert!(matches!(responses[0], Response::SendGameStateChange { .. }));
+    }
+
+    #[test]
     fn unknown_command_returns_empty() {
         let responses = dispatch_command("foobar");
         assert!(responses.is_empty());

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -123,7 +123,7 @@ impl Plugin for CommandPlugin {
                     .append(
                         TextComponent::text(message).color(TextColor::Named(NamedColor::White)),
                     );
-                ctx.send_message_component(&msg);
+                ctx.broadcast_message_component(&msg);
             });
 
         // /stop
@@ -263,7 +263,10 @@ mod tests {
     fn say_message() {
         let responses = dispatch_command("say hello world");
         assert_eq!(responses.len(), 1);
-        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+        assert!(matches!(
+            responses[0],
+            Response::Broadcast(basalt_api::BroadcastMessage::Chat { .. })
+        ));
     }
 
     #[test]

--- a/plugins/world/src/lib.rs
+++ b/plugins/world/src/lib.rs
@@ -23,8 +23,8 @@ impl Plugin for WorldPlugin {
 
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<PlayerMovedEvent>(Stage::Process, 0, |event, ctx| {
-            let new_cx = (event.x as i32) >> 4;
-            let new_cz = (event.z as i32) >> 4;
+            let new_cx = (event.x.floor() as i32) >> 4;
+            let new_cz = (event.z.floor() as i32) >> 4;
             if new_cx != event.old_cx || new_cz != event.old_cz {
                 ctx.stream_chunks(new_cx, new_cz);
             }
@@ -74,6 +74,39 @@ mod tests {
             Response::StreamChunks {
                 new_cx: 1,
                 new_cz: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn negative_coordinate_chunk_boundary() {
+        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        // x=-0.5 is in chunk -1, not chunk 0 (floor before shift)
+        let mut event = PlayerMovedEvent {
+            entity_id: 1,
+            x: -0.5,
+            y: 64.0,
+            z: -0.5,
+            yaw: 0.0,
+            pitch: 0.0,
+            on_ground: true,
+            old_cx: 0,
+            old_cz: 0,
+        };
+
+        let mut bus = EventBus::new();
+        let mut cmds = Vec::new();
+        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
+        WorldPlugin.on_enable(&mut registrar);
+        bus.dispatch(&mut event, &ctx);
+
+        let responses = ctx.drain_responses();
+        assert_eq!(responses.len(), 1);
+        assert!(matches!(
+            responses[0],
+            Response::StreamChunks {
+                new_cx: -1,
+                new_cz: -1
             }
         ));
     }


### PR DESCRIPTION
## Summary

Independent quick fixes from the codebase review, each in its own commit:

- **fix(command)**: `/say` now broadcasts to all players instead of only the sender
- **fix(world)**: negative coordinate chunk calculation uses `floor()` before cast
- **fix(server)**: broadcast channel `Lagged` errors are logged instead of silently dropped
- **fix(net)**: login ack wait loop limited to 100 packets to prevent client DoS
- **fix(server)**: bind/accept errors handled gracefully instead of panicking
- **fix(net)**: zlib compression level 3 for better latency
- **fix(server)**: shared `reqwest::Client` via `LazyLock` for skin fetching
- **fix(types)**: negative VarInt lengths rejected in string, byte array, and opaque decoders

## Test plan

- [ ] `cargo test` passes (598 tests, +1 new negative coord test)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Verify `/say` broadcasts in-game
- [ ] Verify chunk streaming works at negative coordinates
