### PR TITLE
fix(types): resolve fuzz_slot and fuzz_nbt crashes

### DIFF
--- a/crates/basalt-types/src/slot.rs
+++ b/crates/basalt-types/src/slot.rs
@@ -87,7 +87,7 @@ impl Decode for Slot {
     /// Reads a slot from the buffer.
     fn decode(buf: &mut &[u8]) -> Result<Self> {
         let item_count = VarInt::decode(buf)?.0;
-        if item_count == 0 {
+        if item_count <= 0 {
             return Ok(Self::empty());
         }
 

--- a/fuzz/fuzz_targets/nbt.rs
+++ b/fuzz/fuzz_targets/nbt.rs
@@ -10,12 +10,17 @@ fuzz_target!(|data: &[u8]| {
 
     // Fuzz NbtCompound decode — must not panic on arbitrary input
     if let Ok(compound) = NbtCompound::decode(&mut cursor) {
-        // If decode succeeds, roundtrip must produce identical NBT
+        // If decode succeeds, roundtrip must produce identical bytes.
+        // We compare encoded bytes rather than struct equality because
+        // NaN floats break PartialEq (NaN != NaN in IEEE 754).
         let mut buf = Vec::with_capacity(compound.encoded_size());
         compound.encode(&mut buf).unwrap();
 
+        let mut buf2 = Vec::new();
         let mut check = buf.as_slice();
         let roundtrip = NbtCompound::decode(&mut check).unwrap();
-        assert_eq!(compound, roundtrip);
+        roundtrip.encode(&mut buf2).unwrap();
+
+        assert_eq!(buf, buf2);
     }
 });


### PR DESCRIPTION
## Summary

Fixes the two crashes found by the fuzz nightly run:

- **fuzz_slot**: `Slot::decode` accepted negative `item_count` (e.g. -1342177281 from VarInt `ff ff ff ff 7a`). This caused an encode/decode mismatch: `encoded_size` used the `!= 0` path while `encode` used the `> 0` path. Fix: treat any non-positive item_count as an empty slot.

- **fuzz_nbt**: The fuzz target used `assert_eq!(compound, roundtrip)` which fails for compounds containing NaN floats because `NaN != NaN` in IEEE 754. Fix: compare re-encoded bytes instead of struct equality.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All tests pass
- [ ] Fuzz smoke in CI should pass for both targets
