### PR TITLE
fix(server): replace unsafe lifetime extension with Arc<World>

### DIFF
--- a/crates/basalt-api/src/context.rs
+++ b/crates/basalt-api/src/context.rs
@@ -6,7 +6,7 @@
 //! event dispatch completes.
 
 use std::cell::RefCell;
-
+use std::sync::Arc;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use basalt_core::broadcast::BroadcastMessage;
@@ -28,7 +28,7 @@ const GAME_STATE_CHANGE_GAMEMODE: u8 = 3;
 /// `drain_responses`) are not part of the `Context` trait.
 pub struct ServerContext {
     /// Shared world reference for block access and chunk persistence.
-    world: &'static basalt_world::World,
+    world: Arc<basalt_world::World>,
     /// Queue for deferred async responses.
     responses: ResponseQueue,
     /// UUID of the player who triggered this event.
@@ -51,7 +51,7 @@ static GLOBAL_TELEPORT_COUNTER: AtomicI32 = AtomicI32::new(1);
 impl ServerContext {
     /// Creates a new context for a single event dispatch.
     pub fn new(
-        world: &'static basalt_world::World,
+        world: Arc<basalt_world::World>,
         player_uuid: Uuid,
         player_entity_id: i32,
         player_username: String,
@@ -107,7 +107,7 @@ impl Context for ServerContext {
     }
 
     fn world(&self) -> &basalt_world::World {
-        self.world
+        &self.world
     }
 
     fn send_message(&self, text: &str) {
@@ -250,10 +250,8 @@ pub enum Response {
 mod tests {
     use super::*;
 
-    fn test_world() -> &'static basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn test_world() -> Arc<basalt_world::World> {
+        Arc::new(basalt_world::World::new_memory(42))
     }
 
     fn test_ctx() -> ServerContext {

--- a/crates/basalt-server/src/connection.rs
+++ b/crates/basalt-server/src/connection.rs
@@ -185,10 +185,8 @@ async fn handle_configuration(
         pitch: player.pitch,
         skin_properties: player.skin_properties.clone(),
     };
-    let world: &basalt_world::World = &state.world;
-    let world: &'static basalt_world::World = unsafe { &*(world as *const _) };
     let join_ctx = ServerContext::new(
-        world,
+        Arc::clone(&state.world),
         player.uuid,
         player.entity_id,
         player.username.clone(),
@@ -214,7 +212,12 @@ async fn handle_configuration(
 
     // Unregister and dispatch PlayerLeftEvent
     state.unregister_player(&player_uuid);
-    let leave_ctx = ServerContext::new(world, player_uuid, entity_id, player.username.clone());
+    let leave_ctx = ServerContext::new(
+        Arc::clone(&state.world),
+        player_uuid,
+        entity_id,
+        player.username.clone(),
+    );
     let mut leave_event = PlayerLeftEvent {
         uuid: player_uuid,
         entity_id,

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -74,7 +74,7 @@ impl Server {
         };
         log::info!(target: "basalt::server", "Listening on {}", self.config.server.bind);
 
-        let world = self.config.create_world();
+        let world = Arc::new(self.config.create_world());
         let plugins = self.config.create_plugins();
         let state = ServerState::with_world_and_plugins(world, plugins);
 
@@ -87,7 +87,7 @@ impl Server {
     /// listener directly, avoiding port conflicts.
     pub async fn accept_loop(listener: TcpListener) {
         let config = ServerConfig::default();
-        let world = config.create_world();
+        let world = Arc::new(config.create_world());
         let plugins = config.create_plugins();
         let state = ServerState::with_world_and_plugins(world, plugins);
 

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -305,12 +305,8 @@ async fn play_loop(
                             continue;
                         }
                         if let Some(mut event) = packet_to_event(addr, player, packet) {
-                            // Safety: Arc<ServerState> lives for the entire server.
-                            // The world reference is valid for the duration of dispatch.
-                            let world: &basalt_world::World = &state.world;
-                            let world: &'static basalt_world::World = unsafe { &*(world as *const _) };
                             let ctx = ServerContext::new(
-                                world,
+                                Arc::clone(&state.world),
                                 player.uuid,
                                 player.entity_id,
                                 player.username.clone(),

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -24,7 +24,7 @@ pub(crate) struct ServerState {
     /// Broadcast channel sender — O(1) fan-out to all subscribers.
     broadcast_tx: broadcast::Sender<BroadcastMessage>,
     /// The world — chunk cache and terrain generator.
-    pub world: basalt_world::World,
+    pub world: std::sync::Arc<basalt_world::World>,
     /// Event bus with registered plugin handlers.
     pub event_bus: EventBus,
     /// Pre-built DeclareCommands packet payload (empty if no commands).
@@ -68,7 +68,10 @@ impl ServerState {
     #[cfg(test)]
     pub fn new() -> Arc<Self> {
         let config = crate::config::ServerConfig::default();
-        Self::with_world_and_plugins(config.create_world(), config.create_plugins())
+        Self::with_world_and_plugins(
+            std::sync::Arc::new(config.create_world()),
+            config.create_plugins(),
+        )
     }
 
     /// Creates a server state with a given world and plugin set.
@@ -78,7 +81,7 @@ impl ServerState {
     /// are enabled, the collected commands are used to build the
     /// `DeclareCommands` packet and the command dispatch handler.
     pub fn with_world_and_plugins(
-        world: basalt_world::World,
+        world: std::sync::Arc<basalt_world::World>,
         plugins: Vec<Box<dyn basalt_api::Plugin>>,
     ) -> Arc<Self> {
         let (broadcast_tx, _) = broadcast::channel(256);

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -64,17 +64,16 @@ mod tests {
 
     use super::*;
 
-    fn test_world() -> &'static basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn test_world() -> std::sync::Arc<basalt_world::World> {
+        std::sync::Arc::new(basalt_world::World::new_memory(42))
     }
 
     #[test]
     fn block_broken_sets_air_and_queues_responses() {
-        test_world().set_block(5, 64, 3, basalt_world::block::STONE);
+        let world = test_world();
+        world.set_block(5, 64, 3, basalt_world::block::STONE);
 
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into());
         let mut event = BlockBrokenEvent {
             x: 5,
             y: 64,
@@ -90,7 +89,7 @@ mod tests {
         BlockPlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 
-        assert_eq!(test_world().get_block(5, 64, 3), basalt_world::block::AIR);
+        assert_eq!(world.get_block(5, 64, 3), basalt_world::block::AIR);
 
         let responses = ctx.drain_responses();
         assert_eq!(responses.len(), 2);
@@ -106,9 +105,10 @@ mod tests {
 
     #[test]
     fn cancelled_block_break_skips_mutation() {
-        test_world().set_block(8, 64, 8, basalt_world::block::STONE);
+        let world = test_world();
+        world.set_block(8, 64, 8, basalt_world::block::STONE);
 
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into());
         let mut event = BlockBrokenEvent {
             x: 8,
             y: 64,
@@ -128,7 +128,7 @@ mod tests {
         BlockPlugin.on_enable(&mut registrar);
         bus.dispatch(&mut event, &ctx);
 
-        assert_eq!(test_world().get_block(8, 64, 8), basalt_world::block::STONE);
+        assert_eq!(world.get_block(8, 64, 8), basalt_world::block::STONE);
         assert!(ctx.drain_responses().is_empty());
     }
 }

--- a/plugins/chat/src/lib.rs
+++ b/plugins/chat/src/lib.rs
@@ -45,10 +45,8 @@ mod tests {
 
     use super::*;
 
-    fn test_world() -> &'static basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn test_world() -> std::sync::Arc<basalt_world::World> {
+        std::sync::Arc::new(basalt_world::World::new_memory(42))
     }
 
     #[test]

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -202,10 +202,8 @@ mod tests {
 
     use super::*;
 
-    fn test_world() -> &'static basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn test_world() -> std::sync::Arc<basalt_world::World> {
+        std::sync::Arc::new(basalt_world::World::new_memory(42))
     }
 
     fn test_ctx() -> ServerContext {

--- a/plugins/lifecycle/src/lib.rs
+++ b/plugins/lifecycle/src/lib.rs
@@ -46,10 +46,8 @@ mod tests {
 
     use super::*;
 
-    fn test_world() -> &'static basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn test_world() -> std::sync::Arc<basalt_world::World> {
+        std::sync::Arc::new(basalt_world::World::new_memory(42))
     }
 
     #[test]

--- a/plugins/movement/src/lib.rs
+++ b/plugins/movement/src/lib.rs
@@ -43,10 +43,8 @@ mod tests {
 
     use super::*;
 
-    fn test_world() -> &'static basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn test_world() -> std::sync::Arc<basalt_world::World> {
+        std::sync::Arc::new(basalt_world::World::new_memory(42))
     }
 
     #[test]

--- a/plugins/storage/src/lib.rs
+++ b/plugins/storage/src/lib.rs
@@ -48,9 +48,9 @@ mod tests {
     #[test]
     fn storage_persists_to_disk() {
         let dir = tempfile::tempdir().unwrap();
-        let world = Box::leak(Box::new(basalt_world::World::new(42, dir.path())));
+        let world = std::sync::Arc::new(basalt_world::World::new(42, dir.path()));
 
-        let ctx = ServerContext::new(world, Uuid::default(), 1, "Steve".into());
+        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into());
         let mut event = BlockPlacedEvent {
             x: 5,
             y: 100,

--- a/plugins/world/src/lib.rs
+++ b/plugins/world/src/lib.rs
@@ -40,10 +40,8 @@ mod tests {
 
     use super::*;
 
-    fn test_world() -> &'static basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn test_world() -> std::sync::Arc<basalt_world::World> {
+        std::sync::Arc::new(basalt_world::World::new_memory(42))
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes the two `unsafe` blocks that transmuted `&World` to `&'static World` -- the P0 finding from the codebase review.

- **`ServerContext`** now holds `Arc<World>` instead of `&'static World`. `Context::world()` returns `&World` via Arc deref, preserving the trait API.
- **`ServerState`** stores `Arc<World>`, callers wrap `create_world()` in `Arc::new()`.
- **connection.rs / play.rs**: `unsafe { &*(world as *const _) }` replaced by `Arc::clone(&state.world)`. Zero UB risk.
- **All plugin tests**: `test_world()` returns `Arc<World>` instead of `&'static World` via `OnceLock`. Block plugin tests properly share the Arc instance for world mutation verification.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 603 tests pass
- [x] Coverage at 90.06%
- [ ] Verify in-game: join, chunk streaming, block breaking all work with Arc<World>
