### PR TITLE
refactor(api): Gamemode enum, PluginLogger improvement, event derives

### DIFF
--- a/crates/basalt-api/src/context.rs
+++ b/crates/basalt-api/src/context.rs
@@ -7,10 +7,19 @@
 
 use std::cell::RefCell;
 
+use std::sync::atomic::{AtomicI32, Ordering};
+
 use basalt_core::broadcast::BroadcastMessage;
+use basalt_core::gamemode::Gamemode;
 use basalt_core::{Context, PluginLogger};
 use basalt_types::nbt::NbtCompound;
 use basalt_types::{TextComponent, Uuid};
+
+/// Game state change reason codes from the Minecraft protocol.
+///
+/// Used in the GameStateChange packet (0x22) to indicate what kind of
+/// state change is being communicated to the client.
+const GAME_STATE_CHANGE_GAMEMODE: u8 = 3;
 
 /// Context available to event handlers during dispatch.
 ///
@@ -32,7 +41,12 @@ pub struct ServerContext {
     plugin_name: RefCell<String>,
     /// Registered command list (name, description) for /help.
     command_list: RefCell<Vec<(String, String)>>,
+    /// Monotonically increasing teleport ID counter shared across dispatches.
+    teleport_counter: &'static AtomicI32,
 }
+
+/// Global teleport ID counter shared across all server contexts.
+static GLOBAL_TELEPORT_COUNTER: AtomicI32 = AtomicI32::new(1);
 
 impl ServerContext {
     /// Creates a new context for a single event dispatch.
@@ -50,6 +64,7 @@ impl ServerContext {
             player_username,
             plugin_name: RefCell::new(String::new()),
             command_list: RefCell::new(Vec::new()),
+            teleport_counter: &GLOBAL_TELEPORT_COUNTER,
         }
     }
 
@@ -128,8 +143,9 @@ impl Context for ServerContext {
     }
 
     fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32) {
+        let teleport_id = self.teleport_counter.fetch_add(1, Ordering::Relaxed);
         self.responses.push(Response::SendPosition {
-            teleport_id: 2,
+            teleport_id,
             x,
             y,
             z,
@@ -138,10 +154,10 @@ impl Context for ServerContext {
         });
     }
 
-    fn set_gamemode(&self, mode: u8) {
+    fn set_gamemode(&self, mode: Gamemode) {
         self.responses.push(Response::SendGameStateChange {
-            reason: 3,
-            value: mode as f32,
+            reason: GAME_STATE_CHANGE_GAMEMODE,
+            value: mode.id() as f32,
         });
     }
 
@@ -279,12 +295,15 @@ mod tests {
     #[test]
     fn set_gamemode_queues_state_change() {
         let ctx = test_ctx();
-        ctx.set_gamemode(1);
+        ctx.set_gamemode(Gamemode::Creative);
         let responses = ctx.drain_responses();
         assert_eq!(responses.len(), 1);
         assert!(matches!(
             responses[0],
-            Response::SendGameStateChange { reason: 3, .. }
+            Response::SendGameStateChange {
+                reason: GAME_STATE_CHANGE_GAMEMODE,
+                ..
+            }
         ));
     }
 

--- a/crates/basalt-api/src/events.rs
+++ b/crates/basalt-api/src/events.rs
@@ -81,6 +81,7 @@ macro_rules! event {
 /// Fired when the server receives a `BlockDig` packet with status 0.
 /// If cancelled, the block remains unchanged and no acknowledgement
 /// or broadcast is sent.
+#[derive(Debug, Clone)]
 pub struct BlockBrokenEvent {
     /// Block X coordinate (absolute world coordinates).
     pub x: i32,
@@ -102,6 +103,7 @@ cancellable_event!(BlockBrokenEvent);
 /// Fired when the server receives a `BlockPlace` packet with a valid
 /// held item that maps to a block state. The placement position has
 /// already been computed from the target block + face offset.
+#[derive(Debug, Clone)]
 pub struct BlockPlacedEvent {
     /// Placement X coordinate (absolute world coordinates).
     pub x: i32,
@@ -126,6 +128,7 @@ cancellable_event!(BlockPlacedEvent);
 /// state. Carries the previous chunk coordinates for chunk boundary
 /// detection. Not cancellable — the server is not authoritative for
 /// position in vanilla Minecraft.
+#[derive(Debug, Clone)]
 pub struct PlayerMovedEvent {
     /// The moving player's entity ID.
     pub entity_id: i32,
@@ -151,6 +154,7 @@ event!(PlayerMovedEvent);
 /// A player sent a chat message.
 ///
 /// If cancelled, the message is not broadcast to any player.
+#[derive(Debug, Clone)]
 pub struct ChatMessageEvent {
     /// The sender's username.
     pub username: String,
@@ -164,6 +168,7 @@ cancellable_event!(ChatMessageEvent);
 /// A player issued a command (e.g., `/tp 0 64 0`).
 ///
 /// If cancelled, the command is not executed.
+#[derive(Debug, Clone)]
 pub struct CommandEvent {
     /// The command string without the leading `/`.
     pub command: String,
@@ -177,6 +182,7 @@ cancellable_event!(CommandEvent);
 /// A new player has joined the server and entered the Play state.
 ///
 /// Not cancellable — the player is already connected.
+#[derive(Debug, Clone)]
 pub struct PlayerJoinedEvent {
     /// Snapshot of the joining player's state.
     pub info: PlayerSnapshot,
@@ -186,6 +192,7 @@ event!(PlayerJoinedEvent);
 /// A player has disconnected from the server.
 ///
 /// Not cancellable — the connection is already closed.
+#[derive(Debug, Clone)]
 pub struct PlayerLeftEvent {
     /// The leaving player's UUID.
     pub uuid: Uuid,

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -11,7 +11,7 @@ pub mod logger;
 pub mod plugin;
 
 // Re-export core types for convenience.
-pub use basalt_core::{BroadcastMessage, Context, PlayerSnapshot, ProfileProperty};
+pub use basalt_core::{BroadcastMessage, Context, Gamemode, PlayerSnapshot, ProfileProperty};
 pub use context::{Response, ServerContext};
 pub use plugin::{CommandEntry, Plugin, PluginMetadata, PluginRegistrar};
 
@@ -24,7 +24,7 @@ pub use basalt_events::{Event, EventBus, Stage};
 /// Prelude module for convenient glob imports.
 pub mod prelude {
     pub use basalt_command::{Arg, CommandArgs, Validation};
-    pub use basalt_core::{BroadcastMessage, Context, PlayerSnapshot};
+    pub use basalt_core::{BroadcastMessage, Context, Gamemode, PlayerSnapshot};
 
     pub use crate::context::ServerContext;
     pub use crate::events::{

--- a/crates/basalt-command/src/registry.rs
+++ b/crates/basalt-command/src/registry.rs
@@ -104,7 +104,7 @@ mod tests {
         fn broadcast_message(&self, _text: &str) {}
         fn broadcast_message_component(&self, _component: &basalt_types::TextComponent) {}
         fn teleport(&self, _x: f64, _y: f64, _z: f64, _yaw: f32, _pitch: f32) {}
-        fn set_gamemode(&self, _mode: u8) {}
+        fn set_gamemode(&self, _mode: basalt_core::Gamemode) {}
         fn registered_commands(&self) -> Vec<(String, String)> {
             Vec::new()
         }

--- a/crates/basalt-core/src/context.rs
+++ b/crates/basalt-core/src/context.rs
@@ -7,6 +7,7 @@
 use basalt_types::{TextComponent, Uuid};
 
 use crate::broadcast::BroadcastMessage;
+use crate::gamemode::Gamemode;
 
 /// Execution context for commands and event handlers.
 ///
@@ -58,7 +59,7 @@ pub trait Context {
     fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32);
 
     /// Changes the current player's gamemode.
-    fn set_gamemode(&self, mode: u8);
+    fn set_gamemode(&self, mode: Gamemode);
 
     // --- Commands ---
 

--- a/crates/basalt-core/src/gamemode.rs
+++ b/crates/basalt-core/src/gamemode.rs
@@ -1,0 +1,89 @@
+//! Gamemode type for the Minecraft protocol.
+//!
+//! Provides a type-safe enum instead of raw `u8` values for gamemodes,
+//! preventing invalid values from reaching the protocol layer.
+
+use std::fmt;
+
+/// A Minecraft game mode.
+///
+/// Used by [`Context::set_gamemode`](crate::Context::set_gamemode)
+/// and the `/gamemode` command. Maps directly to the protocol values
+/// sent in the GameStateChange packet (reason = 3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Gamemode {
+    /// Survival mode (id 0): resource gathering, health, hunger.
+    Survival = 0,
+    /// Creative mode (id 1): unlimited resources, flight, no damage.
+    Creative = 1,
+    /// Adventure mode (id 2): survival with block interaction restrictions.
+    Adventure = 2,
+    /// Spectator mode (id 3): invisible, fly through blocks, no interaction.
+    Spectator = 3,
+}
+
+impl Gamemode {
+    /// Returns the protocol ID for this gamemode.
+    pub fn id(self) -> u8 {
+        self as u8
+    }
+
+    /// Creates a gamemode from its protocol ID.
+    ///
+    /// Returns `None` for invalid IDs (anything other than 0-3).
+    pub fn from_id(id: u8) -> Option<Self> {
+        match id {
+            0 => Some(Self::Survival),
+            1 => Some(Self::Creative),
+            2 => Some(Self::Adventure),
+            3 => Some(Self::Spectator),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Gamemode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Gamemode::Survival => write!(f, "Survival"),
+            Gamemode::Creative => write!(f, "Creative"),
+            Gamemode::Adventure => write!(f, "Adventure"),
+            Gamemode::Spectator => write!(f, "Spectator"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gamemode_ids() {
+        assert_eq!(Gamemode::Survival.id(), 0);
+        assert_eq!(Gamemode::Creative.id(), 1);
+        assert_eq!(Gamemode::Adventure.id(), 2);
+        assert_eq!(Gamemode::Spectator.id(), 3);
+    }
+
+    #[test]
+    fn from_valid_id() {
+        assert_eq!(Gamemode::from_id(0), Some(Gamemode::Survival));
+        assert_eq!(Gamemode::from_id(1), Some(Gamemode::Creative));
+        assert_eq!(Gamemode::from_id(2), Some(Gamemode::Adventure));
+        assert_eq!(Gamemode::from_id(3), Some(Gamemode::Spectator));
+    }
+
+    #[test]
+    fn from_invalid_id() {
+        assert_eq!(Gamemode::from_id(4), None);
+        assert_eq!(Gamemode::from_id(255), None);
+    }
+
+    #[test]
+    fn display() {
+        assert_eq!(Gamemode::Survival.to_string(), "Survival");
+        assert_eq!(Gamemode::Creative.to_string(), "Creative");
+        assert_eq!(Gamemode::Adventure.to_string(), "Adventure");
+        assert_eq!(Gamemode::Spectator.to_string(), "Spectator");
+    }
+}

--- a/crates/basalt-core/src/lib.rs
+++ b/crates/basalt-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! across the Basalt server ecosystem:
 //!
 //! - [`Context`] trait — abstraction over execution environments
+//! - [`Gamemode`] — type-safe gamemode enum
 //! - [`BroadcastMessage`] — cross-player message types
 //! - [`PlayerSnapshot`] — player state snapshots
 //! - [`ProfileProperty`] — Mojang profile data
@@ -11,8 +12,10 @@
 
 pub mod broadcast;
 pub mod context;
+pub mod gamemode;
 pub mod logger;
 
 pub use broadcast::{BroadcastMessage, PlayerSnapshot, ProfileProperty};
 pub use context::Context;
+pub use gamemode::Gamemode;
 pub use logger::PluginLogger;

--- a/crates/basalt-core/src/logger.rs
+++ b/crates/basalt-core/src/logger.rs
@@ -4,18 +4,23 @@
 //! sets the log target to `basalt::plugin::<name>`, ensuring
 //! consistent, filterable log output across all plugins.
 
+use std::fmt;
+
 /// A logger scoped to a specific plugin.
 ///
 /// Obtained via [`ServerContext::logger()`](crate::ServerContext::logger).
 /// All messages are logged with target `basalt::plugin::<name>`,
 /// making them easy to filter in log output.
 ///
+/// Methods accept `impl Display`, so formatting is deferred until
+/// the log level is checked — no allocation if the level is filtered.
+///
 /// # Example
 ///
 /// ```ignore
 /// registrar.on::<PlayerJoinedEvent>(Stage::Post, 0, |event, ctx| {
 ///     let log = ctx.logger();
-///     log.info(&format!("{} joined", event.info.username));
+///     log.info(format_args!("{} joined", event.info.username));
 ///     log.debug("sending welcome message");
 /// });
 /// ```
@@ -32,27 +37,27 @@ impl PluginLogger {
     }
 
     /// Logs at ERROR level.
-    pub fn error(&self, msg: &str) {
+    pub fn error(&self, msg: impl fmt::Display) {
         log::log!(target: &self.target, log::Level::Error, "{msg}");
     }
 
     /// Logs at WARN level.
-    pub fn warn(&self, msg: &str) {
+    pub fn warn(&self, msg: impl fmt::Display) {
         log::log!(target: &self.target, log::Level::Warn, "{msg}");
     }
 
     /// Logs at INFO level.
-    pub fn info(&self, msg: &str) {
+    pub fn info(&self, msg: impl fmt::Display) {
         log::log!(target: &self.target, log::Level::Info, "{msg}");
     }
 
     /// Logs at DEBUG level.
-    pub fn debug(&self, msg: &str) {
+    pub fn debug(&self, msg: impl fmt::Display) {
         log::log!(target: &self.target, log::Level::Debug, "{msg}");
     }
 
     /// Logs at TRACE level.
-    pub fn trace(&self, msg: &str) {
+    pub fn trace(&self, msg: impl fmt::Display) {
         log::log!(target: &self.target, log::Level::Trace, "{msg}");
     }
 }

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -91,21 +91,15 @@ impl Plugin for CommandPlugin {
             )
             .handler(|args, ctx| {
                 let mode_str = args.get_string("mode").unwrap();
-                let mode: u8 = match mode_str {
-                    "survival" => 0,
-                    "creative" => 1,
-                    "adventure" => 2,
-                    _ => 3,
+                let mode = match mode_str {
+                    "survival" => Gamemode::Survival,
+                    "creative" => Gamemode::Creative,
+                    "adventure" => Gamemode::Adventure,
+                    _ => Gamemode::Spectator,
                 };
                 ctx.set_gamemode(mode);
-                let name = match mode {
-                    0 => "Survival",
-                    1 => "Creative",
-                    2 => "Adventure",
-                    _ => "Spectator",
-                };
                 ctx.send_message_component(
-                    &TextComponent::text(format!("Game mode set to {name}"))
+                    &TextComponent::text(format!("Game mode set to {mode}"))
                         .color(TextColor::Named(NamedColor::Green)),
                 );
             });
@@ -148,7 +142,9 @@ impl Plugin for CommandPlugin {
             .handler(|args, ctx| {
                 let target = args.get_string("player").unwrap();
                 let log = ctx.logger();
-                log.info(&format!("Kick issued for {target} — not yet implemented"));
+                log.info(format_args!(
+                    "Kick issued for {target} — not yet implemented"
+                ));
                 ctx.send_message_component(
                     &TextComponent::text(format!("Kick not yet implemented: {target}"))
                         .color(TextColor::Named(NamedColor::Yellow)),


### PR DESCRIPTION
## Summary

API improvements from the codebase review (PR4 from the plan):

- **Gamemode enum** (`basalt-core`): Type-safe `Gamemode` enum (Survival, Creative, Adventure, Spectator) replaces raw `u8` in `Context::set_gamemode`. Provides `id()`, `from_id()`, and `Display` impl.
- **Magic numbers removed** (`basalt-api`): `teleport_id` is now a monotonically increasing `AtomicI32` counter instead of hardcoded `2`. Game state change reason uses a named constant `GAME_STATE_CHANGE_GAMEMODE` instead of magic `3`.
- **PluginLogger accepts `impl Display`** (`basalt-core`): Logger methods accept `impl fmt::Display` instead of `&str`, deferring formatting until the log level is checked. Existing `&str` callers work unchanged.
- **Event derives** (`basalt-api`): All 7 event structs now derive `Debug` and `Clone` for easier logging and testing.

Each change is in its own commit.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` all pass (603 tests)
- [x] `cargo llvm-cov` coverage at 90.19%
- [ ] Verify `/gamemode` command in-game uses the new Display names
