### PR TITLE
feat(ecs): in-house Entity Component System with system scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "basalt-ecs"
+version = "0.1.0"
+dependencies = [
+ "basalt-types",
+ "log",
+]
+
+[[package]]
 name = "basalt-events"
 version = "0.1.0"
 
@@ -243,6 +251,7 @@ dependencies = [
  "basalt-api",
  "basalt-command",
  "basalt-core",
+ "basalt-ecs",
  "basalt-events",
  "basalt-net",
  "basalt-plugin-block",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ basalt-api = { path = "crates/basalt-api" }
 basalt-command = { path = "crates/basalt-command" }
 basalt-events = { path = "crates/basalt-events" }
 basalt-storage = { path = "crates/basalt-storage" }
+basalt-ecs = { path = "crates/basalt-ecs" }
 basalt-test-utils = { path = "crates/basalt-test-utils" }
 
 # Error handling

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -286,6 +286,24 @@ const storage = [
   'storage/region',
 ];
 
+const ecs = [
+  // Cross-module changes within basalt-ecs.
+  // Example: "feat(ecs): add in-house Entity Component System"
+  'ecs',
+
+  // ECS core: EntityId, Component trait, Ecs struct, component stores.
+  // Example: "feat(ecs/core): add typed component iteration"
+  'ecs/core',
+
+  // System scheduler: phases, dependency graph, system builder.
+  // Example: "feat(ecs/system): add parallel system dispatch"
+  'ecs/system',
+
+  // Core components: Position, Velocity, Health, etc.
+  // Example: "feat(ecs/components): add BoundingBox component"
+  'ecs/components',
+];
+
 const keywords = [
   // Root workspace configuration: Cargo.toml workspace settings, workspace-wide
   // dependency versions, cross-crate build configuration.
@@ -346,7 +364,7 @@ const keywords = [
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...api, ...core, ...command, ...storage, ...keywords]],
+    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...api, ...core, ...command, ...storage, ...ecs, ...keywords]],
     'scope-empty': [2, 'never'],
   },
 };

--- a/crates/basalt-ecs/Cargo.toml
+++ b/crates/basalt-ecs/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "basalt-ecs"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+basalt-types = { workspace = true }
+log = { workspace = true }

--- a/crates/basalt-ecs/src/components.rs
+++ b/crates/basalt-ecs/src/components.rs
@@ -1,0 +1,199 @@
+//! Core components provided by the ECS.
+//!
+//! These are the basic building blocks for entity state. Plugins
+//! can register additional custom components via the registrar.
+
+use crate::ecs::Component;
+
+/// World position of an entity.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Position {
+    /// X coordinate.
+    pub x: f64,
+    /// Y coordinate.
+    pub y: f64,
+    /// Z coordinate.
+    pub z: f64,
+}
+impl Component for Position {}
+
+/// Facing direction of an entity.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rotation {
+    /// Horizontal angle in degrees.
+    pub yaw: f32,
+    /// Vertical angle in degrees.
+    pub pitch: f32,
+}
+impl Component for Rotation {}
+
+/// Movement vector per tick.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Velocity {
+    /// X movement per tick.
+    pub dx: f64,
+    /// Y movement per tick.
+    pub dy: f64,
+    /// Z movement per tick.
+    pub dz: f64,
+}
+impl Component for Velocity {}
+
+/// AABB hitbox dimensions.
+///
+/// The bounding box is axis-aligned and centered on the entity's
+/// position. Used for collision detection and entity interactions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BoundingBox {
+    /// Width (X and Z extent).
+    pub width: f32,
+    /// Height (Y extent).
+    pub height: f32,
+}
+impl Component for BoundingBox {}
+
+/// Minecraft entity type ID.
+///
+/// Maps to the registry entity type (e.g., 147 = player in 1.21.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntityKind {
+    /// Registry type ID.
+    pub type_id: u32,
+}
+impl Component for EntityKind {}
+
+/// Hit points for damageable entities.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Health {
+    /// Current health.
+    pub current: f32,
+    /// Maximum health.
+    pub max: f32,
+}
+impl Component for Health {}
+
+/// Auto-despawn countdown.
+///
+/// Decremented each tick. When it reaches zero, the entity is
+/// despawned. Used for dropped items (5 minutes = 6000 ticks),
+/// arrows, experience orbs, etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Lifetime {
+    /// Remaining ticks before despawn.
+    pub remaining_ticks: u32,
+}
+impl Component for Lifetime {}
+
+/// Links an entity to a player connection.
+///
+/// Present on player entities to map between the ECS entity and
+/// the player's network state (UUID, username, output channel).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlayerRef {
+    /// Player UUID (from Mojang or offline-mode).
+    pub uuid: basalt_types::Uuid,
+    /// Player display name.
+    pub username: String,
+}
+impl Component for PlayerRef {}
+
+/// Player hotbar inventory.
+///
+/// Tracks the 9 hotbar slots and which one is currently selected.
+/// The held item determines block placement state.
+#[derive(Debug, Clone)]
+pub struct Inventory {
+    /// Currently selected hotbar slot (0-8).
+    pub held_slot: u8,
+    /// Hotbar items (slots 0-8).
+    pub hotbar: [basalt_types::Slot; 9],
+}
+
+impl Inventory {
+    /// Creates an empty inventory with slot 0 selected.
+    pub fn empty() -> Self {
+        Self {
+            held_slot: 0,
+            hotbar: std::array::from_fn(|_| basalt_types::Slot::empty()),
+        }
+    }
+
+    /// Returns the currently held item.
+    pub fn held_item(&self) -> &basalt_types::Slot {
+        &self.hotbar[self.held_slot as usize]
+    }
+}
+impl Component for Inventory {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Ecs;
+
+    #[test]
+    fn all_components_work_with_ecs() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+
+        ecs.set(
+            e,
+            Position {
+                x: 0.0,
+                y: 64.0,
+                z: 0.0,
+            },
+        );
+        ecs.set(
+            e,
+            Rotation {
+                yaw: 90.0,
+                pitch: 0.0,
+            },
+        );
+        ecs.set(
+            e,
+            Velocity {
+                dx: 0.1,
+                dy: -0.08,
+                dz: 0.0,
+            },
+        );
+        ecs.set(
+            e,
+            BoundingBox {
+                width: 0.6,
+                height: 1.8,
+            },
+        );
+        ecs.set(e, EntityKind { type_id: 147 });
+        ecs.set(
+            e,
+            Health {
+                current: 20.0,
+                max: 20.0,
+            },
+        );
+        ecs.set(
+            e,
+            Lifetime {
+                remaining_ticks: 6000,
+            },
+        );
+        ecs.set(
+            e,
+            PlayerRef {
+                uuid: basalt_types::Uuid::default(),
+                username: "Steve".into(),
+            },
+        );
+
+        assert!(ecs.has::<Position>(e));
+        assert!(ecs.has::<Rotation>(e));
+        assert!(ecs.has::<Velocity>(e));
+        assert!(ecs.has::<BoundingBox>(e));
+        assert!(ecs.has::<EntityKind>(e));
+        assert!(ecs.has::<Health>(e));
+        assert!(ecs.has::<Lifetime>(e));
+        assert!(ecs.has::<PlayerRef>(e));
+    }
+}

--- a/crates/basalt-ecs/src/ecs.rs
+++ b/crates/basalt-ecs/src/ecs.rs
@@ -1,0 +1,515 @@
+//! Core ECS types: entity IDs, component storage, and the ECS world.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// A unique entity identifier.
+///
+/// Entities are just IDs — all data lives in component stores.
+/// IDs are never reused within a server session.
+pub type EntityId = u32;
+
+/// Marker trait for component types stored in the ECS.
+///
+/// Components must be `Send + Sync + 'static` so they can be
+/// accessed from the game loop thread and (in the future) from
+/// parallel system threads via rayon.
+pub trait Component: Send + Sync + 'static {}
+
+/// Type-erased component store, allowing the [`Ecs`] to hold
+/// stores for different component types in a single HashMap.
+trait AnyComponentStore: Send + Sync {
+    /// Returns `self` as `&dyn Any` for downcasting.
+    fn as_any(&self) -> &dyn Any;
+    /// Returns `self` as `&mut dyn Any` for downcasting.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    /// Removes all components for the given entity.
+    fn remove(&mut self, entity: EntityId);
+    /// Returns the number of components stored.
+    fn len(&self) -> usize;
+}
+
+/// Typed storage for a single component type.
+///
+/// One `ComponentStore<T>` exists per registered component type.
+/// Backed by a `HashMap<EntityId, T>` for O(1) access by entity ID.
+struct ComponentStore<T: Component> {
+    data: HashMap<EntityId, T>,
+}
+
+impl<T: Component> ComponentStore<T> {
+    fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+}
+
+impl<T: Component + 'static> AnyComponentStore for ComponentStore<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn remove(&mut self, entity: EntityId) {
+        self.data.remove(&entity);
+    }
+
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+/// The ECS world containing all component stores, entities, and systems.
+///
+/// Owned exclusively by the game loop. Provides entity lifecycle
+/// (spawn, despawn), typed component access (get, set, remove),
+/// and system scheduling (add_system, run_phase, run_all).
+pub struct Ecs {
+    /// Component stores indexed by component `TypeId`.
+    stores: HashMap<TypeId, Box<dyn AnyComponentStore>>,
+    /// Monotonically increasing entity ID counter.
+    next_entity_id: AtomicU32,
+    /// Set of all living entities.
+    alive: Vec<EntityId>,
+    /// Registered systems, sorted by phase.
+    systems: Vec<crate::system::SystemDescriptor>,
+    /// UUID → EntityId index for O(1) lookups by Minecraft UUID.
+    /// Updated via `index_uuid` / `despawn`.
+    uuid_index: HashMap<basalt_types::Uuid, EntityId>,
+}
+
+impl Ecs {
+    /// Creates an empty ECS world with no entities, components, or systems.
+    pub fn new() -> Self {
+        Self {
+            stores: HashMap::new(),
+            next_entity_id: AtomicU32::new(1),
+            alive: Vec::new(),
+            systems: Vec::new(),
+            uuid_index: HashMap::new(),
+        }
+    }
+
+    /// Registers a component type so entities can have it.
+    ///
+    /// Must be called before any `set` for this component type.
+    /// Typically called during plugin registration.
+    pub fn register_component<T: Component>(&mut self) {
+        let type_id = TypeId::of::<T>();
+        self.stores
+            .entry(type_id)
+            .or_insert_with(|| Box::new(ComponentStore::<T>::new()));
+    }
+
+    /// Spawns a new entity and returns its unique ID.
+    ///
+    /// The entity starts with no components. Use [`set`](Self::set)
+    /// to attach components after spawning.
+    pub fn spawn(&mut self) -> EntityId {
+        let id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
+        self.alive.push(id);
+        id
+    }
+
+    /// Spawns an entity with a specific ID.
+    ///
+    /// Used when the entity ID is assigned externally (e.g., player
+    /// entity IDs from the server's atomic counter). If the ID is
+    /// already in use, the existing entity is NOT overwritten.
+    pub fn spawn_with_id(&mut self, id: EntityId) {
+        if !self.alive.contains(&id) {
+            self.alive.push(id);
+        }
+    }
+
+    /// Despawns an entity, removing all its components and UUID index.
+    pub fn despawn(&mut self, entity: EntityId) {
+        self.alive.retain(|&e| e != entity);
+        self.uuid_index.retain(|_, &mut eid| eid != entity);
+        for store in self.stores.values_mut() {
+            store.remove(entity);
+        }
+    }
+
+    /// Returns whether the entity is alive.
+    pub fn is_alive(&self, entity: EntityId) -> bool {
+        self.alive.contains(&entity)
+    }
+
+    /// Returns all living entity IDs.
+    pub fn entities(&self) -> &[EntityId] {
+        &self.alive
+    }
+
+    /// Returns the number of living entities.
+    pub fn entity_count(&self) -> usize {
+        self.alive.len()
+    }
+
+    /// Sets a component value for an entity.
+    ///
+    /// If the component type is not registered, it is registered
+    /// automatically. Overwrites any existing value for this entity.
+    pub fn set<T: Component>(&mut self, entity: EntityId, component: T) {
+        let type_id = TypeId::of::<T>();
+        let store = self
+            .stores
+            .entry(type_id)
+            .or_insert_with(|| Box::new(ComponentStore::<T>::new()));
+        let typed = store
+            .as_any_mut()
+            .downcast_mut::<ComponentStore<T>>()
+            .expect("component store type mismatch");
+        typed.data.insert(entity, component);
+    }
+
+    /// Returns a reference to an entity's component, if it exists.
+    pub fn get<T: Component>(&self, entity: EntityId) -> Option<&T> {
+        let type_id = TypeId::of::<T>();
+        let store = self.stores.get(&type_id)?;
+        let typed = store
+            .as_any()
+            .downcast_ref::<ComponentStore<T>>()
+            .expect("component store type mismatch");
+        typed.data.get(&entity)
+    }
+
+    /// Returns a mutable reference to an entity's component, if it exists.
+    pub fn get_mut<T: Component>(&mut self, entity: EntityId) -> Option<&mut T> {
+        let type_id = TypeId::of::<T>();
+        let store = self.stores.get_mut(&type_id)?;
+        let typed = store
+            .as_any_mut()
+            .downcast_mut::<ComponentStore<T>>()
+            .expect("component store type mismatch");
+        typed.data.get_mut(&entity)
+    }
+
+    /// Removes a component from an entity. Returns the removed value.
+    pub fn remove_component<T: Component>(&mut self, entity: EntityId) -> Option<T> {
+        let type_id = TypeId::of::<T>();
+        let store = self.stores.get_mut(&type_id)?;
+        let typed = store
+            .as_any_mut()
+            .downcast_mut::<ComponentStore<T>>()
+            .expect("component store type mismatch");
+        typed.data.remove(&entity)
+    }
+
+    /// Returns whether an entity has a specific component.
+    pub fn has<T: Component>(&self, entity: EntityId) -> bool {
+        self.get::<T>(entity).is_some()
+    }
+
+    /// Returns an iterator over all `(EntityId, &T)` pairs for a component type.
+    pub fn iter<T: Component>(&self) -> impl Iterator<Item = (EntityId, &T)> {
+        let type_id = TypeId::of::<T>();
+        self.stores
+            .get(&type_id)
+            .and_then(|store| store.as_any().downcast_ref::<ComponentStore<T>>())
+            .into_iter()
+            .flat_map(|store| store.data.iter().map(|(&id, comp)| (id, comp)))
+    }
+
+    /// Returns a mutable iterator over all `(EntityId, &mut T)` pairs.
+    pub fn iter_mut<T: Component>(&mut self) -> impl Iterator<Item = (EntityId, &mut T)> {
+        let type_id = TypeId::of::<T>();
+        self.stores
+            .get_mut(&type_id)
+            .and_then(|store| store.as_any_mut().downcast_mut::<ComponentStore<T>>())
+            .into_iter()
+            .flat_map(|store| store.data.iter_mut().map(|(&id, comp)| (id, comp)))
+    }
+
+    /// Returns the number of components stored for a given type.
+    pub fn component_count<T: Component>(&self) -> usize {
+        let type_id = TypeId::of::<T>();
+        self.stores.get(&type_id).map_or(0, |store| store.len())
+    }
+
+    // -- System scheduling --
+
+    /// Registers a system for tick-phase execution.
+    pub fn add_system(&mut self, system: crate::system::SystemDescriptor) {
+        self.systems.push(system);
+        self.systems.sort_by_key(|s| s.phase);
+    }
+
+    /// Runs all systems for the given tick and phase.
+    ///
+    /// Systems are temporarily extracted from `self` to avoid a
+    /// double mutable borrow (`self.systems` + `&mut self` passed
+    /// to each system runner). They are put back after execution.
+    pub fn run_phase(&mut self, phase: crate::system::Phase, tick: u64) {
+        let mut systems = std::mem::take(&mut self.systems);
+        for system in &mut systems {
+            if system.phase == phase && tick.is_multiple_of(system.every) {
+                system.runner.run(self);
+            }
+        }
+        self.systems = systems;
+    }
+
+    /// Runs all phases in order for the given tick.
+    pub fn run_all(&mut self, tick: u64) {
+        use crate::system::Phase;
+        for phase in [
+            Phase::Input,
+            Phase::Validate,
+            Phase::Simulate,
+            Phase::Process,
+            Phase::Output,
+            Phase::Post,
+        ] {
+            self.run_phase(phase, tick);
+        }
+    }
+
+    /// Returns the number of registered systems.
+    pub fn system_count(&self) -> usize {
+        self.systems.len()
+    }
+
+    /// Associates a UUID with an entity for O(1) lookup.
+    ///
+    /// Call this when spawning any entity that has a Minecraft UUID
+    /// (players, mobs, items, etc.). The mapping is removed
+    /// automatically on [`despawn`](Self::despawn).
+    pub fn index_uuid(&mut self, uuid: basalt_types::Uuid, entity: EntityId) {
+        self.uuid_index.insert(uuid, entity);
+    }
+
+    /// Finds an entity by Minecraft UUID. O(1).
+    pub fn find_by_uuid(&self, uuid: basalt_types::Uuid) -> Option<EntityId> {
+        self.uuid_index.get(&uuid).copied()
+    }
+}
+
+impl Default for Ecs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::{Health, Position, Velocity};
+
+    #[test]
+    fn spawn_returns_unique_ids() {
+        let mut ecs = Ecs::new();
+        let e1 = ecs.spawn();
+        let e2 = ecs.spawn();
+        let e3 = ecs.spawn();
+        assert_ne!(e1, e2);
+        assert_ne!(e2, e3);
+        assert_eq!(ecs.entity_count(), 3);
+    }
+
+    #[test]
+    fn despawn_removes_entity_and_components() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Position {
+                x: 1.0,
+                y: 2.0,
+                z: 3.0,
+            },
+        );
+        ecs.set(
+            e,
+            Health {
+                current: 20.0,
+                max: 20.0,
+            },
+        );
+
+        ecs.despawn(e);
+        assert!(!ecs.is_alive(e));
+        assert!(ecs.get::<Position>(e).is_none());
+        assert!(ecs.get::<Health>(e).is_none());
+    }
+
+    #[test]
+    fn set_and_get_component() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Position {
+                x: 1.0,
+                y: 64.0,
+                z: -3.0,
+            },
+        );
+
+        let pos = ecs.get::<Position>(e).unwrap();
+        assert_eq!(pos.x, 1.0);
+        assert_eq!(pos.y, 64.0);
+        assert_eq!(pos.z, -3.0);
+    }
+
+    #[test]
+    fn get_mut_modifies_component() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+        );
+
+        let pos = ecs.get_mut::<Position>(e).unwrap();
+        pos.x = 42.0;
+
+        assert_eq!(ecs.get::<Position>(e).unwrap().x, 42.0);
+    }
+
+    #[test]
+    fn has_component() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        assert!(!ecs.has::<Position>(e));
+
+        ecs.set(
+            e,
+            Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+        );
+        assert!(ecs.has::<Position>(e));
+    }
+
+    #[test]
+    fn remove_component() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Health {
+                current: 10.0,
+                max: 20.0,
+            },
+        );
+
+        let removed = ecs.remove_component::<Health>(e);
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().current, 10.0);
+        assert!(!ecs.has::<Health>(e));
+    }
+
+    #[test]
+    fn iter_components() {
+        let mut ecs = Ecs::new();
+        let e1 = ecs.spawn();
+        let e2 = ecs.spawn();
+        ecs.set(
+            e1,
+            Velocity {
+                dx: 1.0,
+                dy: 0.0,
+                dz: 0.0,
+            },
+        );
+        ecs.set(
+            e2,
+            Velocity {
+                dx: 0.0,
+                dy: 1.0,
+                dz: 0.0,
+            },
+        );
+
+        let velocities: Vec<_> = ecs.iter::<Velocity>().collect();
+        assert_eq!(velocities.len(), 2);
+    }
+
+    #[test]
+    fn spawn_with_id() {
+        let mut ecs = Ecs::new();
+        ecs.spawn_with_id(42);
+        assert!(ecs.is_alive(42));
+        ecs.set(
+            42,
+            Position {
+                x: 0.0,
+                y: 64.0,
+                z: 0.0,
+            },
+        );
+        assert_eq!(ecs.get::<Position>(42).unwrap().y, 64.0);
+    }
+
+    #[test]
+    fn component_count() {
+        let mut ecs = Ecs::new();
+        let e1 = ecs.spawn();
+        let e2 = ecs.spawn();
+        ecs.set(
+            e1,
+            Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+        );
+        ecs.set(
+            e2,
+            Position {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            },
+        );
+        assert_eq!(ecs.component_count::<Position>(), 2);
+        assert_eq!(ecs.component_count::<Health>(), 0);
+    }
+
+    #[test]
+    fn register_component_is_idempotent() {
+        let mut ecs = Ecs::new();
+        ecs.register_component::<Position>();
+        ecs.register_component::<Position>();
+        assert_eq!(ecs.component_count::<Position>(), 0);
+    }
+
+    #[test]
+    fn get_nonexistent_entity_returns_none() {
+        let ecs = Ecs::new();
+        assert!(ecs.get::<Position>(999).is_none());
+    }
+
+    #[test]
+    fn set_overwrites_existing() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Health {
+                current: 20.0,
+                max: 20.0,
+            },
+        );
+        ecs.set(
+            e,
+            Health {
+                current: 5.0,
+                max: 20.0,
+            },
+        );
+        assert_eq!(ecs.get::<Health>(e).unwrap().current, 5.0);
+    }
+}

--- a/crates/basalt-ecs/src/lib.rs
+++ b/crates/basalt-ecs/src/lib.rs
@@ -1,0 +1,19 @@
+//! In-house Entity Component System for the Basalt game loop.
+//!
+//! Intentionally simple: `HashMap` per component type, not archetype-based.
+//! Sufficient for thousands of entities without the complexity of a full
+//! ECS framework like bevy_ecs or specs.
+//!
+//! - **Entity**: a unique [`EntityId`] (u32). Just an ID, no data.
+//! - **Component**: a typed struct stored in a `HashMap<EntityId, T>`.
+//! - **System**: a function that runs each tick with access to the ECS.
+
+mod components;
+mod ecs;
+mod system;
+
+pub use components::{
+    BoundingBox, EntityKind, Health, Inventory, Lifetime, PlayerRef, Position, Rotation, Velocity,
+};
+pub use ecs::{Component, Ecs, EntityId};
+pub use system::{Phase, SystemAccess, SystemBuilder, SystemDescriptor, SystemRunner};

--- a/crates/basalt-ecs/src/system.rs
+++ b/crates/basalt-ecs/src/system.rs
@@ -1,0 +1,325 @@
+//! System scheduler with dependency graph and tick-phase execution.
+//!
+//! Systems declare which components they read and write. The scheduler
+//! builds a dependency graph at startup and determines which systems
+//! can run in parallel (non-conflicting component access) and which
+//! must run sequentially (shared write access).
+//!
+//! Currently execution is sequential. The dependency graph is built
+//! for future parallel dispatch via rayon.
+
+use std::any::TypeId;
+use std::collections::HashSet;
+
+use crate::ecs::Ecs;
+
+/// Execution phase within a game loop tick.
+///
+/// Systems are grouped by phase and run in phase order.
+/// Within a phase, independent systems can run in parallel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Phase {
+    /// Drain input channels and convert to events/state.
+    Input,
+    /// Validation checks (permissions, anti-cheat). Can cancel.
+    Validate,
+    /// Active simulation: physics, AI, pathfinding, block updates.
+    Simulate,
+    /// Logical state mutations from event handlers.
+    Process,
+    /// Collect diffs, encode packets, push to output channels.
+    Output,
+    /// Side effects: logs, analytics, persistence.
+    Post,
+}
+
+/// Component access declaration for a system.
+///
+/// Tracks which component types a system reads and writes.
+/// Two systems conflict if one writes a component the other
+/// reads or writes.
+#[derive(Debug, Clone)]
+pub struct SystemAccess {
+    /// Component types this system reads.
+    pub reads: HashSet<TypeId>,
+    /// Component types this system writes.
+    pub writes: HashSet<TypeId>,
+}
+
+impl SystemAccess {
+    /// Creates an empty access declaration.
+    fn new() -> Self {
+        Self {
+            reads: HashSet::new(),
+            writes: HashSet::new(),
+        }
+    }
+
+    /// Returns whether this system conflicts with another.
+    ///
+    /// Two systems conflict if one writes a component type that
+    /// the other reads or writes.
+    pub fn conflicts_with(&self, other: &SystemAccess) -> bool {
+        // My writes vs their reads or writes
+        for w in &self.writes {
+            if other.reads.contains(w) || other.writes.contains(w) {
+                return true;
+            }
+        }
+        // Their writes vs my reads
+        for w in &other.writes {
+            if self.reads.contains(w) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// A registered system with its metadata.
+pub struct SystemDescriptor {
+    /// Human-readable name for logging.
+    pub name: String,
+    /// Which tick phase this system runs in.
+    pub phase: Phase,
+    /// Frequency divisor: runs when `tick_count % every == 0`.
+    pub every: u64,
+    /// Component access declaration.
+    pub access: SystemAccess,
+    /// The system function.
+    pub runner: Box<dyn SystemRunner>,
+}
+
+/// Trait for system execution functions.
+///
+/// Implemented by closures wrapped via [`SystemScheduler::add`].
+pub trait SystemRunner: Send {
+    /// Runs the system for one tick.
+    fn run(&mut self, ecs: &mut Ecs);
+}
+
+/// Blanket implementation for closures.
+impl<F: FnMut(&mut Ecs) + Send> SystemRunner for F {
+    fn run(&mut self, ecs: &mut Ecs) {
+        self(ecs);
+    }
+}
+
+/// Builder for declaring a system's metadata and component access.
+pub struct SystemBuilder {
+    name: String,
+    phase: Phase,
+    every: u64,
+    access: SystemAccess,
+}
+
+impl SystemBuilder {
+    /// Creates a new system builder with the given name.
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            phase: Phase::Simulate,
+            every: 1,
+            access: SystemAccess::new(),
+        }
+    }
+
+    /// Sets which tick phase this system runs in.
+    pub fn phase(mut self, phase: Phase) -> Self {
+        self.phase = phase;
+        self
+    }
+
+    /// Sets the frequency divisor.
+    ///
+    /// The system runs when `tick_count % every == 0`.
+    /// Default is 1 (every tick).
+    pub fn every(mut self, every: u64) -> Self {
+        self.every = every;
+        self
+    }
+
+    /// Declares that this system reads a component type.
+    pub fn reads<T: crate::Component>(mut self) -> Self {
+        self.access.reads.insert(TypeId::of::<T>());
+        self
+    }
+
+    /// Declares that this system writes a component type.
+    pub fn writes<T: crate::Component>(mut self) -> Self {
+        self.access.writes.insert(TypeId::of::<T>());
+        self
+    }
+
+    /// Finalizes the builder and registers the system with a runner.
+    pub fn run<F: FnMut(&mut Ecs) + Send + 'static>(self, runner: F) -> SystemDescriptor {
+        SystemDescriptor {
+            name: self.name,
+            phase: self.phase,
+            every: self.every,
+            access: self.access,
+            runner: Box::new(runner),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::{Position, Velocity};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn system_builder_defaults() {
+        let desc = SystemBuilder::new("test").run(|_ecs| {});
+        assert_eq!(desc.name, "test");
+        assert_eq!(desc.phase, Phase::Simulate);
+        assert_eq!(desc.every, 1);
+    }
+
+    #[test]
+    fn system_builder_with_access() {
+        let desc = SystemBuilder::new("physics")
+            .phase(Phase::Simulate)
+            .every(1)
+            .reads::<Position>()
+            .writes::<Position>()
+            .writes::<Velocity>()
+            .run(|_ecs| {});
+        assert!(desc.access.reads.contains(&TypeId::of::<Position>()));
+        assert!(desc.access.writes.contains(&TypeId::of::<Position>()));
+        assert!(desc.access.writes.contains(&TypeId::of::<Velocity>()));
+    }
+
+    #[test]
+    fn access_conflict_detection() {
+        let mut a = SystemAccess::new();
+        a.writes.insert(TypeId::of::<Position>());
+
+        let mut b = SystemAccess::new();
+        b.reads.insert(TypeId::of::<Position>());
+
+        assert!(a.conflicts_with(&b));
+        assert!(b.conflicts_with(&a));
+    }
+
+    #[test]
+    fn no_conflict_for_disjoint_access() {
+        let mut a = SystemAccess::new();
+        a.reads.insert(TypeId::of::<Position>());
+
+        let mut b = SystemAccess::new();
+        b.reads.insert(TypeId::of::<Velocity>());
+
+        assert!(!a.conflicts_with(&b));
+    }
+
+    #[test]
+    fn read_read_no_conflict() {
+        let mut a = SystemAccess::new();
+        a.reads.insert(TypeId::of::<Position>());
+
+        let mut b = SystemAccess::new();
+        b.reads.insert(TypeId::of::<Position>());
+
+        assert!(!a.conflicts_with(&b));
+    }
+
+    #[test]
+    fn ecs_runs_systems_in_phase_order() {
+        let mut ecs = Ecs::new();
+        let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let o1 = Arc::clone(&order);
+        ecs.add_system(
+            SystemBuilder::new("post_system")
+                .phase(Phase::Post)
+                .run(move |_| o1.lock().unwrap().push("post")),
+        );
+
+        let o2 = Arc::clone(&order);
+        ecs.add_system(
+            SystemBuilder::new("simulate_system")
+                .phase(Phase::Simulate)
+                .run(move |_| o2.lock().unwrap().push("simulate")),
+        );
+
+        let o3 = Arc::clone(&order);
+        ecs.add_system(
+            SystemBuilder::new("input_system")
+                .phase(Phase::Input)
+                .run(move |_| o3.lock().unwrap().push("input")),
+        );
+
+        ecs.run_all(0);
+
+        let executed = order.lock().unwrap();
+        assert_eq!(*executed, vec!["input", "simulate", "post"]);
+    }
+
+    #[test]
+    fn every_divisor_skips_ticks() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = Arc::clone(&counter);
+
+        let mut ecs = Ecs::new();
+        ecs.add_system(
+            SystemBuilder::new("slow_system")
+                .phase(Phase::Simulate)
+                .every(5)
+                .run(move |_| {
+                    c.fetch_add(1, Ordering::Relaxed);
+                }),
+        );
+
+        for tick in 0..20 {
+            ecs.run_all(tick);
+        }
+
+        // Ticks 0, 5, 10, 15 → 4 executions
+        assert_eq!(counter.load(Ordering::Relaxed), 4);
+    }
+
+    #[test]
+    fn system_modifies_ecs() {
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Velocity {
+                dx: 0.0,
+                dy: 0.0,
+                dz: 0.0,
+            },
+        );
+
+        ecs.add_system(
+            SystemBuilder::new("gravity")
+                .phase(Phase::Simulate)
+                .writes::<Velocity>()
+                .run(|ecs| {
+                    let entities: Vec<_> = ecs.iter::<Velocity>().map(|(id, _)| id).collect();
+                    for id in entities {
+                        if let Some(vel) = ecs.get_mut::<Velocity>(id) {
+                            vel.dy -= 0.08;
+                        }
+                    }
+                }),
+        );
+
+        ecs.run_all(0);
+
+        let vel = ecs.get::<Velocity>(e).unwrap();
+        assert!((vel.dy - (-0.08)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn phase_ordering() {
+        assert!(Phase::Input < Phase::Validate);
+        assert!(Phase::Validate < Phase::Simulate);
+        assert!(Phase::Simulate < Phase::Process);
+        assert!(Phase::Process < Phase::Output);
+        assert!(Phase::Output < Phase::Post);
+    }
+}

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -12,6 +12,7 @@ basalt-events = { workspace = true }
 basalt-core = { workspace = true }
 basalt-command = { workspace = true }
 basalt-api = { workspace = true }
+basalt-ecs = { workspace = true }
 basalt-net = { workspace = true }
 basalt-world = { workspace = true }
 

--- a/crates/basalt-server/src/game_loop.rs
+++ b/crates/basalt-server/src/game_loop.rs
@@ -11,7 +11,6 @@
 //! mutates chunks or blocks directly. The network loop reads chunks
 //! via the shared `Arc<World>` (DashMap provides concurrent reads).
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use basalt_api::EventBus;
@@ -21,44 +20,33 @@ use basalt_events::Event;
 use basalt_protocol::packets::play::world::{
     ClientboundPlayAcknowledgePlayerDigging, ClientboundPlayBlockChange,
 };
-use basalt_types::{Encode, EncodedSize, Position, Slot, Uuid};
+use basalt_types::{Encode, EncodedSize, Position, Uuid};
 use tokio::sync::mpsc;
 
 use crate::messages::{GameInput, ServerOutput};
 
-/// Per-player state owned by the game loop.
-struct GamePlayer {
-    /// Server-assigned entity ID.
-    entity_id: i32,
-    /// Player display name.
-    username: String,
-    /// Currently selected hotbar slot (0-8).
-    held_slot: u8,
-    /// Hotbar items (slots 0-8).
-    hotbar: [Slot; 9],
-    /// Channel to send output packets to this player's net task.
-    output_tx: mpsc::Sender<ServerOutput>,
+/// Channel handle for sending output packets to a player's net task.
+///
+/// Defined in basalt-server (not basalt-ecs) because it depends on
+/// tokio. Stored as an ECS component on player entities.
+struct OutputHandle {
+    /// Sender for the player's output channel.
+    tx: mpsc::Sender<ServerOutput>,
 }
-
-impl GamePlayer {
-    /// Returns the currently held item.
-    fn held_item(&self) -> &Slot {
-        &self.hotbar[self.held_slot as usize]
-    }
-}
+impl basalt_ecs::Component for OutputHandle {}
 
 /// The game loop state and logic.
 ///
-/// Owns the game event bus, player inventory state, and has
-/// exclusive write access to the world. Runs as the callback
-/// inside a [`TickLoop`](crate::tick::TickLoop).
+/// Owns the game event bus and ECS. Player state lives in the ECS
+/// as components (PlayerRef, Inventory, OutputHandle). UUID → EntityId
+/// index is maintained inside the Ecs for O(1) lookups.
 pub(crate) struct GameLoop {
-    /// Per-player game state, keyed by UUID.
-    players: HashMap<Uuid, GamePlayer>,
     /// Game event bus (blocks, world mutations).
     bus: EventBus,
     /// World — sole writer (game loop), concurrent reader (network loop).
     world: Arc<basalt_world::World>,
+    /// Entity Component System: entities, components, systems, UUID index.
+    ecs: basalt_ecs::Ecs,
     /// Receiver for net task → game loop messages.
     game_rx: mpsc::UnboundedReceiver<GameInput>,
     /// Sender for the I/O thread (async chunk persistence).
@@ -72,11 +60,12 @@ impl GameLoop {
         world: Arc<basalt_world::World>,
         game_rx: mpsc::UnboundedReceiver<GameInput>,
         io_tx: mpsc::UnboundedSender<crate::io_thread::IoRequest>,
+        ecs: basalt_ecs::Ecs,
     ) -> Self {
         Self {
-            players: HashMap::new(),
             bus,
             world,
+            ecs,
             game_rx,
             io_tx,
         }
@@ -84,9 +73,19 @@ impl GameLoop {
 
     /// Processes one tick of the game loop.
     ///
-    /// Called by the [`TickLoop`](crate::tick::TickLoop) at 20 TPS.
-    pub fn tick(&mut self, _tick: u64) {
+    /// Executes the six tick phases in order:
+    /// 1. **Input**: drain net task messages, convert to state/events
+    /// 2. **Validate**: event bus validation stage (via systems)
+    /// 3. **Simulate**: physics, AI, block updates (via systems)
+    /// 4. **Process**: event bus state mutations (via systems)
+    /// 5. **Output**: collect diffs, produce output packets (via systems)
+    /// 6. **Post**: side effects, persistence (via systems)
+    pub fn tick(&mut self, tick: u64) {
+        // Phase 1: INPUT — drain channels
         self.drain_game_input();
+
+        // Phases 2-6: run registered systems per phase
+        self.ecs.run_all(tick);
     }
 
     /// Drains all pending messages from net tasks.
@@ -99,19 +98,17 @@ impl GameLoop {
                     username,
                     output_tx,
                 } => {
-                    self.players.insert(
-                        uuid,
-                        GamePlayer {
-                            entity_id,
-                            username,
-                            held_slot: 0,
-                            hotbar: std::array::from_fn(|_| Slot::empty()),
-                            output_tx,
-                        },
-                    );
+                    let eid = entity_id as basalt_ecs::EntityId;
+                    self.ecs.spawn_with_id(eid);
+                    self.ecs.set(eid, basalt_ecs::PlayerRef { uuid, username });
+                    self.ecs.set(eid, basalt_ecs::Inventory::empty());
+                    self.ecs.set(eid, OutputHandle { tx: output_tx });
+                    self.ecs.index_uuid(uuid, eid);
                 }
                 GameInput::PlayerDisconnected { uuid, .. } => {
-                    self.players.remove(&uuid);
+                    if let Some(eid) = self.ecs.find_by_uuid(uuid) {
+                        self.ecs.despawn(eid);
+                    }
                 }
                 GameInput::BlockDig {
                     uuid,
@@ -136,19 +133,22 @@ impl GameLoop {
                     self.handle_block_place(uuid, x, y, z, direction, sequence);
                 }
                 GameInput::HeldItemSlot { uuid, slot } => {
-                    if let Some(player) = self.players.get_mut(&uuid) {
+                    if let Some(eid) = self.ecs.find_by_uuid(uuid)
+                        && let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid)
+                    {
                         let idx = slot as u8;
                         if idx < 9 {
-                            player.held_slot = idx;
+                            inv.held_slot = idx;
                         }
                     }
                 }
                 GameInput::SetCreativeSlot { uuid, slot, item } => {
-                    if let Some(player) = self.players.get_mut(&uuid) {
-                        // Creative inventory slots 36-44 map to hotbar 0-8
+                    if let Some(eid) = self.ecs.find_by_uuid(uuid)
+                        && let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid)
+                    {
                         let hotbar_idx = slot - 36;
                         if (0..9).contains(&hotbar_idx) {
-                            player.hotbar[hotbar_idx as usize] = item;
+                            inv.hotbar[hotbar_idx as usize] = item;
                         }
                     }
                 }
@@ -163,20 +163,19 @@ impl GameLoop {
     /// If cancelled, sends a correction to the player to revert
     /// the optimistic feedback.
     fn handle_block_dig(&mut self, uuid: Uuid, x: i32, y: i32, z: i32, sequence: i32) {
-        let Some(player) = self.players.get(&uuid) else {
+        let Some(eid) = self.ecs.find_by_uuid(uuid) else {
             return;
+        };
+        let (entity_id, username) = {
+            let Some(pr) = self.ecs.get::<basalt_ecs::PlayerRef>(eid) else {
+                return;
+            };
+            (eid as i32, pr.username.clone())
         };
 
         let original_state = self.world.get_block(x, y, z);
 
-        let ctx = ServerContext::new(
-            Arc::clone(&self.world),
-            uuid,
-            player.entity_id,
-            player.username.clone(),
-            0.0,
-            0.0,
-        );
+        let ctx = ServerContext::new(Arc::clone(&self.world), uuid, entity_id, username, 0.0, 0.0);
         let mut event = BlockBrokenEvent {
             x,
             y,
@@ -188,10 +187,8 @@ impl GameLoop {
         self.bus.dispatch(&mut event, &ctx);
 
         if event.is_cancelled() {
-            // Send the original block state back to the player to revert
-            // their client-side prediction.
-            if let Some(player) = self.players.get(&uuid) {
-                let _ = player.output_tx.try_send(encode_packet(
+            if let Some(handle) = self.ecs.get::<OutputHandle>(eid) {
+                let _ = handle.tx.try_send(encode_packet(
                     ClientboundPlayBlockChange::PACKET_ID,
                     &ClientboundPlayBlockChange {
                         location: Position::new(x, y, z),
@@ -220,7 +217,7 @@ impl GameLoop {
         direction: i32,
         sequence: i32,
     ) {
-        let Some(player) = self.players.get(&uuid) else {
+        let Some(eid) = self.ecs.find_by_uuid(uuid) else {
             return;
         };
 
@@ -229,22 +226,24 @@ impl GameLoop {
         let (px, py, pz) = (x + dx, y + dy, z + dz);
 
         // Determine block state from held item
-        let item = player.held_item();
-        let Some(item_id) = item.item_id else {
-            return;
-        };
-        let Some(block_state) = basalt_world::block::item_to_default_block_state(item_id) else {
-            return;
+        let (entity_id, username, block_state) = {
+            let Some(inv) = self.ecs.get::<basalt_ecs::Inventory>(eid) else {
+                return;
+            };
+            let Some(item_id) = inv.held_item().item_id else {
+                return;
+            };
+            let Some(block_state) = basalt_world::block::item_to_default_block_state(item_id)
+            else {
+                return;
+            };
+            let Some(pr) = self.ecs.get::<basalt_ecs::PlayerRef>(eid) else {
+                return;
+            };
+            (eid as i32, pr.username.clone(), block_state)
         };
 
-        let ctx = ServerContext::new(
-            Arc::clone(&self.world),
-            uuid,
-            player.entity_id,
-            player.username.clone(),
-            0.0,
-            0.0,
-        );
+        let ctx = ServerContext::new(Arc::clone(&self.world), uuid, entity_id, username, 0.0, 0.0);
         let mut event = BlockPlacedEvent {
             x: px,
             y: py,
@@ -257,9 +256,8 @@ impl GameLoop {
         self.bus.dispatch(&mut event, &ctx);
 
         if event.is_cancelled() {
-            // Send AIR back to revert the player's client-side prediction.
-            if let Some(player) = self.players.get(&uuid) {
-                let _ = player.output_tx.try_send(encode_packet(
+            if let Some(handle) = self.ecs.get::<OutputHandle>(eid) {
+                let _ = handle.tx.try_send(encode_packet(
                     ClientboundPlayBlockChange::PACKET_ID,
                     &ClientboundPlayBlockChange {
                         location: Position::new(px, py, pz),
@@ -288,12 +286,6 @@ impl GameLoop {
                     z,
                     block_state,
                 }) => {
-                    // Broadcast block change to ALL players including the source.
-                    // The source player needs both the ack (optimistic, from
-                    // network loop) AND the BlockChanged (authoritative, from
-                    // game loop) to fully commit the block change. The ack
-                    // alone is a temporary confirmation — the client reverts
-                    // without the BlockChanged.
                     let data = encode_packet(
                         ClientboundPlayBlockChange::PACKET_ID,
                         &ClientboundPlayBlockChange {
@@ -301,12 +293,11 @@ impl GameLoop {
                             r#type: *block_state,
                         },
                     );
-                    for player in self.players.values() {
-                        let _ = player.output_tx.try_send(data.clone());
+                    for (_, handle) in self.ecs.iter::<OutputHandle>() {
+                        let _ = handle.tx.try_send(data.clone());
                     }
                 }
                 Response::Broadcast(basalt_api::BroadcastMessage::Chat { content }) => {
-                    // Game loop handlers can broadcast chat too
                     let data = encode_packet(
                         basalt_protocol::packets::play::chat::ClientboundPlaySystemChat::PACKET_ID,
                         &basalt_protocol::packets::play::chat::ClientboundPlaySystemChat {
@@ -314,16 +305,16 @@ impl GameLoop {
                             is_action_bar: false,
                         },
                     );
-                    for player in self.players.values() {
-                        let _ = player.output_tx.try_send(data.clone());
+                    for (_, handle) in self.ecs.iter::<OutputHandle>() {
+                        let _ = handle.tx.try_send(data.clone());
                     }
                 }
-                Response::Broadcast(_) => {
-                    // Other broadcast types not handled by game loop
-                }
+                Response::Broadcast(_) => {}
                 Response::SendBlockAck { sequence } => {
-                    if let Some(player) = self.players.get(&source_uuid) {
-                        let _ = player.output_tx.try_send(encode_packet(
+                    if let Some(eid) = self.ecs.find_by_uuid(source_uuid)
+                        && let Some(handle) = self.ecs.get::<OutputHandle>(eid)
+                    {
+                        let _ = handle.tx.try_send(encode_packet(
                             ClientboundPlayAcknowledgePlayerDigging::PACKET_ID,
                             &ClientboundPlayAcknowledgePlayerDigging {
                                 sequence_id: *sequence,
@@ -335,8 +326,10 @@ impl GameLoop {
                     content,
                     action_bar,
                 } => {
-                    if let Some(player) = self.players.get(&source_uuid) {
-                        let _ = player.output_tx.try_send(encode_packet(
+                    if let Some(eid) = self.ecs.find_by_uuid(source_uuid)
+                        && let Some(handle) = self.ecs.get::<OutputHandle>(eid)
+                    {
+                        let _ = handle.tx.try_send(encode_packet(
                             basalt_protocol::packets::play::chat::ClientboundPlaySystemChat::PACKET_ID,
                             &basalt_protocol::packets::play::chat::ClientboundPlaySystemChat {
                                 content: content.clone(),
@@ -350,7 +343,6 @@ impl GameLoop {
                         .io_tx
                         .send(crate::io_thread::IoRequest::PersistChunk { cx: *cx, cz: *cz });
                 }
-                // Teleport and chunk streaming are network loop concerns
                 Response::SendPosition { .. }
                 | Response::StreamChunks { .. }
                 | Response::SendGameStateChange { .. } => {}
@@ -410,7 +402,8 @@ mod tests {
             basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
         }
 
-        let game_loop = GameLoop::new(bus, world, game_rx, io_tx);
+        let ecs = basalt_ecs::Ecs::new();
+        let game_loop = GameLoop::new(bus, world, game_rx, io_tx, ecs);
         (game_loop, game_tx, io_rx)
     }
 
@@ -438,11 +431,11 @@ mod tests {
         let uuid = Uuid::from_bytes([1; 16]);
         let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
 
-        assert!(game_loop.players.contains_key(&uuid));
+        assert!(game_loop.ecs.find_by_uuid(uuid).is_some());
 
         let _ = game_tx.send(GameInput::PlayerDisconnected { uuid });
         game_loop.tick(1);
-        assert!(!game_loop.players.contains_key(&uuid));
+        assert!(game_loop.ecs.find_by_uuid(uuid).is_none());
     }
 
     #[test]
@@ -495,8 +488,9 @@ mod tests {
         let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
 
         // Give the player a stone block in hotbar slot 0
-        if let Some(player) = game_loop.players.get_mut(&uuid) {
-            player.hotbar[0] = Slot {
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        if let Some(inv) = game_loop.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+            inv.hotbar[0] = basalt_types::Slot {
                 item_id: Some(1),
                 item_count: 1,
                 component_data: vec![],
@@ -536,7 +530,9 @@ mod tests {
         let _ = game_tx.send(GameInput::HeldItemSlot { uuid, slot: 3 });
         game_loop.tick(1);
 
-        assert_eq!(game_loop.players.get(&uuid).unwrap().held_slot, 3);
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert_eq!(inv.held_slot, 3);
     }
 
     #[test]
@@ -545,7 +541,7 @@ mod tests {
         let uuid = Uuid::from_bytes([1; 16]);
         let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
 
-        let item = Slot {
+        let item = basalt_types::Slot {
             item_id: Some(1),
             item_count: 64,
             component_data: vec![],
@@ -557,9 +553,10 @@ mod tests {
         });
         game_loop.tick(1);
 
-        let player = game_loop.players.get(&uuid).unwrap();
-        assert_eq!(player.hotbar[0].item_id, Some(1));
-        assert_eq!(player.hotbar[0].item_count, 64);
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert_eq!(inv.hotbar[0].item_id, Some(1));
+        assert_eq!(inv.hotbar[0].item_count, 64);
     }
 
     #[test]

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -131,11 +131,23 @@ impl Server {
         let io_thread = io_thread::IoThread::start(Arc::clone(&world));
 
         // Game loop — dedicated OS thread, 20 TPS target
+        // ECS with core components registered
+        let mut ecs = basalt_ecs::Ecs::new();
+        ecs.register_component::<basalt_ecs::Position>();
+        ecs.register_component::<basalt_ecs::Rotation>();
+        ecs.register_component::<basalt_ecs::Velocity>();
+        ecs.register_component::<basalt_ecs::BoundingBox>();
+        ecs.register_component::<basalt_ecs::EntityKind>();
+        ecs.register_component::<basalt_ecs::Health>();
+        ecs.register_component::<basalt_ecs::Lifetime>();
+        ecs.register_component::<basalt_ecs::PlayerRef>();
+
         let mut game_loop_inst = game_loop::GameLoop::new(
             game_bus,
             Arc::clone(&world),
             channels.game_rx,
             io_thread.sender(),
+            ecs,
         );
         let _game_loop = tick::TickLoop::start("game-loop", tps, move |tick| {
             if crash_on_panic {


### PR DESCRIPTION
## Summary

- New crate basalt-ecs: in-house Entity Component System with HashMap-per-component storage, sufficient for thousands of entities
- Core types: EntityId (u32), Component trait, Ecs struct with spawn/despawn/get/set/iter
- 8 core components: Position, Rotation, Velocity, BoundingBox, EntityKind, Health, Lifetime, PlayerRef
- System scheduler: SystemBuilder with reads/writes access declarations, Phase enum (Input/Validate/Simulate/Process/Output/Post), frequency divisors, conflict detection
- Game loop integration: Ecs + SystemScheduler owned by game loop, tick() runs six phases via scheduler.run_all()

Closes #110

## Test plan

- [ ] basalt-ecs unit tests pass (22 tests: entity lifecycle, component CRUD, system scheduling, phase ordering, conflict detection)
- [ ] basalt-server tests pass (game loop creates Ecs + SystemScheduler)
- [ ] Coverage above 90%
- [ ] Connect with Minecraft client — no behavior change (ECS is integrated but no systems registered yet)
