### PR TITLE
fix: trailing bytes, proc macro dedup, /tp rotation preservation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "basalt-protocol",
  "basalt-types",
  "flate2",
+ "log",
  "thiserror",
  "tokio",
 ]

--- a/crates/basalt-api/src/context.rs
+++ b/crates/basalt-api/src/context.rs
@@ -37,6 +37,10 @@ pub struct ServerContext {
     player_entity_id: i32,
     /// Username of the player who triggered this event.
     player_username: String,
+    /// Current yaw rotation of the player (horizontal, degrees).
+    player_yaw: f32,
+    /// Current pitch rotation of the player (vertical, degrees).
+    player_pitch: f32,
     /// Name of the plugin currently being dispatched.
     plugin_name: RefCell<String>,
     /// Registered command list (name, description) for /help.
@@ -55,6 +59,8 @@ impl ServerContext {
         player_uuid: Uuid,
         player_entity_id: i32,
         player_username: String,
+        player_yaw: f32,
+        player_pitch: f32,
     ) -> Self {
         Self {
             world,
@@ -62,6 +68,8 @@ impl ServerContext {
             player_uuid,
             player_entity_id,
             player_username,
+            player_yaw,
+            player_pitch,
             plugin_name: RefCell::new(String::new()),
             command_list: RefCell::new(Vec::new()),
             teleport_counter: &GLOBAL_TELEPORT_COUNTER,
@@ -100,6 +108,14 @@ impl Context for ServerContext {
 
     fn player_username(&self) -> &str {
         &self.player_username
+    }
+
+    fn player_yaw(&self) -> f32 {
+        self.player_yaw
+    }
+
+    fn player_pitch(&self) -> f32 {
+        self.player_pitch
     }
 
     fn logger(&self) -> PluginLogger {
@@ -255,7 +271,7 @@ mod tests {
     }
 
     fn test_ctx() -> ServerContext {
-        ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into())
+        ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into(), 0.0, 0.0)
     }
 
     #[test]

--- a/crates/basalt-command/src/registry.rs
+++ b/crates/basalt-command/src/registry.rs
@@ -90,6 +90,12 @@ mod tests {
         fn player_username(&self) -> &str {
             "Steve"
         }
+        fn player_yaw(&self) -> f32 {
+            0.0
+        }
+        fn player_pitch(&self) -> f32 {
+            0.0
+        }
         fn logger(&self) -> PluginLogger {
             PluginLogger::new("test")
         }

--- a/crates/basalt-core/src/context.rs
+++ b/crates/basalt-core/src/context.rs
@@ -26,6 +26,12 @@ pub trait Context {
     /// Returns the username of the player.
     fn player_username(&self) -> &str;
 
+    /// Returns the player's current yaw rotation (horizontal, degrees).
+    fn player_yaw(&self) -> f32;
+
+    /// Returns the player's current pitch rotation (vertical, degrees).
+    fn player_pitch(&self) -> f32;
+
     // --- Logger ---
 
     /// Returns a logger scoped to the current plugin.

--- a/crates/basalt-derive/src/codegen.rs
+++ b/crates/basalt-derive/src/codegen.rs
@@ -1,0 +1,146 @@
+//! Shared code generation helpers for field attribute handling.
+//!
+//! These functions generate `TokenStream` fragments for a single field
+//! based on its `FieldAttr`. They are used by both struct and enum
+//! codegen paths, eliminating the duplication between the two.
+//!
+//! The `val` parameter is the expression that accesses the field value:
+//! - For structs: `self.field_name`
+//! - For enum variants: `field_name` (destructured binding)
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::attrs::FieldAttr;
+
+/// Generates the encode expression for a single field.
+pub fn field_encode(val: &TokenStream, attr: &FieldAttr) -> TokenStream {
+    if attr.varint {
+        quote! { basalt_types::Encode::encode(&basalt_types::VarInt(*#val), buf)?; }
+    } else if attr.optional {
+        quote! {
+            match #val {
+                Some(value) => {
+                    basalt_types::Encode::encode(&true, buf)?;
+                    basalt_types::Encode::encode(value, buf)?;
+                }
+                None => {
+                    basalt_types::Encode::encode(&false, buf)?;
+                }
+            }
+        }
+    } else if attr.length_varint && attr.element_varint {
+        quote! {
+            basalt_types::Encode::encode(&basalt_types::VarInt((#val).len() as i32), buf)?;
+            for item in (#val) {
+                basalt_types::Encode::encode(&basalt_types::VarInt(*item), buf)?;
+            }
+        }
+    } else if attr.length_varint {
+        quote! {
+            basalt_types::Encode::encode(&basalt_types::VarInt((#val).len() as i32), buf)?;
+            for item in (#val) {
+                basalt_types::Encode::encode(item, buf)?;
+            }
+        }
+    } else if attr.rest {
+        quote! { buf.extend_from_slice(#val); }
+    } else {
+        quote! { basalt_types::Encode::encode(#val, buf)?; }
+    }
+}
+
+/// Generates the decode expression for a single field.
+///
+/// `field_name` is the local variable name to bind the decoded value.
+/// `field_type` is the type (only used for the default decode path).
+pub fn field_decode(
+    field_name: &syn::Ident,
+    field_type: &syn::Type,
+    attr: &FieldAttr,
+) -> TokenStream {
+    if attr.varint {
+        quote! {
+            let #field_name = {
+                let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                var.0
+            };
+        }
+    } else if attr.optional {
+        quote! {
+            let #field_name = {
+                let present: bool = basalt_types::Decode::decode(buf)?;
+                if present {
+                    Some(basalt_types::Decode::decode(buf)?)
+                } else {
+                    None
+                }
+            };
+        }
+    } else if attr.length_varint && attr.element_varint {
+        quote! {
+            let #field_name = {
+                let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                let len = len.0 as usize;
+                let mut items = Vec::with_capacity(len);
+                for _ in 0..len {
+                    let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                    items.push(var.0);
+                }
+                items
+            };
+        }
+    } else if attr.length_varint {
+        quote! {
+            let #field_name = {
+                let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
+                let len = len.0 as usize;
+                let mut items = Vec::with_capacity(len);
+                for _ in 0..len {
+                    items.push(basalt_types::Decode::decode(buf)?);
+                }
+                items
+            };
+        }
+    } else if attr.rest {
+        quote! {
+            let #field_name = {
+                let rest = buf.to_vec();
+                *buf = &buf[buf.len()..];
+                rest
+            };
+        }
+    } else {
+        quote! {
+            let #field_name: #field_type = basalt_types::Decode::decode(buf)?;
+        }
+    }
+}
+
+/// Generates the encoded_size expression for a single field.
+pub fn field_size(val: &TokenStream, attr: &FieldAttr) -> TokenStream {
+    if attr.varint {
+        quote! { basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(*#val)) }
+    } else if attr.optional {
+        quote! {
+            1 + match #val {
+                Some(value) => basalt_types::EncodedSize::encoded_size(value),
+                None => 0,
+            }
+        }
+    } else if attr.length_varint && attr.element_varint {
+        quote! {
+            basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt((#val).len() as i32))
+            + (#val).iter().map(|item| basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(*item))).sum::<usize>()
+        }
+    } else if attr.length_varint {
+        quote! {
+            basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt((#val).len() as i32))
+            + (#val).iter().map(|item| basalt_types::EncodedSize::encoded_size(item)).sum::<usize>()
+        }
+    } else if attr.rest {
+        quote! { (#val).len() }
+    } else {
+        quote! { basalt_types::EncodedSize::encoded_size(#val) }
+    }
+}

--- a/crates/basalt-derive/src/decode.rs
+++ b/crates/basalt-derive/src/decode.rs
@@ -53,62 +53,7 @@ fn derive_decode_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenS
 
         field_names.push(field_name);
 
-        let decode = if attr.varint {
-            quote! {
-                let #field_name = {
-                    let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                    var.0
-                };
-            }
-        } else if attr.optional {
-            quote! {
-                let #field_name = {
-                    let present: bool = basalt_types::Decode::decode(buf)?;
-                    if present {
-                        Some(basalt_types::Decode::decode(buf)?)
-                    } else {
-                        None
-                    }
-                };
-            }
-        } else if attr.length_varint && attr.element_varint {
-            quote! {
-                let #field_name = {
-                    let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                    let len = len.0 as usize;
-                    let mut items = Vec::with_capacity(len);
-                    for _ in 0..len {
-                        let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                        items.push(var.0);
-                    }
-                    items
-                };
-            }
-        } else if attr.length_varint {
-            quote! {
-                let #field_name = {
-                    let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                    let len = len.0 as usize;
-                    let mut items = Vec::with_capacity(len);
-                    for _ in 0..len {
-                        items.push(basalt_types::Decode::decode(buf)?);
-                    }
-                    items
-                };
-            }
-        } else if attr.rest {
-            quote! {
-                let #field_name = {
-                    let rest = buf.to_vec();
-                    *buf = &buf[buf.len()..];
-                    rest
-                };
-            }
-        } else {
-            quote! {
-                let #field_name: #field_type = basalt_types::Decode::decode(buf)?;
-            }
-        };
+        let decode = crate::codegen::field_decode(field_name, field_type, &attr);
 
         field_decodes.push(decode);
     }
@@ -159,62 +104,7 @@ fn derive_decode_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStrea
                         let fname = f.ident.as_ref().unwrap();
                         let fty = &f.ty;
                         let attr = parse_field_attr(&f.attrs)?;
-                        Ok(if attr.varint {
-                            quote! {
-                                let #fname = {
-                                    let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                                    var.0
-                                };
-                            }
-                        } else if attr.optional {
-                            quote! {
-                                let #fname = {
-                                    let present: bool = basalt_types::Decode::decode(buf)?;
-                                    if present {
-                                        Some(basalt_types::Decode::decode(buf)?)
-                                    } else {
-                                        None
-                                    }
-                                };
-                            }
-                        } else if attr.length_varint && attr.element_varint {
-                            quote! {
-                                let #fname = {
-                                    let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                                    let len = len.0 as usize;
-                                    let mut items = Vec::with_capacity(len);
-                                    for _ in 0..len {
-                                        let var: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                                        items.push(var.0);
-                                    }
-                                    items
-                                };
-                            }
-                        } else if attr.length_varint {
-                            quote! {
-                                let #fname = {
-                                    let len: basalt_types::VarInt = basalt_types::Decode::decode(buf)?;
-                                    let len = len.0 as usize;
-                                    let mut items = Vec::with_capacity(len);
-                                    for _ in 0..len {
-                                        items.push(basalt_types::Decode::decode(buf)?);
-                                    }
-                                    items
-                                };
-                            }
-                        } else if attr.rest {
-                            quote! {
-                                let #fname = {
-                                    let rest = buf.to_vec();
-                                    *buf = &buf[buf.len()..];
-                                    rest
-                                };
-                            }
-                        } else {
-                            quote! {
-                                let #fname: #fty = basalt_types::Decode::decode(buf)?;
-                            }
-                        })
+                        Ok(crate::codegen::field_decode(fname, fty, &attr))
                     })
                     .collect::<Result<Vec<_>>>()?;
                 quote! {

--- a/crates/basalt-derive/src/encode.rs
+++ b/crates/basalt-derive/src/encode.rs
@@ -67,45 +67,8 @@ fn derive_encode_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenS
         let field_name = field.ident.as_ref().unwrap();
         let attr = parse_field_attr(&field.attrs)?;
 
-        let encode = if attr.varint {
-            quote! {
-                basalt_types::Encode::encode(&basalt_types::VarInt(self.#field_name), buf)?;
-            }
-        } else if attr.optional {
-            quote! {
-                match &self.#field_name {
-                    Some(value) => {
-                        basalt_types::Encode::encode(&true, buf)?;
-                        basalt_types::Encode::encode(value, buf)?;
-                    }
-                    None => {
-                        basalt_types::Encode::encode(&false, buf)?;
-                    }
-                }
-            }
-        } else if attr.length_varint && attr.element_varint {
-            quote! {
-                basalt_types::Encode::encode(&basalt_types::VarInt(self.#field_name.len() as i32), buf)?;
-                for item in &self.#field_name {
-                    basalt_types::Encode::encode(&basalt_types::VarInt(*item), buf)?;
-                }
-            }
-        } else if attr.length_varint {
-            quote! {
-                basalt_types::Encode::encode(&basalt_types::VarInt(self.#field_name.len() as i32), buf)?;
-                for item in &self.#field_name {
-                    basalt_types::Encode::encode(item, buf)?;
-                }
-            }
-        } else if attr.rest {
-            quote! {
-                buf.extend_from_slice(&self.#field_name);
-            }
-        } else {
-            quote! {
-                basalt_types::Encode::encode(&self.#field_name, buf)?;
-            }
-        };
+        let val = quote! { &self.#field_name };
+        let encode = crate::codegen::field_encode(&val, &attr);
 
         field_encodes.push(encode);
     }
@@ -155,39 +118,8 @@ fn derive_encode_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStrea
                     .map(|f| {
                         let fname = f.ident.as_ref().unwrap();
                         let attr = parse_field_attr(&f.attrs)?;
-                        Ok(if attr.varint {
-                            quote! { basalt_types::Encode::encode(&basalt_types::VarInt(*#fname), buf)?; }
-                        } else if attr.optional {
-                            quote! {
-                                match #fname {
-                                    Some(value) => {
-                                        basalt_types::Encode::encode(&true, buf)?;
-                                        basalt_types::Encode::encode(value, buf)?;
-                                    }
-                                    None => {
-                                        basalt_types::Encode::encode(&false, buf)?;
-                                    }
-                                }
-                            }
-                        } else if attr.length_varint && attr.element_varint {
-                            quote! {
-                                basalt_types::Encode::encode(&basalt_types::VarInt(#fname.len() as i32), buf)?;
-                                for item in #fname {
-                                    basalt_types::Encode::encode(&basalt_types::VarInt(*item), buf)?;
-                                }
-                            }
-                        } else if attr.length_varint {
-                            quote! {
-                                basalt_types::Encode::encode(&basalt_types::VarInt(#fname.len() as i32), buf)?;
-                                for item in #fname {
-                                    basalt_types::Encode::encode(item, buf)?;
-                                }
-                            }
-                        } else if attr.rest {
-                            quote! { buf.extend_from_slice(#fname); }
-                        } else {
-                            quote! { basalt_types::Encode::encode(#fname, buf)?; }
-                        })
+                        let val = quote! { #fname };
+                        Ok(crate::codegen::field_encode(&val, &attr))
                     })
                     .collect::<Result<Vec<_>>>()?;
                 quote! {

--- a/crates/basalt-derive/src/lib.rs
+++ b/crates/basalt-derive/src/lib.rs
@@ -37,6 +37,7 @@
 //! - `#[variant(id = N)]` — explicit discriminant (default: sequential from 0)
 
 mod attrs;
+mod codegen;
 mod decode;
 mod encode;
 mod packet;

--- a/crates/basalt-derive/src/size.rs
+++ b/crates/basalt-derive/src/size.rs
@@ -62,36 +62,8 @@ fn derive_encoded_size_struct(input: &DeriveInput, data: &DataStruct) -> Result<
         let field_name = field.ident.as_ref().unwrap();
         let attr = parse_field_attr(&field.attrs)?;
 
-        let size = if attr.varint {
-            quote! {
-                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(self.#field_name))
-            }
-        } else if attr.optional {
-            quote! {
-                1 + match &self.#field_name {
-                    Some(value) => basalt_types::EncodedSize::encoded_size(value),
-                    None => 0,
-                }
-            }
-        } else if attr.length_varint && attr.element_varint {
-            quote! {
-                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(self.#field_name.len() as i32))
-                + self.#field_name.iter().map(|item| basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(*item))).sum::<usize>()
-            }
-        } else if attr.length_varint {
-            quote! {
-                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(self.#field_name.len() as i32))
-                + self.#field_name.iter().map(|item| basalt_types::EncodedSize::encoded_size(item)).sum::<usize>()
-            }
-        } else if attr.rest {
-            quote! {
-                self.#field_name.len()
-            }
-        } else {
-            quote! {
-                basalt_types::EncodedSize::encoded_size(&self.#field_name)
-            }
-        };
+        let val = quote! { &self.#field_name };
+        let size = crate::codegen::field_size(&val, &attr);
 
         field_sizes.push(size);
     }
@@ -140,30 +112,8 @@ fn derive_encoded_size_enum(input: &DeriveInput, data: &DataEnum) -> Result<Toke
                     .map(|f| {
                         let fname = f.ident.as_ref().unwrap();
                         let attr = parse_field_attr(&f.attrs)?;
-                        Ok(if attr.varint {
-                            quote! { basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(*#fname)) }
-                        } else if attr.optional {
-                            quote! {
-                                1 + match #fname {
-                                    Some(value) => basalt_types::EncodedSize::encoded_size(value),
-                                    None => 0,
-                                }
-                            }
-                        } else if attr.length_varint && attr.element_varint {
-                            quote! {
-                                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#fname.len() as i32))
-                                + #fname.iter().map(|item| basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(*item))).sum::<usize>()
-                            }
-                        } else if attr.length_varint {
-                            quote! {
-                                basalt_types::EncodedSize::encoded_size(&basalt_types::VarInt(#fname.len() as i32))
-                                + #fname.iter().map(|item| basalt_types::EncodedSize::encoded_size(item)).sum::<usize>()
-                            }
-                        } else if attr.rest {
-                            quote! { #fname.len() }
-                        } else {
-                            quote! { basalt_types::EncodedSize::encoded_size(#fname) }
-                        })
+                        let val = quote! { #fname };
+                        Ok(crate::codegen::field_size(&val, &attr))
                     })
                     .collect::<Result<Vec<_>>>()?;
                 quote! {

--- a/crates/basalt-net/Cargo.toml
+++ b/crates/basalt-net/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { workspace = true }
 thiserror = { workspace = true }
 aes = { workspace = true }
 flate2 = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/basalt-net/src/connection.rs
+++ b/crates/basalt-net/src/connection.rs
@@ -248,7 +248,15 @@ impl Connection<Play> {
     pub async fn read_packet(&mut self) -> Result<ServerboundPlayPacket> {
         let raw = self.read_raw().await?;
         let mut cursor = raw.payload.as_slice();
-        Ok(ServerboundPlayPacket::decode_by_id(raw.id, &mut cursor)?)
+        let packet = ServerboundPlayPacket::decode_by_id(raw.id, &mut cursor)?;
+        if !cursor.is_empty() {
+            log::trace!(
+                "Packet 0x{:02x} had {} trailing bytes",
+                raw.id,
+                cursor.len()
+            );
+        }
+        Ok(packet)
     }
 
     /// Writes a clientbound Play packet to the client.

--- a/crates/basalt-server/src/connection.rs
+++ b/crates/basalt-server/src/connection.rs
@@ -190,6 +190,8 @@ async fn handle_configuration(
         player.uuid,
         player.entity_id,
         player.username.clone(),
+        player.yaw,
+        player.pitch,
     );
     let mut join_event = PlayerJoinedEvent { info: snapshot };
     state.event_bus.dispatch(&mut join_event, &join_ctx);
@@ -217,6 +219,8 @@ async fn handle_configuration(
         player_uuid,
         entity_id,
         player.username.clone(),
+        player.yaw,
+        player.pitch,
     );
     let mut leave_event = PlayerLeftEvent {
         uuid: player_uuid,

--- a/crates/basalt-server/src/play.rs
+++ b/crates/basalt-server/src/play.rs
@@ -317,6 +317,8 @@ async fn play_loop(
                                 player.uuid,
                                 player.entity_id,
                                 player.username.clone(),
+                                player.yaw,
+                                player.pitch,
                             );
                             ctx.set_command_list(
                                 state.command_args.iter()

--- a/crates/basalt-test-utils/src/lib.rs
+++ b/crates/basalt-test-utils/src/lib.rs
@@ -69,7 +69,14 @@ impl PluginTestHarness {
 
     /// Creates a default server context for "Steve" with entity ID 1.
     pub fn context(&self) -> ServerContext {
-        ServerContext::new(Arc::clone(&self.world), Uuid::default(), 1, "Steve".into())
+        ServerContext::new(
+            Arc::clone(&self.world),
+            Uuid::default(),
+            1,
+            "Steve".into(),
+            0.0,
+            0.0,
+        )
     }
 
     /// Creates a server context with custom player identity.
@@ -79,6 +86,8 @@ impl PluginTestHarness {
             uuid,
             entity_id,
             username.to_string(),
+            0.0,
+            0.0,
         )
     }
 

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -106,7 +106,7 @@ mod tests {
         let world = std::sync::Arc::new(basalt_world::World::new_memory(42));
         world.set_block(8, 64, 8, basalt_world::block::STONE);
 
-        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into());
+        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into(), 0.0, 0.0);
         let mut event = BlockBrokenEvent {
             x: 8,
             y: 64,

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -39,7 +39,7 @@ impl Plugin for CommandPlugin {
             .variant(|v| v.arg("targets", Arg::Entity).arg("location", Arg::Vec3))
             .handler(|args, ctx| {
                 if let Some((x, y, z)) = args.get_vec3("location") {
-                    ctx.teleport(x, y, z, 0.0, 0.0);
+                    ctx.teleport(x, y, z, ctx.player_yaw(), ctx.player_pitch());
                     ctx.send_message_component(
                         &TextComponent::text(format!("Teleported to {x}, {y}, {z}"))
                             .color(TextColor::Named(NamedColor::Green)),
@@ -193,7 +193,7 @@ mod tests {
     }
 
     fn test_ctx() -> ServerContext {
-        ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into())
+        ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into(), 0.0, 0.0)
     }
 
     fn dispatch_command(cmd: &str) -> Vec<Response> {


### PR DESCRIPTION
## Summary

Three of the four remaining codebase review findings:

- **#33 Trailing bytes warning** (`basalt-net`): Play packet decode now logs at TRACE level when trailing bytes remain after decode, helping detect version mismatches or corruption.
- **#21 Proc macro dedup** (`basalt-derive`): Extracted `field_encode`, `field_decode`, `field_size` into a shared `codegen.rs` module. The 6x duplicated field attribute handling (struct+enum x encode/decode/size) is now a single source of truth. -81 lines net.
- **#10 /tp preserve yaw/pitch** (`basalt-core`, `basalt-api`, `plugins/command`): Added `player_yaw()` and `player_pitch()` to the Context trait. `/tp` now preserves the player's look direction instead of resetting to 0.0.

**#18 PlayerIdentity** is deferred -- the server runtime architecture spec redesigns events entirely, so adding a shared identity struct now would be throwaway work.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All tests pass
- [x] Coverage at 90.25%
- [ ] Verify `/tp` preserves look direction in-game
