### PR TITLE
fix(server): keep-alive timeout, input validation, encrypt buffer, fsync

### DIFF
--- a/crates/basalt-net/src/stream.rs
+++ b/crates/basalt-net/src/stream.rs
@@ -29,6 +29,8 @@ pub struct ProtocolStream {
     /// Packets with uncompressed size >= threshold are zlib-compressed.
     /// `None` means compression is disabled.
     compression_threshold: Option<usize>,
+    /// Reusable buffer for encrypting outgoing data, avoiding per-write allocation.
+    encrypt_buf: Vec<u8>,
 }
 
 impl ProtocolStream {
@@ -38,6 +40,7 @@ impl ProtocolStream {
             stream,
             cipher: None,
             compression_threshold: None,
+            encrypt_buf: Vec::new(),
         }
     }
 
@@ -204,9 +207,10 @@ impl ProtocolStream {
     /// `AsyncWriteExt::write_all` with transparent encryption.
     pub async fn write_all(&mut self, data: &[u8]) -> std::io::Result<()> {
         if let Some(cipher) = &mut self.cipher {
-            let mut encrypted = data.to_vec();
-            cipher.encrypt(&mut encrypted);
-            self.stream.write_all(&encrypted).await
+            self.encrypt_buf.clear();
+            self.encrypt_buf.extend_from_slice(data);
+            cipher.encrypt(&mut self.encrypt_buf);
+            self.stream.write_all(&self.encrypt_buf).await
         } else {
             self.stream.write_all(data).await
         }

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -289,6 +289,13 @@ async fn play_loop(
     loop {
         tokio::select! {
             _ = keep_alive.tick() => {
+                // Disconnect if the client hasn't responded to the previous keep-alive
+                if player.last_keep_alive_id > 0
+                    && player.last_keep_alive_sent.elapsed() > std::time::Duration::from_secs(30)
+                {
+                    log::warn!(target: "basalt::play", "[{addr}] {} timed out (no keep-alive response in 30s)", player.username);
+                    break;
+                }
                 player.last_keep_alive_id += 1;
                 player.last_keep_alive_sent = Instant::now();
                 let ka = ClientboundPlayKeepAlive {
@@ -381,6 +388,10 @@ fn packet_to_event(
             None
         }
         ServerboundPlayPacket::Position(p) => {
+            if !is_valid_position(p.x, p.y, p.z) {
+                log::warn!(target: "basalt::play", "[{addr}] {} sent invalid position ({}, {}, {})", player.username, p.x, p.y, p.z);
+                return None;
+            }
             let old_cx = (player.x as i32) >> 4;
             let old_cz = (player.z as i32) >> 4;
             player.update_position(p.x, p.y, p.z);
@@ -398,6 +409,10 @@ fn packet_to_event(
             }))
         }
         ServerboundPlayPacket::PositionLook(p) => {
+            if !is_valid_position(p.x, p.y, p.z) {
+                log::warn!(target: "basalt::play", "[{addr}] {} sent invalid position ({}, {}, {})", player.username, p.x, p.y, p.z);
+                return None;
+            }
             let old_cx = (player.x as i32) >> 4;
             let old_cz = (player.z as i32) >> 4;
             player.update_position(p.x, p.y, p.z);
@@ -437,6 +452,10 @@ fn packet_to_event(
             None
         }
         ServerboundPlayPacket::ChatMessage(msg) => {
+            if msg.message.len() > 256 {
+                log::warn!(target: "basalt::play", "[{addr}] {} sent oversized chat message ({} bytes)", player.username, msg.message.len());
+                return None;
+            }
             log::info!(target: "basalt::play", "[{addr}] <{}> {}", player.username, msg.message);
             Some(Box::new(ChatMessageEvent {
                 username: player.username.clone(),
@@ -516,6 +535,18 @@ fn packet_to_event(
             None
         }
     }
+}
+
+/// Maximum valid coordinate magnitude in Minecraft.
+const MAX_COORDINATE: f64 = 30_000_000.0;
+
+/// Validates that coordinates are finite and within the Minecraft world bounds.
+fn is_valid_position(x: f64, y: f64, z: f64) -> bool {
+    x.is_finite()
+        && y.is_finite()
+        && z.is_finite()
+        && x.abs() <= MAX_COORDINATE
+        && z.abs() <= MAX_COORDINATE
 }
 
 /// Executes queued responses from event handlers.

--- a/crates/basalt-storage/src/region.rs
+++ b/crates/basalt-storage/src/region.rs
@@ -194,7 +194,7 @@ fn write_offset_table(file: &mut File, table: &[(u32, u32)]) -> io::Result<()> {
         buf.extend_from_slice(&size.to_le_bytes());
     }
     file.write_all(&buf)?;
-    file.flush()?;
+    file.sync_all()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Server hardening from the codebase review (PR8 from the plan):

- **Keep-alive timeout**: Players that fail to respond to keep-alive within 30 seconds are disconnected. Previously dead connections stayed open indefinitely.
- **Position validation**: Rejects non-finite (NaN/Infinity) and out-of-bounds (>30M blocks) coordinates from clients, preventing propagation through the broadcast system.
- **Chat length limit**: Drops chat messages longer than 256 bytes, matching the vanilla Minecraft limit.
- **Reusable encrypt buffer**: `ProtocolStream::write_all` reuses a persistent `Vec` instead of allocating per encrypted write, reducing allocation pressure for chunk data.
- **fsync for storage**: `write_offset_table` uses `sync_all()` instead of `flush()` to ensure data reaches stable storage before returning.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All tests pass
- [x] Coverage at 90.10%
- [ ] Verify keep-alive disconnect works by suspending a connected client
- [ ] Verify chunk streaming still works with reusable encrypt buffer
