### PR TITLE
feat(api): add system and component registration to PluginRegistrar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ version = "0.1.0"
 dependencies = [
  "basalt-command",
  "basalt-core",
+ "basalt-ecs",
  "basalt-events",
  "basalt-types",
  "basalt-world",

--- a/crates/basalt-api/Cargo.toml
+++ b/crates/basalt-api/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 [dependencies]
 basalt-core = { workspace = true }
 basalt-command = { workspace = true }
+basalt-ecs = { workspace = true }
 basalt-events = { workspace = true }
 basalt-types = { workspace = true }
 basalt-world = { workspace = true }

--- a/crates/basalt-api/src/plugin.rs
+++ b/crates/basalt-api/src/plugin.rs
@@ -59,6 +59,20 @@ pub struct CommandEntry {
 /// Handler registration is routed automatically based on the event
 /// type's [`EventRouting::BUS`] constant — plugins do not specify
 /// which loop handles their events.
+/// A registered component type for deferred ECS registration.
+pub struct ComponentRegistration {
+    /// The TypeId of the component.
+    pub type_id: std::any::TypeId,
+    /// A function that registers the component on the Ecs.
+    pub register_fn: fn(&mut basalt_ecs::Ecs),
+}
+
+/// Plugin registration interface for events, commands, systems, and components.
+///
+/// Holds mutable references to both the network and game event buses.
+/// Handler registration is routed automatically based on the event
+/// type's [`EventRouting::BUS`] constant — plugins do not specify
+/// which loop handles their events.
 pub struct PluginRegistrar<'a> {
     /// Event bus for the network loop (movement, chat, commands).
     network_bus: &'a mut EventBus,
@@ -66,6 +80,10 @@ pub struct PluginRegistrar<'a> {
     game_bus: &'a mut EventBus,
     /// Collected command entries.
     commands: &'a mut Vec<CommandEntry>,
+    /// Collected ECS system descriptors.
+    systems: &'a mut Vec<basalt_ecs::SystemDescriptor>,
+    /// Collected component registrations.
+    components: &'a mut Vec<ComponentRegistration>,
 }
 
 impl<'a> PluginRegistrar<'a> {
@@ -74,11 +92,15 @@ impl<'a> PluginRegistrar<'a> {
         network_bus: &'a mut EventBus,
         game_bus: &'a mut EventBus,
         commands: &'a mut Vec<CommandEntry>,
+        systems: &'a mut Vec<basalt_ecs::SystemDescriptor>,
+        components: &'a mut Vec<ComponentRegistration>,
     ) -> Self {
         Self {
             network_bus,
             game_bus,
             commands,
+            systems,
+            components,
         }
     }
 
@@ -105,6 +127,46 @@ impl<'a> PluginRegistrar<'a> {
         }
     }
 
+    /// Starts building an ECS system for the game loop.
+    ///
+    /// Returns a [`SystemBuilder`](basalt_ecs::SystemBuilder) for
+    /// fluent configuration of phase, frequency, component access,
+    /// and the system runner function.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// registrar.system("gravity")
+    ///     .phase(Phase::Simulate)
+    ///     .every(1)
+    ///     .writes::<Position>()
+    ///     .writes::<Velocity>()
+    ///     .run(|ecs| { /* apply gravity */ });
+    /// ```
+    pub fn system(&mut self, name: &str) -> PluginSystemBuilder<'_, 'a> {
+        PluginSystemBuilder {
+            registrar: self,
+            builder: basalt_ecs::SystemBuilder::new(name),
+        }
+    }
+
+    /// Registers a custom component type in the ECS.
+    ///
+    /// The component is registered on the Ecs after all plugins
+    /// are enabled. Core components (Position, Velocity, etc.) are
+    /// registered automatically — only call this for plugin-specific
+    /// component types.
+    pub fn component<T: basalt_ecs::Component>(&mut self) {
+        let type_id = std::any::TypeId::of::<T>();
+        // Avoid duplicates
+        if !self.components.iter().any(|c| c.type_id == type_id) {
+            self.components.push(ComponentRegistration {
+                type_id,
+                register_fn: |ecs| ecs.register_component::<T>(),
+            });
+        }
+    }
+
     /// Starts building a command with typed arguments.
     pub fn command(&mut self, name: &str) -> CommandBuilder<'_, 'a> {
         CommandBuilder {
@@ -114,6 +176,47 @@ impl<'a> PluginRegistrar<'a> {
             args: Vec::new(),
             variants: Vec::new(),
         }
+    }
+}
+
+/// Fluent builder for registering an ECS system via a plugin.
+///
+/// Wraps [`SystemBuilder`](basalt_ecs::SystemBuilder) and pushes the
+/// resulting descriptor into the registrar's system list on `run()`.
+pub struct PluginSystemBuilder<'r, 'a> {
+    registrar: &'r mut PluginRegistrar<'a>,
+    builder: basalt_ecs::SystemBuilder,
+}
+
+impl<'r, 'a> PluginSystemBuilder<'r, 'a> {
+    /// Sets which tick phase this system runs in.
+    pub fn phase(mut self, phase: basalt_ecs::Phase) -> Self {
+        self.builder = self.builder.phase(phase);
+        self
+    }
+
+    /// Sets the frequency divisor (runs when `tick % every == 0`).
+    pub fn every(mut self, every: u64) -> Self {
+        self.builder = self.builder.every(every);
+        self
+    }
+
+    /// Declares that this system reads a component type.
+    pub fn reads<T: basalt_ecs::Component>(mut self) -> Self {
+        self.builder = self.builder.reads::<T>();
+        self
+    }
+
+    /// Declares that this system writes a component type.
+    pub fn writes<T: basalt_ecs::Component>(mut self) -> Self {
+        self.builder = self.builder.writes::<T>();
+        self
+    }
+
+    /// Sets the system runner and registers the system.
+    pub fn run<F: FnMut(&mut basalt_ecs::Ecs) + Send + 'static>(self, runner: F) {
+        let descriptor = self.builder.run(runner);
+        self.registrar.systems.push(descriptor);
     }
 }
 
@@ -254,9 +357,16 @@ mod tests {
         let mut network_bus = EventBus::new();
         let mut game_bus = EventBus::new();
         let mut commands = Vec::new();
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         {
-            let mut registrar =
-                PluginRegistrar::new(&mut network_bus, &mut game_bus, &mut commands);
+            let mut registrar = PluginRegistrar::new(
+                &mut network_bus,
+                &mut game_bus,
+                &mut commands,
+                &mut systems,
+                &mut components,
+            );
             registrar.on::<ChatMessageEvent>(Stage::Post, 0, |_event, _ctx| {});
             registrar.on::<BlockBrokenEvent>(Stage::Process, 0, |_event, _ctx| {});
         }
@@ -269,9 +379,16 @@ mod tests {
         let mut network_bus = EventBus::new();
         let mut game_bus = EventBus::new();
         let mut commands = Vec::new();
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         {
-            let mut registrar =
-                PluginRegistrar::new(&mut network_bus, &mut game_bus, &mut commands);
+            let mut registrar = PluginRegistrar::new(
+                &mut network_bus,
+                &mut game_bus,
+                &mut commands,
+                &mut systems,
+                &mut components,
+            );
             registrar
                 .command("tp")
                 .description("Teleport")
@@ -291,9 +408,16 @@ mod tests {
         let mut network_bus = EventBus::new();
         let mut game_bus = EventBus::new();
         let mut commands = Vec::new();
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         {
-            let mut registrar =
-                PluginRegistrar::new(&mut network_bus, &mut game_bus, &mut commands);
+            let mut registrar = PluginRegistrar::new(
+                &mut network_bus,
+                &mut game_bus,
+                &mut commands,
+                &mut systems,
+                &mut components,
+            );
             registrar
                 .command("tp")
                 .description("Teleport")
@@ -316,9 +440,16 @@ mod tests {
         let mut network_bus = EventBus::new();
         let mut game_bus = EventBus::new();
         let mut commands = Vec::new();
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         {
-            let mut registrar =
-                PluginRegistrar::new(&mut network_bus, &mut game_bus, &mut commands);
+            let mut registrar = PluginRegistrar::new(
+                &mut network_bus,
+                &mut game_bus,
+                &mut commands,
+                &mut systems,
+                &mut components,
+            );
             registrar
                 .command("help")
                 .description("Show help")

--- a/crates/basalt-server/src/game_loop.rs
+++ b/crates/basalt-server/src/game_loop.rs
@@ -396,9 +396,16 @@ mod tests {
         let mut bus = EventBus::new();
         let mut network_bus = EventBus::new();
         let mut commands = Vec::new();
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         {
-            let mut registrar =
-                basalt_api::PluginRegistrar::new(&mut network_bus, &mut bus, &mut commands);
+            let mut registrar = basalt_api::PluginRegistrar::new(
+                &mut network_bus,
+                &mut bus,
+                &mut commands,
+                &mut systems,
+                &mut components,
+            );
             basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
         }
 

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -99,7 +99,7 @@ impl Server {
     async fn run_with_listener(&self, listener: TcpListener) {
         let world = Arc::new(self.config.create_world());
         let plugins = self.config.create_plugins();
-        let (state, network_bus, game_bus) =
+        let (state, network_bus, game_bus, plugin_systems, plugin_components) =
             ServerState::build_for_loops(Arc::clone(&world), plugins);
 
         let channels = LoopChannels::new();
@@ -133,6 +133,7 @@ impl Server {
         // Game loop — dedicated OS thread, 20 TPS target
         // ECS with core components registered
         let mut ecs = basalt_ecs::Ecs::new();
+        // Core components
         ecs.register_component::<basalt_ecs::Position>();
         ecs.register_component::<basalt_ecs::Rotation>();
         ecs.register_component::<basalt_ecs::Velocity>();
@@ -141,6 +142,15 @@ impl Server {
         ecs.register_component::<basalt_ecs::Health>();
         ecs.register_component::<basalt_ecs::Lifetime>();
         ecs.register_component::<basalt_ecs::PlayerRef>();
+        ecs.register_component::<basalt_ecs::Inventory>();
+        // Plugin-registered components
+        for reg in &plugin_components {
+            (reg.register_fn)(&mut ecs);
+        }
+        // Plugin-registered systems
+        for system in plugin_systems {
+            ecs.add_system(system);
+        }
 
         let mut game_loop_inst = game_loop::GameLoop::new(
             game_bus,

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -50,13 +50,26 @@ impl ServerState {
     pub fn build_for_loops(
         world: Arc<basalt_world::World>,
         plugins: Vec<Box<dyn basalt_api::Plugin>>,
-    ) -> (Arc<Self>, EventBus, EventBus) {
+    ) -> (
+        Arc<Self>,
+        EventBus,
+        EventBus,
+        Vec<basalt_ecs::SystemDescriptor>,
+        Vec<basalt_api::plugin::ComponentRegistration>,
+    ) {
         let mut network_bus = EventBus::new();
         let mut game_bus = EventBus::new();
         let mut commands = Vec::new();
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         {
-            let mut registrar =
-                basalt_api::PluginRegistrar::new(&mut network_bus, &mut game_bus, &mut commands);
+            let mut registrar = basalt_api::PluginRegistrar::new(
+                &mut network_bus,
+                &mut game_bus,
+                &mut commands,
+                &mut systems,
+                &mut components,
+            );
             for plugin in &plugins {
                 log::info!(target: "basalt::plugin", "Enabling {} v{}", plugin.metadata().name, plugin.metadata().version);
                 plugin.on_enable(&mut registrar);
@@ -123,7 +136,7 @@ impl ServerState {
             command_args,
         });
 
-        (state, network_bus, game_bus)
+        (state, network_bus, game_bus, systems, components)
     }
 
     /// Allocates a unique entity ID for a new player.
@@ -378,7 +391,8 @@ mod tests {
         let config = crate::config::ServerConfig::default();
         let world = Arc::new(config.create_world());
         let plugins = config.create_plugins();
-        let (state, _network_bus, _game_bus) = ServerState::build_for_loops(world, plugins);
+        let (state, _network_bus, _game_bus, _systems, _components) =
+            ServerState::build_for_loops(world, plugins);
         state
     }
 

--- a/crates/basalt-test-utils/src/lib.rs
+++ b/crates/basalt-test-utils/src/lib.rs
@@ -67,10 +67,14 @@ impl PluginTestHarness {
 
     /// Registers a plugin's event handlers and commands.
     pub fn register(&mut self, plugin: impl Plugin) {
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         let mut registrar = PluginRegistrar::new(
             &mut self.network_bus,
             &mut self.game_bus,
             &mut self.commands,
+            &mut systems,
+            &mut components,
         );
         plugin.on_enable(&mut registrar);
     }

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -120,8 +120,15 @@ mod tests {
         let mut game_bus = EventBus::new();
         // Validate handler cancels before BlockPlugin runs
         let mut cmds = Vec::new();
-        let mut registrar =
-            basalt_api::plugin::PluginRegistrar::new(&mut network_bus, &mut game_bus, &mut cmds);
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
+        let mut registrar = basalt_api::plugin::PluginRegistrar::new(
+            &mut network_bus,
+            &mut game_bus,
+            &mut cmds,
+            &mut systems,
+            &mut components,
+        );
         registrar.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, _| {
             event.cancel();
         });

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -203,8 +203,16 @@ mod tests {
         let mut network_bus = EventBus::new();
         let mut game_bus = EventBus::new();
         let mut cmds = Vec::new();
+        let mut systems = Vec::new();
+        let mut components = Vec::new();
         {
-            let mut registrar = PluginRegistrar::new(&mut network_bus, &mut game_bus, &mut cmds);
+            let mut registrar = PluginRegistrar::new(
+                &mut network_bus,
+                &mut game_bus,
+                &mut cmds,
+                &mut systems,
+                &mut components,
+            );
             plugin.on_enable(&mut registrar);
         }
 


### PR DESCRIPTION
## Summary

- PluginRegistrar gains system() and component() methods for ECS integration
- registrar.system("name") returns a PluginSystemBuilder for fluent configuration (phase, every, reads/writes, run)
- registrar.component::<T>() records custom components for deferred ECS registration
- SystemDescriptors and ComponentRegistrations are collected during plugin.on_enable() and forwarded to the Ecs after all plugins are registered
- basalt-api now depends on basalt-ecs for SystemBuilder, Phase, and Component types

Closes #112

## Test plan

- [ ] All existing tests pass (no behavior change)
- [ ] Coverage above 90%
- [ ] Clippy clean
- [ ] Connect with Minecraft client — no behavior change (no systems registered yet by built-in plugins)
