### PR TITLE
fix(derive): support element_varint in enum variant fields

### DIFF
--- a/crates/basalt-derive/src/decode.rs
+++ b/crates/basalt-derive/src/decode.rs
@@ -177,6 +177,19 @@ fn derive_decode_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStrea
                                     }
                                 };
                             }
+                        } else if attr.length_varint && attr.element_varint {
+                            quote! {
+                                let #fname = {
+                                    let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                                    let len = len.0 as usize;
+                                    let mut items = Vec::with_capacity(len);
+                                    for _ in 0..len {
+                                        let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                                        items.push(var.0);
+                                    }
+                                    items
+                                };
+                            }
                         } else if attr.length_varint {
                             quote! {
                                 let #fname = {

--- a/crates/basalt-derive/src/encode.rs
+++ b/crates/basalt-derive/src/encode.rs
@@ -169,6 +169,13 @@ fn derive_encode_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStrea
                                     }
                                 }
                             }
+                        } else if attr.length_varint && attr.element_varint {
+                            quote! {
+                                basalt_types::Encode::encode(&basalt_types::VarInt(#fname.len() as i32), buf)?;
+                                for item in #fname {
+                                    basalt_types::Encode::encode(&basalt_types::VarInt(*item), buf)?;
+                                }
+                            }
                         } else if attr.length_varint {
                             quote! {
                                 basalt_types::Encode::encode(&basalt_types::VarInt(#fname.len() as i32), buf)?;

--- a/crates/basalt-derive/src/size.rs
+++ b/crates/basalt-derive/src/size.rs
@@ -149,6 +149,11 @@ fn derive_encoded_size_enum(input: &DeriveInput, data: &DataEnum) -> Result<Toke
                                     None => 0,
                                 }
                             }
+                        } else if attr.length_varint && attr.element_varint {
+                            quote! {
+                                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#fname.len() as i32))
+                                + #fname.iter().map(|item| basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(*item))).sum::<usize>()
+                            }
                         } else if attr.length_varint {
                             quote! {
                                 basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#fname.len() as i32))

--- a/crates/basalt-protocol/src/derive_tests.rs
+++ b/crates/basalt-protocol/src/derive_tests.rs
@@ -210,6 +210,40 @@ fn element_varint_empty() {
     assert_eq!(decoded, original);
 }
 
+// -- Element VarInt in enum variant --
+
+/// Tests that `element = "varint"` works inside enum variants,
+/// not just structs. Previously this was silently ignored.
+#[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]
+enum VarIntArrayEnum {
+    #[variant(id = 0)]
+    Empty,
+    #[variant(id = 1)]
+    WithIds {
+        #[field(length = "varint", element = "varint")]
+        ids: Vec<i32>,
+    },
+}
+
+#[test]
+fn element_varint_enum_variant_roundtrip() {
+    let original = VarIntArrayEnum::WithIds {
+        ids: vec![1, 128, -1],
+    };
+    let mut buf = Vec::with_capacity(original.encoded_size());
+    original.encode(&mut buf).unwrap();
+    assert_eq!(buf.len(), original.encoded_size());
+
+    // VarInt(1) discriminant + VarInt(3) length + VarInt(1) + VarInt(128) + VarInt(-1)
+    // = 1 + 1 + 1 + 2 + 5 = 10 bytes
+    assert_eq!(buf.len(), 10);
+
+    let mut cursor = buf.as_slice();
+    let decoded = VarIntArrayEnum::decode(&mut cursor).unwrap();
+    assert!(cursor.is_empty());
+    assert_eq!(decoded, original);
+}
+
 // -- Rest field --
 
 #[derive(Debug, PartialEq, Encode, Decode, EncodedSize)]


### PR DESCRIPTION
## Summary

- **element_varint in enum variants**: The `#[field(length = "varint", element = "varint")]` attribute combination was silently ignored when used inside enum variant fields. Only the struct code path handled it. Added the missing `element_varint` check to encode, decode, and size codegen for enum variants. Added a roundtrip test verifying correct wire format.

## Test plan

- [ ] `cargo test` passes (598 tests, +1 new enum element_varint test)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] New test verifies VarInt element encoding in enum variant (10 bytes expected)
