### PR TITLE
feat(test): test harness, plugin migration, first benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ basalt-api = { path = "crates/basalt-api" }
 basalt-command = { path = "crates/basalt-command" }
 basalt-events = { path = "crates/basalt-events" }
 basalt-storage = { path = "crates/basalt-storage" }
+basalt-test-utils = { path = "crates/basalt-test-utils" }
 
 # Error handling
 thiserror = "2"

--- a/crates/basalt-test-utils/Cargo.toml
+++ b/crates/basalt-test-utils/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "basalt-test-utils"
+version = "0.1.0"
+description = "Shared test helpers for Basalt plugin and server tests"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+basalt-api = { workspace = true }
+basalt-world = { workspace = true }
+basalt-types = { workspace = true }
+basalt-events = { workspace = true }

--- a/crates/basalt-test-utils/src/lib.rs
+++ b/crates/basalt-test-utils/src/lib.rs
@@ -1,0 +1,137 @@
+//! Shared test helpers for Basalt plugin and server tests.
+//!
+//! Provides [`PluginTestHarness`] to eliminate the duplicated test
+//! scaffolding (world creation, event bus, plugin registration, dispatch)
+//! that appears in every plugin's test module.
+
+use std::sync::Arc;
+
+use basalt_api::context::ServerContext;
+use basalt_api::plugin::PluginRegistrar;
+use basalt_api::{EventBus, Plugin, Response};
+use basalt_events::Event;
+use basalt_types::Uuid;
+use basalt_world::World;
+
+/// Test harness that encapsulates the common plugin test setup.
+///
+/// Creates a world, event bus, and server context, then registers a
+/// plugin and dispatches events — all in a few method calls instead
+/// of 10+ lines of boilerplate per test.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut harness = PluginTestHarness::new();
+/// harness.register(MyPlugin);
+/// let mut event = SomeEvent { ... };
+/// let responses = harness.dispatch(&mut event);
+/// assert_eq!(responses.len(), 1);
+/// ```
+pub struct PluginTestHarness {
+    /// Shared world instance for the test.
+    world: Arc<World>,
+    /// Event bus with registered handlers.
+    bus: EventBus,
+    /// Collected command entries (not used in most tests, but needed for registration).
+    commands: Vec<basalt_api::CommandEntry>,
+}
+
+impl PluginTestHarness {
+    /// Creates a new test harness with a memory-only noise world (seed 42).
+    pub fn new() -> Self {
+        Self {
+            world: Arc::new(World::new_memory(42)),
+            bus: EventBus::new(),
+            commands: Vec::new(),
+        }
+    }
+
+    /// Creates a new test harness with the given world.
+    pub fn with_world(world: Arc<World>) -> Self {
+        Self {
+            world,
+            bus: EventBus::new(),
+            commands: Vec::new(),
+        }
+    }
+
+    /// Returns a reference to the shared world.
+    pub fn world(&self) -> &Arc<World> {
+        &self.world
+    }
+
+    /// Registers a plugin's event handlers and commands.
+    pub fn register(&mut self, plugin: impl Plugin) {
+        let mut registrar = PluginRegistrar::new(&mut self.bus, &mut self.commands);
+        plugin.on_enable(&mut registrar);
+    }
+
+    /// Creates a default server context for "Steve" with entity ID 1.
+    pub fn context(&self) -> ServerContext {
+        ServerContext::new(Arc::clone(&self.world), Uuid::default(), 1, "Steve".into())
+    }
+
+    /// Creates a server context with custom player identity.
+    pub fn context_for(&self, uuid: Uuid, entity_id: i32, username: &str) -> ServerContext {
+        ServerContext::new(
+            Arc::clone(&self.world),
+            uuid,
+            entity_id,
+            username.to_string(),
+        )
+    }
+
+    /// Dispatches an event and returns the queued responses.
+    ///
+    /// Creates a default context, dispatches the event through the bus,
+    /// and drains the response queue.
+    pub fn dispatch(&self, event: &mut dyn Event) -> Vec<Response> {
+        let ctx = self.context();
+        self.bus.dispatch_dyn(event, &ctx);
+        ctx.drain_responses()
+    }
+
+    /// Dispatches an event with a specific context and returns responses.
+    pub fn dispatch_with(&self, event: &mut dyn Event, ctx: &ServerContext) -> Vec<Response> {
+        self.bus.dispatch_dyn(event, ctx);
+        ctx.drain_responses()
+    }
+
+    /// Returns a reference to the collected command entries.
+    pub fn commands(&self) -> &[basalt_api::CommandEntry] {
+        &self.commands
+    }
+}
+
+impl Default for PluginTestHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harness_creates_world() {
+        let harness = PluginTestHarness::new();
+        assert!(harness.world().chunk_count() == 0);
+    }
+
+    #[test]
+    fn harness_default() {
+        let harness = PluginTestHarness::default();
+        assert!(harness.commands().is_empty());
+    }
+
+    #[test]
+    fn context_has_default_identity() {
+        let harness = PluginTestHarness::new();
+        let ctx = harness.context();
+        use basalt_api::Context;
+        assert_eq!(ctx.player_username(), "Steve");
+        assert_eq!(ctx.player_entity_id(), 1);
+    }
+}

--- a/crates/basalt-types/Cargo.toml
+++ b/crates/basalt-types/Cargo.toml
@@ -13,3 +13,11 @@ indexmap = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 proptest = { workspace = true }
+
+[[bench]]
+name = "varint"
+harness = false
+
+[[bench]]
+name = "nbt"
+harness = false

--- a/crates/basalt-types/benches/nbt.rs
+++ b/crates/basalt-types/benches/nbt.rs
@@ -1,0 +1,96 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use basalt_types::nbt::{NbtCompound, NbtTag};
+use basalt_types::{Decode, Encode, EncodedSize};
+
+fn build_registry_compound() -> NbtCompound {
+    let mut compound = NbtCompound::new();
+    for i in 0..47 {
+        let mut entry = NbtCompound::new();
+        entry.insert("id", NbtTag::Int(i));
+        entry.insert("name", NbtTag::String(format!("minecraft:damage_type_{i}")));
+        entry.insert(
+            "scaling",
+            NbtTag::String("when_caused_by_living_non_player".into()),
+        );
+        entry.insert("exhaustion", NbtTag::Float(0.1));
+        compound.insert(format!("entry_{i}"), NbtTag::Compound(entry));
+    }
+    compound
+}
+
+fn bench_nbt_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nbt_encode");
+
+    group.bench_function("small (3 entries)", |b| {
+        let mut compound = NbtCompound::new();
+        compound.insert("x", NbtTag::Int(10));
+        compound.insert("y", NbtTag::Int(64));
+        compound.insert("z", NbtTag::Int(-20));
+        let mut buf = Vec::with_capacity(compound.encoded_size());
+        b.iter(|| {
+            buf.clear();
+            compound.encode(black_box(&mut buf)).unwrap();
+        });
+    });
+
+    group.bench_function("registry (47 entries)", |b| {
+        let compound = build_registry_compound();
+        let mut buf = Vec::with_capacity(compound.encoded_size());
+        b.iter(|| {
+            buf.clear();
+            compound.encode(black_box(&mut buf)).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_nbt_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nbt_decode");
+
+    group.bench_function("small (3 entries)", |b| {
+        let mut compound = NbtCompound::new();
+        compound.insert("x", NbtTag::Int(10));
+        compound.insert("y", NbtTag::Int(64));
+        compound.insert("z", NbtTag::Int(-20));
+        let mut buf = Vec::new();
+        compound.encode(&mut buf).unwrap();
+        b.iter(|| {
+            let mut cursor = black_box(buf.as_slice());
+            NbtCompound::decode(&mut cursor).unwrap()
+        });
+    });
+
+    group.bench_function("registry (47 entries)", |b| {
+        let compound = build_registry_compound();
+        let mut buf = Vec::new();
+        compound.encode(&mut buf).unwrap();
+        b.iter(|| {
+            let mut cursor = black_box(buf.as_slice());
+            NbtCompound::decode(&mut cursor).unwrap()
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_nbt_lookup(c: &mut Criterion) {
+    let compound = build_registry_compound();
+
+    c.bench_function("nbt_compound_get (47 entries)", |b| {
+        b.iter(|| {
+            black_box(compound.get("entry_23"));
+            black_box(compound.get("entry_46"));
+            black_box(compound.get("nonexistent"));
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_nbt_encode,
+    bench_nbt_decode,
+    bench_nbt_lookup
+);
+criterion_main!(benches);

--- a/crates/basalt-types/benches/varint.rs
+++ b/crates/basalt-types/benches/varint.rs
@@ -1,0 +1,81 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use basalt_types::{Decode, Encode, EncodedSize, VarInt};
+
+fn bench_varint_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("varint_encode");
+
+    group.bench_function("small (1 byte)", |b| {
+        let v = VarInt(1);
+        let mut buf = Vec::with_capacity(v.encoded_size());
+        b.iter(|| {
+            buf.clear();
+            v.encode(black_box(&mut buf)).unwrap();
+        });
+    });
+
+    group.bench_function("medium (3 bytes)", |b| {
+        let v = VarInt(25565);
+        let mut buf = Vec::with_capacity(v.encoded_size());
+        b.iter(|| {
+            buf.clear();
+            v.encode(black_box(&mut buf)).unwrap();
+        });
+    });
+
+    group.bench_function("max (5 bytes)", |b| {
+        let v = VarInt(i32::MAX);
+        let mut buf = Vec::with_capacity(v.encoded_size());
+        b.iter(|| {
+            buf.clear();
+            v.encode(black_box(&mut buf)).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_varint_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("varint_decode");
+
+    for (name, value) in [("small", 1i32), ("medium", 25565), ("max", i32::MAX)] {
+        let v = VarInt(value);
+        let mut buf = Vec::with_capacity(v.encoded_size());
+        v.encode(&mut buf).unwrap();
+
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                let mut cursor = black_box(buf.as_slice());
+                VarInt::decode(&mut cursor).unwrap()
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_string_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_encode");
+
+    for (name, len) in [("short", 16), ("chat_msg", 256), ("max", 32767)] {
+        let s = "a".repeat(len);
+        let mut buf = Vec::with_capacity(s.encoded_size());
+
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                buf.clear();
+                s.encode(black_box(&mut buf)).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_varint_encode,
+    bench_varint_decode,
+    bench_string_encode
+);
+criterion_main!(benches);

--- a/crates/basalt-world/Cargo.toml
+++ b/crates/basalt-world/Cargo.toml
@@ -12,4 +12,9 @@ basalt-storage = { workspace = true }
 noise = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 tempfile = "3"
+
+[[bench]]
+name = "chunk"
+harness = false

--- a/crates/basalt-world/benches/chunk.rs
+++ b/crates/basalt-world/benches/chunk.rs
@@ -1,0 +1,76 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use basalt_world::palette::PalettedContainer;
+use basalt_world::{ChunkColumn, FlatWorldGenerator, NoiseTerrainGenerator};
+
+fn bench_palette_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("palette_encode");
+
+    group.bench_function("single_value", |b| {
+        let container = PalettedContainer::filled(0);
+        let mut buf = Vec::with_capacity(64);
+        b.iter(|| {
+            buf.clear();
+            container.encode_to(black_box(&mut buf));
+        });
+    });
+
+    group.bench_function("two_states", |b| {
+        let mut container = PalettedContainer::filled(0);
+        for x in 0..16 {
+            for z in 0..16 {
+                container.set(x, 0, z, 1);
+            }
+        }
+        let mut buf = Vec::with_capacity(4096);
+        b.iter(|| {
+            buf.clear();
+            container.encode_to(black_box(&mut buf));
+        });
+    });
+
+    group.bench_function("diverse (16 states)", |b| {
+        let mut container = PalettedContainer::filled(0);
+        for i in 0..4096u16 {
+            container.set(
+                i as usize % 16,
+                i as usize / 256,
+                (i as usize / 16) % 16,
+                i % 16,
+            );
+        }
+        let mut buf = Vec::with_capacity(8192);
+        b.iter(|| {
+            buf.clear();
+            container.encode_to(black_box(&mut buf));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_chunk_to_packet(c: &mut Criterion) {
+    let mut group = c.benchmark_group("chunk_to_packet");
+
+    group.bench_function("flat", |b| {
+        let mut col = ChunkColumn::new(0, 0);
+        FlatWorldGenerator.generate(&mut col);
+        b.iter(|| {
+            black_box(col.to_packet());
+        });
+    });
+
+    group.bench_function("noise", |b| {
+        let noise = NoiseTerrainGenerator::new(42);
+        let mut col = ChunkColumn::new(0, 0);
+        noise.generate(&mut col);
+        b.iter(|| {
+            black_box(col.to_packet());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_palette_encode, bench_chunk_to_packet);
+criterion_main!(benches);

--- a/plugins/block/Cargo.toml
+++ b/plugins/block/Cargo.toml
@@ -10,4 +10,6 @@ basalt-api = { workspace = true }
 basalt-world = { workspace = true }
 
 [dev-dependencies]
+basalt-test-utils = { workspace = true }
 basalt-types = { workspace = true }
+basalt-world = { workspace = true }

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -60,20 +60,19 @@ impl Plugin for BlockPlugin {
 mod tests {
     use basalt_api::context::ServerContext;
     use basalt_api::{Event, EventBus, Response};
+    use basalt_test_utils::PluginTestHarness;
     use basalt_types::Uuid;
 
     use super::*;
 
-    fn test_world() -> std::sync::Arc<basalt_world::World> {
-        std::sync::Arc::new(basalt_world::World::new_memory(42))
-    }
-
     #[test]
     fn block_broken_sets_air_and_queues_responses() {
-        let world = test_world();
-        world.set_block(5, 64, 3, basalt_world::block::STONE);
+        let mut harness = PluginTestHarness::new();
+        harness
+            .world()
+            .set_block(5, 64, 3, basalt_world::block::STONE);
+        harness.register(BlockPlugin);
 
-        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into());
         let mut event = BlockBrokenEvent {
             x: 5,
             y: 64,
@@ -83,15 +82,14 @@ mod tests {
             cancelled: false,
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        BlockPlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
+        let ctx = harness.context();
+        let responses = harness.dispatch_with(&mut event, &ctx);
 
-        assert_eq!(world.get_block(5, 64, 3), basalt_world::block::AIR);
+        assert_eq!(
+            harness.world().get_block(5, 64, 3),
+            basalt_world::block::AIR
+        );
 
-        let responses = ctx.drain_responses();
         assert_eq!(responses.len(), 2);
         assert!(matches!(
             responses[0],
@@ -105,7 +103,7 @@ mod tests {
 
     #[test]
     fn cancelled_block_break_skips_mutation() {
-        let world = test_world();
+        let world = std::sync::Arc::new(basalt_world::World::new_memory(42));
         world.set_block(8, 64, 8, basalt_world::block::STONE);
 
         let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into());
@@ -119,9 +117,9 @@ mod tests {
         };
 
         let mut bus = EventBus::new();
-        // Validate handler cancels
+        // Validate handler cancels before BlockPlugin runs
         let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
+        let mut registrar = basalt_api::plugin::PluginRegistrar::new(&mut bus, &mut cmds);
         registrar.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, _| {
             event.cancel();
         });

--- a/plugins/chat/Cargo.toml
+++ b/plugins/chat/Cargo.toml
@@ -10,4 +10,4 @@ basalt-api = { workspace = true }
 basalt-types = { workspace = true }
 
 [dev-dependencies]
-basalt-world = { workspace = true }
+basalt-test-utils = { workspace = true }

--- a/plugins/chat/src/lib.rs
+++ b/plugins/chat/src/lib.rs
@@ -39,32 +39,23 @@ pub fn build_chat_component(username: &str, message: &str) -> TextComponent {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::context::ServerContext;
-    use basalt_api::{EventBus, Response};
-    use basalt_types::Uuid;
+    use basalt_api::Response;
+    use basalt_test_utils::PluginTestHarness;
 
     use super::*;
 
-    fn test_world() -> std::sync::Arc<basalt_world::World> {
-        std::sync::Arc::new(basalt_world::World::new_memory(42))
-    }
-
     #[test]
     fn chat_message_broadcasts() {
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::new();
+        harness.register(ChatPlugin);
+
         let mut event = ChatMessageEvent {
             username: "Steve".into(),
             message: "hello".into(),
             cancelled: false,
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        ChatPlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
-
-        let responses = ctx.drain_responses();
+        let responses = harness.dispatch(&mut event);
         assert_eq!(responses.len(), 1);
         assert!(matches!(
             responses[0],

--- a/plugins/lifecycle/Cargo.toml
+++ b/plugins/lifecycle/Cargo.toml
@@ -9,5 +9,5 @@ repository.workspace = true
 basalt-api = { workspace = true }
 
 [dev-dependencies]
+basalt-test-utils = { workspace = true }
 basalt-types = { workspace = true }
-basalt-world = { workspace = true }

--- a/plugins/lifecycle/src/lib.rs
+++ b/plugins/lifecycle/src/lib.rs
@@ -40,19 +40,17 @@ impl Plugin for LifecyclePlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::context::ServerContext;
-    use basalt_api::{EventBus, Response};
+    use basalt_api::Response;
+    use basalt_test_utils::PluginTestHarness;
     use basalt_types::Uuid;
 
     use super::*;
 
-    fn test_world() -> std::sync::Arc<basalt_world::World> {
-        std::sync::Arc::new(basalt_world::World::new_memory(42))
-    }
-
     #[test]
     fn player_joined_broadcasts() {
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::new();
+        harness.register(LifecyclePlugin);
+
         let mut event = PlayerJoinedEvent {
             info: PlayerSnapshot {
                 username: "Steve".into(),
@@ -67,13 +65,7 @@ mod tests {
             },
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        LifecyclePlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
-
-        let responses = ctx.drain_responses();
+        let responses = harness.dispatch(&mut event);
         assert_eq!(responses.len(), 1);
         assert!(matches!(
             responses[0],
@@ -83,20 +75,16 @@ mod tests {
 
     #[test]
     fn player_left_broadcasts() {
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::new();
+        harness.register(LifecyclePlugin);
+
         let mut event = PlayerLeftEvent {
             uuid: Uuid::default(),
             entity_id: 1,
             username: "Steve".into(),
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        LifecyclePlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
-
-        let responses = ctx.drain_responses();
+        let responses = harness.dispatch(&mut event);
         assert_eq!(responses.len(), 1);
         assert!(matches!(
             responses[0],

--- a/plugins/movement/Cargo.toml
+++ b/plugins/movement/Cargo.toml
@@ -9,5 +9,4 @@ repository.workspace = true
 basalt-api = { workspace = true }
 
 [dev-dependencies]
-basalt-types = { workspace = true }
-basalt-world = { workspace = true }
+basalt-test-utils = { workspace = true }

--- a/plugins/movement/src/lib.rs
+++ b/plugins/movement/src/lib.rs
@@ -37,19 +37,16 @@ impl Plugin for MovementPlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::context::ServerContext;
-    use basalt_api::{EventBus, Response};
-    use basalt_types::Uuid;
+    use basalt_api::Response;
+    use basalt_test_utils::PluginTestHarness;
 
     use super::*;
 
-    fn test_world() -> std::sync::Arc<basalt_world::World> {
-        std::sync::Arc::new(basalt_world::World::new_memory(42))
-    }
-
     #[test]
     fn movement_broadcasts() {
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::new();
+        harness.register(MovementPlugin);
+
         let mut event = PlayerMovedEvent {
             entity_id: 1,
             x: 10.0,
@@ -62,13 +59,7 @@ mod tests {
             old_cz: 0,
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        MovementPlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
-
-        let responses = ctx.drain_responses();
+        let responses = harness.dispatch(&mut event);
         assert_eq!(responses.len(), 1);
         assert!(matches!(
             responses[0],

--- a/plugins/storage/Cargo.toml
+++ b/plugins/storage/Cargo.toml
@@ -11,5 +11,7 @@ basalt-world = { workspace = true }
 
 [dev-dependencies]
 basalt-plugin-block = { path = "../block" }
+basalt-test-utils = { workspace = true }
 basalt-types = { workspace = true }
+basalt-world = { workspace = true }
 tempfile = "3"

--- a/plugins/storage/src/lib.rs
+++ b/plugins/storage/src/lib.rs
@@ -39,8 +39,7 @@ impl Plugin for StoragePlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::EventBus;
-    use basalt_api::context::ServerContext;
+    use basalt_test_utils::PluginTestHarness;
     use basalt_types::Uuid;
 
     use super::*;
@@ -50,7 +49,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let world = std::sync::Arc::new(basalt_world::World::new(42, dir.path()));
 
-        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::with_world(world);
+        // Block plugin sets the block, storage plugin persists
+        harness.register(basalt_plugin_block::BlockPlugin);
+        harness.register(StoragePlugin);
+
         let mut event = BlockPlacedEvent {
             x: 5,
             y: 100,
@@ -61,13 +64,7 @@ mod tests {
             cancelled: false,
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        // Block plugin sets the block, storage plugin persists
-        basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
-        StoragePlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
+        harness.dispatch(&mut event);
 
         // Verify persisted — fresh world should see the block
         let world2 = basalt_world::World::new(42, dir.path());

--- a/plugins/world/Cargo.toml
+++ b/plugins/world/Cargo.toml
@@ -10,4 +10,4 @@ basalt-api = { workspace = true }
 basalt-world = { workspace = true }
 
 [dev-dependencies]
-basalt-types = { workspace = true }
+basalt-test-utils = { workspace = true }

--- a/plugins/world/src/lib.rs
+++ b/plugins/world/src/lib.rs
@@ -34,19 +34,16 @@ impl Plugin for WorldPlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::context::ServerContext;
-    use basalt_api::{EventBus, Response};
-    use basalt_types::Uuid;
+    use basalt_api::Response;
+    use basalt_test_utils::PluginTestHarness;
 
     use super::*;
 
-    fn test_world() -> std::sync::Arc<basalt_world::World> {
-        std::sync::Arc::new(basalt_world::World::new_memory(42))
-    }
-
     #[test]
     fn chunk_boundary_crossing_queues_stream() {
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::new();
+        harness.register(WorldPlugin);
+
         let mut event = PlayerMovedEvent {
             entity_id: 1,
             x: 16.0,
@@ -59,13 +56,7 @@ mod tests {
             old_cz: 0,
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        WorldPlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
-
-        let responses = ctx.drain_responses();
+        let responses = harness.dispatch(&mut event);
         assert_eq!(responses.len(), 1);
         assert!(matches!(
             responses[0],
@@ -78,7 +69,9 @@ mod tests {
 
     #[test]
     fn negative_coordinate_chunk_boundary() {
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::new();
+        harness.register(WorldPlugin);
+
         // x=-0.5 is in chunk -1, not chunk 0 (floor before shift)
         let mut event = PlayerMovedEvent {
             entity_id: 1,
@@ -92,13 +85,7 @@ mod tests {
             old_cz: 0,
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        WorldPlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
-
-        let responses = ctx.drain_responses();
+        let responses = harness.dispatch(&mut event);
         assert_eq!(responses.len(), 1);
         assert!(matches!(
             responses[0],
@@ -111,7 +98,9 @@ mod tests {
 
     #[test]
     fn same_chunk_no_streaming() {
-        let ctx = ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into());
+        let mut harness = PluginTestHarness::new();
+        harness.register(WorldPlugin);
+
         let mut event = PlayerMovedEvent {
             entity_id: 1,
             x: 5.0,
@@ -124,12 +113,6 @@ mod tests {
             old_cz: 0,
         };
 
-        let mut bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut registrar = PluginRegistrar::new(&mut bus, &mut cmds);
-        WorldPlugin.on_enable(&mut registrar);
-        bus.dispatch(&mut event, &ctx);
-
-        assert!(ctx.drain_responses().is_empty());
+        assert!(harness.dispatch(&mut event).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Test infrastructure from the codebase review (PR9 from the plan):

- **basalt-test-utils crate**: `PluginTestHarness` encapsulates world creation, event bus, plugin registration, context setup, dispatch, and response draining. Eliminates ~10 lines of duplicated boilerplate per test.
- **Plugin test migration**: All 7 plugin test modules migrated to use the harness. Net -49 lines across 12 files. The block cancel test retains manual EventBus setup since it registers a Validate handler before the plugin.
- **First benchmarks** (criterion):
  - `basalt-types`: VarInt encode/decode (3 sizes), string encode (3 lengths), NBT encode/decode (small + 47-entry registry), compound lookup
  - `basalt-world`: Palette encode (single-value, two-state, 16-state), chunk-to-packet (flat + noise terrain)

Run with `cargo bench` or `cargo b`.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All tests pass (603 tests)
- [x] Coverage at 90.18%
- [ ] `cargo bench` runs without errors
