### PR TITLE
feat(physics): add physics plugin with gravity and AABB collision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "basalt-plugin-physics"
+version = "0.1.0"
+dependencies = [
+ "basalt-api",
+ "basalt-ecs",
+ "basalt-world",
+ "log",
+]
+
+[[package]]
 name = "basalt-plugin-storage"
 version = "0.1.0"
 dependencies = [
@@ -260,6 +270,7 @@ dependencies = [
  "basalt-plugin-command",
  "basalt-plugin-lifecycle",
  "basalt-plugin-movement",
+ "basalt-plugin-physics",
  "basalt-plugin-storage",
  "basalt-plugin-world",
  "basalt-protocol",

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -304,6 +304,12 @@ const ecs = [
   'ecs/components',
 ];
 
+const physics = [
+  // Physics plugin: gravity, AABB collision, movement resolution.
+  // Example: "feat(physics): add AABB-vs-block collision"
+  'physics',
+];
+
 const keywords = [
   // Root workspace configuration: Cargo.toml workspace settings, workspace-wide
   // dependency versions, cross-crate build configuration.
@@ -364,7 +370,7 @@ const keywords = [
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...api, ...core, ...command, ...storage, ...ecs, ...keywords]],
+    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...api, ...core, ...command, ...storage, ...ecs, ...physics, ...keywords]],
     'scope-empty': [2, 'never'],
   },
 };

--- a/crates/basalt-api/src/plugin.rs
+++ b/crates/basalt-api/src/plugin.rs
@@ -84,6 +84,8 @@ pub struct PluginRegistrar<'a> {
     systems: &'a mut Vec<basalt_ecs::SystemDescriptor>,
     /// Collected component registrations.
     components: &'a mut Vec<ComponentRegistration>,
+    /// Shared world reference, available to all plugins.
+    world: std::sync::Arc<basalt_world::World>,
 }
 
 impl<'a> PluginRegistrar<'a> {
@@ -94,6 +96,7 @@ impl<'a> PluginRegistrar<'a> {
         commands: &'a mut Vec<CommandEntry>,
         systems: &'a mut Vec<basalt_ecs::SystemDescriptor>,
         components: &'a mut Vec<ComponentRegistration>,
+        world: std::sync::Arc<basalt_world::World>,
     ) -> Self {
         Self {
             network_bus,
@@ -101,7 +104,16 @@ impl<'a> PluginRegistrar<'a> {
             commands,
             systems,
             components,
+            world,
         }
+    }
+
+    /// Returns a shared reference to the world.
+    ///
+    /// Available to all plugins — use this to capture the world
+    /// in system closures for block access, collision checks, etc.
+    pub fn world(&self) -> std::sync::Arc<basalt_world::World> {
+        std::sync::Arc::clone(&self.world)
     }
 
     /// Registers an event handler on the correct bus.
@@ -366,6 +378,7 @@ mod tests {
                 &mut commands,
                 &mut systems,
                 &mut components,
+                std::sync::Arc::new(basalt_world::World::new_memory(42)),
             );
             registrar.on::<ChatMessageEvent>(Stage::Post, 0, |_event, _ctx| {});
             registrar.on::<BlockBrokenEvent>(Stage::Process, 0, |_event, _ctx| {});
@@ -388,6 +401,7 @@ mod tests {
                 &mut commands,
                 &mut systems,
                 &mut components,
+                std::sync::Arc::new(basalt_world::World::new_memory(42)),
             );
             registrar
                 .command("tp")
@@ -417,6 +431,7 @@ mod tests {
                 &mut commands,
                 &mut systems,
                 &mut components,
+                std::sync::Arc::new(basalt_world::World::new_memory(42)),
             );
             registrar
                 .command("tp")
@@ -449,6 +464,7 @@ mod tests {
                 &mut commands,
                 &mut systems,
                 &mut components,
+                std::sync::Arc::new(basalt_world::World::new_memory(42)),
             );
             registrar
                 .command("help")

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -22,6 +22,7 @@ basalt-plugin-command = { path = "../../plugins/command" }
 basalt-plugin-block = { path = "../../plugins/block" }
 basalt-plugin-world = { path = "../../plugins/world" }
 basalt-plugin-storage = { path = "../../plugins/storage" }
+basalt-plugin-physics = { path = "../../plugins/physics" }
 basalt-plugin-lifecycle = { path = "../../plugins/lifecycle" }
 basalt-plugin-movement = { path = "../../plugins/movement" }
 

--- a/crates/basalt-server/src/config.rs
+++ b/crates/basalt-server/src/config.rs
@@ -168,6 +168,8 @@ pub struct PluginsSection {
     pub lifecycle: bool,
     /// Player movement broadcasts.
     pub movement: bool,
+    /// Physics simulation (gravity, AABB collision).
+    pub physics: bool,
 }
 
 impl Default for ServerSection {
@@ -209,6 +211,7 @@ impl Default for PluginsSection {
             world: true,
             lifecycle: true,
             movement: true,
+            physics: true,
         }
     }
 }
@@ -333,6 +336,9 @@ impl ServerConfig {
         if self.plugins.block && self.world.storage == StorageMode::ReadWrite {
             plugins.push(Box::new(basalt_plugin_storage::StoragePlugin));
         }
+        if self.plugins.physics {
+            plugins.push(Box::new(basalt_plugin_physics::PhysicsPlugin));
+        }
 
         plugins
     }
@@ -419,8 +425,8 @@ storage = "none"
     fn create_plugins_all_enabled() {
         let config = ServerConfig::default();
         let plugins = config.create_plugins();
-        // 7 plugins: lifecycle, chat, command, movement, world, block, storage
-        assert_eq!(plugins.len(), 7);
+        // 8 built-in plugins
+        assert_eq!(plugins.len(), 8);
     }
 
     #[test]
@@ -428,8 +434,8 @@ storage = "none"
         let mut config = ServerConfig::default();
         config.world.storage = StorageMode::ReadOnly;
         let plugins = config.create_plugins();
-        // 6 plugins: no StoragePlugin
-        assert_eq!(plugins.len(), 6);
+        // 7 plugins: no StoragePlugin (physics still enabled)
+        assert_eq!(plugins.len(), 7);
         assert!(plugins.iter().all(|p| p.metadata().name != "storage"));
     }
 
@@ -442,6 +448,7 @@ storage = "none"
         config.plugins.world = false;
         config.plugins.lifecycle = false;
         config.plugins.movement = false;
+        config.plugins.physics = false;
         let plugins = config.create_plugins();
         assert!(plugins.is_empty());
     }

--- a/crates/basalt-server/src/connection.rs
+++ b/crates/basalt-server/src/connection.rs
@@ -183,6 +183,7 @@ async fn handle_configuration(
         entity_id,
         uuid: player_uuid,
         username: username_owned.clone(),
+        position,
         output_tx: output_tx.clone(),
     });
 

--- a/crates/basalt-server/src/game_loop.rs
+++ b/crates/basalt-server/src/game_loop.rs
@@ -405,6 +405,7 @@ mod tests {
                 &mut commands,
                 &mut systems,
                 &mut components,
+                std::sync::Arc::clone(&world),
             );
             basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
         }

--- a/crates/basalt-server/src/game_loop.rs
+++ b/crates/basalt-server/src/game_loop.rs
@@ -126,6 +126,15 @@ impl GameLoop {
                         self.ecs.despawn(eid);
                     }
                 }
+                GameInput::PlayerPosition { uuid, x, y, z } => {
+                    if let Some(eid) = self.ecs.find_by_uuid(uuid)
+                        && let Some(pos) = self.ecs.get_mut::<basalt_ecs::Position>(eid)
+                    {
+                        pos.x = x;
+                        pos.y = y;
+                        pos.z = z;
+                    }
+                }
                 GameInput::BlockDig {
                     uuid,
                     status,

--- a/crates/basalt-server/src/game_loop.rs
+++ b/crates/basalt-server/src/game_loop.rs
@@ -96,11 +96,27 @@ impl GameLoop {
                     entity_id,
                     uuid,
                     username,
+                    position,
                     output_tx,
                 } => {
                     let eid = entity_id as basalt_ecs::EntityId;
                     self.ecs.spawn_with_id(eid);
                     self.ecs.set(eid, basalt_ecs::PlayerRef { uuid, username });
+                    self.ecs.set(
+                        eid,
+                        basalt_ecs::Position {
+                            x: position.0,
+                            y: position.1,
+                            z: position.2,
+                        },
+                    );
+                    self.ecs.set(
+                        eid,
+                        basalt_ecs::BoundingBox {
+                            width: 0.6,
+                            height: 1.8,
+                        },
+                    );
                     self.ecs.set(eid, basalt_ecs::Inventory::empty());
                     self.ecs.set(eid, OutputHandle { tx: output_tx });
                     self.ecs.index_uuid(uuid, eid);
@@ -427,6 +443,7 @@ mod tests {
             entity_id,
             uuid,
             username: "Steve".into(),
+            position: (0.0, -60.0, 0.0),
             output_tx,
         });
         game_loop.tick(0);

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -116,6 +116,8 @@ pub enum GameInput {
         uuid: Uuid,
         /// Player display name.
         username: String,
+        /// Initial spawn position.
+        position: (f64, f64, f64),
         /// Channel for sending output packets back to this player.
         output_tx: mpsc::Sender<ServerOutput>,
     },

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -126,6 +126,17 @@ pub enum GameInput {
         /// UUID of the leaving player.
         uuid: Uuid,
     },
+    /// Player position update (synced from network loop for ECS).
+    PlayerPosition {
+        /// UUID of the moving player.
+        uuid: Uuid,
+        /// New X coordinate.
+        x: f64,
+        /// New Y coordinate.
+        y: f64,
+        /// New Z coordinate.
+        z: f64,
+    },
     /// Block dig (status 0 = started digging / instant break in creative).
     ///
     /// The game loop validates the action, mutates the world, and

--- a/crates/basalt-server/src/net_task.rs
+++ b/crates/basalt-server/src/net_task.rs
@@ -173,6 +173,12 @@ fn fan_out(
                     z: p.z,
                     on_ground: p.flags & 1 != 0,
                 });
+                let _ = game_tx.send(GameInput::PlayerPosition {
+                    uuid,
+                    x: p.x,
+                    y: p.y,
+                    z: p.z,
+                });
             }
         }
         ServerboundPlayPacket::PositionLook(p) => {
@@ -185,6 +191,12 @@ fn fan_out(
                     yaw: p.yaw,
                     pitch: p.pitch,
                     on_ground: p.flags & 1 != 0,
+                });
+                let _ = game_tx.send(GameInput::PlayerPosition {
+                    uuid,
+                    x: p.x,
+                    y: p.y,
+                    z: p.z,
                 });
             }
         }
@@ -414,7 +426,10 @@ mod tests {
         );
 
         assert!(nrx.try_recv().is_ok(), "position should go to network_tx");
-        assert!(grx.try_recv().is_err(), "position should not go to game_tx");
+        assert!(
+            grx.try_recv().is_ok(),
+            "position should go to game_tx for ECS sync"
+        );
     }
 
     #[test]
@@ -467,7 +482,7 @@ mod tests {
         );
 
         assert!(nrx.try_recv().is_ok());
-        assert!(grx.try_recv().is_err());
+        assert!(grx.try_recv().is_ok());
     }
 
     #[test]

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -69,6 +69,7 @@ impl ServerState {
                 &mut commands,
                 &mut systems,
                 &mut components,
+                std::sync::Arc::clone(&world),
             );
             for plugin in &plugins {
                 log::info!(target: "basalt::plugin", "Enabling {} v{}", plugin.metadata().name, plugin.metadata().version);

--- a/crates/basalt-test-utils/src/lib.rs
+++ b/crates/basalt-test-utils/src/lib.rs
@@ -75,6 +75,7 @@ impl PluginTestHarness {
             &mut self.commands,
             &mut systems,
             &mut components,
+            std::sync::Arc::clone(&self.world),
         );
         plugin.on_enable(&mut registrar);
     }

--- a/crates/basalt-world/src/block.rs
+++ b/crates/basalt-world/src/block.rs
@@ -128,6 +128,18 @@ const ITEM_TO_BLOCK_STATE: [u16; 1385] = [
     25724,25728,25732,25736,27657,65535,65535,27667,65535,
 ];
 
+/// Returns whether a block state ID represents a solid (collidable) block.
+///
+/// Solid blocks prevent entity movement through them. Air, water, and
+/// a few other blocks are non-solid. This is a simplified check — a
+/// full implementation would use the block registry's collision shape.
+pub fn is_solid(state: u16) -> bool {
+    // Non-solid blocks: air, water, lava, and their variants
+    // This is a conservative approximation — in vanilla, collision
+    // shapes are per-block-state, but for basic physics this suffices.
+    !matches!(state, AIR | WATER)
+}
+
 /// Maps a Minecraft item registry ID to the default block state ID.
 ///
 /// Returns `None` if the item does not have a corresponding block

--- a/crates/basalt-world/src/collision.rs
+++ b/crates/basalt-world/src/collision.rs
@@ -1,0 +1,283 @@
+//! Collision utilities for physics simulation.
+//!
+//! Provides AABB-vs-block collision detection and ray casting against
+//! the block grid. These are the building blocks for the physics system
+//! and future gameplay mechanics (line-of-sight, block targeting).
+
+use crate::World;
+use crate::block::is_solid;
+
+/// An axis-aligned bounding box in world coordinates.
+#[derive(Debug, Clone, Copy)]
+pub struct Aabb {
+    /// Minimum corner (lowest X, Y, Z).
+    pub min_x: f64,
+    /// Minimum Y.
+    pub min_y: f64,
+    /// Minimum Z.
+    pub min_z: f64,
+    /// Maximum corner (highest X, Y, Z).
+    pub max_x: f64,
+    /// Maximum Y.
+    pub max_y: f64,
+    /// Maximum Z.
+    pub max_z: f64,
+}
+
+impl Aabb {
+    /// Creates an AABB centered at `(x, y, z)` with the given dimensions.
+    ///
+    /// The box extends `width/2` in X and Z from center, and `height`
+    /// upward from `y` (entity position is at feet level).
+    pub fn from_entity(x: f64, y: f64, z: f64, width: f32, height: f32) -> Self {
+        let hw = f64::from(width) / 2.0;
+        let h = f64::from(height);
+        Self {
+            min_x: x - hw,
+            min_y: y,
+            min_z: z - hw,
+            max_x: x + hw,
+            max_y: y + h,
+            max_z: z + hw,
+        }
+    }
+
+    /// Returns this AABB offset by the given delta.
+    pub fn offset(&self, dx: f64, dy: f64, dz: f64) -> Self {
+        Self {
+            min_x: self.min_x + dx,
+            min_y: self.min_y + dy,
+            min_z: self.min_z + dz,
+            max_x: self.max_x + dx,
+            max_y: self.max_y + dy,
+            max_z: self.max_z + dz,
+        }
+    }
+
+    /// Returns whether this AABB overlaps a unit block at (bx, by, bz).
+    fn overlaps_block(&self, bx: i32, by: i32, bz: i32) -> bool {
+        let bx = bx as f64;
+        let by = by as f64;
+        let bz = bz as f64;
+        self.max_x > bx
+            && self.min_x < bx + 1.0
+            && self.max_y > by
+            && self.min_y < by + 1.0
+            && self.max_z > bz
+            && self.min_z < bz + 1.0
+    }
+}
+
+/// Checks if an AABB overlaps any solid block in the world.
+///
+/// Iterates all block positions that the AABB spans and returns
+/// `true` if any of them are solid. Used for ground detection and
+/// simple collision checks.
+pub fn check_overlap(world: &World, aabb: &Aabb) -> bool {
+    let min_bx = aabb.min_x.floor() as i32;
+    let min_by = aabb.min_y.floor() as i32;
+    let min_bz = aabb.min_z.floor() as i32;
+    let max_bx = aabb.max_x.ceil() as i32;
+    let max_by = aabb.max_y.ceil() as i32;
+    let max_bz = aabb.max_z.ceil() as i32;
+
+    for bx in min_bx..max_bx {
+        for by in min_by..max_by {
+            for bz in min_bz..max_bz {
+                if is_solid(world.get_block(bx, by, bz)) && aabb.overlaps_block(bx, by, bz) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Result of a ray cast against the block grid.
+#[derive(Debug, Clone)]
+pub struct RayHit {
+    /// The block position that was hit.
+    pub block_x: i32,
+    /// Block Y.
+    pub block_y: i32,
+    /// Block Z.
+    pub block_z: i32,
+    /// Distance from origin to hit point.
+    pub distance: f64,
+}
+
+/// Casts a ray through the world and returns the first solid block hit.
+///
+/// Uses a simple stepping algorithm along the ray direction.
+/// Returns `None` if no solid block is found within `max_distance`.
+pub fn ray_cast(
+    world: &World,
+    origin: (f64, f64, f64),
+    direction: (f64, f64, f64),
+    max_distance: f64,
+) -> Option<RayHit> {
+    let (origin_x, origin_y, origin_z) = origin;
+    let (dir_x, dir_y, dir_z) = direction;
+    let step = 0.1;
+    let steps = (max_distance / step) as usize;
+    let len = (dir_x * dir_x + dir_y * dir_y + dir_z * dir_z).sqrt();
+    if len < 1e-10 {
+        return None;
+    }
+    let (nx, ny, nz) = (dir_x / len, dir_y / len, dir_z / len);
+
+    for i in 0..=steps {
+        let d = i as f64 * step;
+        let x = origin_x + nx * d;
+        let y = origin_y + ny * d;
+        let z = origin_z + nz * d;
+        let bx = x.floor() as i32;
+        let by = y.floor() as i32;
+        let bz = z.floor() as i32;
+
+        if is_solid(world.get_block(bx, by, bz)) {
+            return Some(RayHit {
+                block_x: bx,
+                block_y: by,
+                block_z: bz,
+                distance: d,
+            });
+        }
+    }
+    None
+}
+
+/// Resolves movement of an AABB against solid blocks.
+///
+/// Takes the entity's AABB and desired velocity, returns the actual
+/// velocity after clamping against solid blocks. Each axis is resolved
+/// independently (Y first for gravity, then X, then Z).
+pub fn resolve_movement(world: &World, aabb: &Aabb, dx: f64, dy: f64, dz: f64) -> (f64, f64, f64) {
+    let mut resolved_dy = dy;
+    let mut resolved_dx = dx;
+    let mut resolved_dz = dz;
+
+    // Resolve Y axis first (gravity is most important)
+    if resolved_dy != 0.0 {
+        let test = aabb.offset(0.0, resolved_dy, 0.0);
+        if check_overlap(world, &test) {
+            // Clamp to the nearest block boundary
+            if resolved_dy < 0.0 {
+                // Falling: snap to top of block below
+                resolved_dy = (aabb.min_y.floor() - aabb.min_y).max(resolved_dy);
+                // If still overlapping, zero out
+                if check_overlap(world, &aabb.offset(0.0, resolved_dy, 0.0)) {
+                    resolved_dy = 0.0;
+                }
+            } else {
+                // Rising: snap to bottom of block above
+                resolved_dy = (aabb.max_y.ceil() - aabb.max_y).min(resolved_dy);
+                if check_overlap(world, &aabb.offset(0.0, resolved_dy, 0.0)) {
+                    resolved_dy = 0.0;
+                }
+            }
+        }
+    }
+
+    let aabb_after_y = aabb.offset(0.0, resolved_dy, 0.0);
+
+    // Resolve X axis
+    if resolved_dx != 0.0 {
+        let test = aabb_after_y.offset(resolved_dx, 0.0, 0.0);
+        if check_overlap(world, &test) {
+            resolved_dx = 0.0;
+        }
+    }
+
+    // Resolve Z axis
+    if resolved_dz != 0.0 {
+        let test = aabb_after_y.offset(resolved_dx, 0.0, resolved_dz);
+        if check_overlap(world, &test) {
+            resolved_dz = 0.0;
+        }
+    }
+
+    (resolved_dx, resolved_dy, resolved_dz)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_world() -> World {
+        // Flat world: solid blocks at y=-61 and below, air above
+        World::flat()
+    }
+
+    #[test]
+    fn aabb_from_entity() {
+        let aabb = Aabb::from_entity(0.0, -60.0, 0.0, 0.6, 1.8);
+        // f32→f64 conversion causes small precision loss, use relaxed tolerance
+        assert!(aabb.min_x < 0.0, "min_x should be negative");
+        assert!((aabb.min_y - (-60.0)).abs() < 1e-6);
+        assert!((aabb.max_y - (-58.2)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn check_overlap_detects_solid() {
+        let world = test_world();
+        // AABB at y=-62 overlaps dirt block at y=-62
+        let aabb = Aabb::from_entity(0.0, -62.0, 0.0, 0.6, 1.8);
+        assert!(check_overlap(&world, &aabb));
+    }
+
+    #[test]
+    fn check_overlap_no_collision_in_air() {
+        let world = test_world();
+        // AABB at y=-60 (above grass at -61) — all air
+        let aabb = Aabb::from_entity(0.0, -60.0, 0.0, 0.6, 1.8);
+        assert!(!check_overlap(&world, &aabb));
+    }
+
+    #[test]
+    fn ray_cast_finds_ground() {
+        let world = test_world();
+        // Cast straight down from y=-50
+        let hit = ray_cast(&world, (0.5, -50.0, 0.5), (0.0, -1.0, 0.0), 20.0);
+        assert!(hit.is_some());
+        let hit = hit.unwrap();
+        assert_eq!(hit.block_y, -61); // Grass layer
+    }
+
+    #[test]
+    fn ray_cast_misses_in_air() {
+        let world = test_world();
+        // Cast horizontally at y=-50 — all air
+        let hit = ray_cast(&world, (0.5, -50.0, 0.5), (1.0, 0.0, 0.0), 5.0);
+        assert!(hit.is_none());
+    }
+
+    #[test]
+    fn resolve_movement_stops_at_ground() {
+        let world = test_world();
+        // Entity at y=-60 (just above grass), falling
+        let aabb = Aabb::from_entity(0.0, -60.0, 0.0, 0.6, 1.8);
+        let (dx, dy, dz) = resolve_movement(&world, &aabb, 0.0, -1.0, 0.0);
+        assert_eq!(dx, 0.0);
+        assert_eq!(dy, 0.0); // Stopped by ground
+        assert_eq!(dz, 0.0);
+    }
+
+    #[test]
+    fn resolve_movement_allows_free_fall() {
+        let world = test_world();
+        // Entity at y=-50 (high in air), falling
+        let aabb = Aabb::from_entity(0.0, -50.0, 0.0, 0.6, 1.8);
+        let (_, dy, _) = resolve_movement(&world, &aabb, 0.0, -0.5, 0.0);
+        assert!((dy - (-0.5)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_movement_stops_horizontal() {
+        let world = test_world();
+        // Entity overlapping ground at y=-62, horizontal blocked
+        let aabb = Aabb::from_entity(0.0, -62.0, 0.0, 0.6, 1.8);
+        let (dx, _, _) = resolve_movement(&world, &aabb, 1.0, 0.0, 0.0);
+        assert_eq!(dx, 0.0);
+    }
+}

--- a/crates/basalt-world/src/lib.rs
+++ b/crates/basalt-world/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod block;
 pub mod chunk;
+pub mod collision;
 pub mod format;
 mod generator;
 mod noise_gen;

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -128,6 +128,7 @@ mod tests {
             &mut cmds,
             &mut systems,
             &mut components,
+            std::sync::Arc::new(basalt_world::World::new_memory(42)),
         );
         registrar.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, _| {
             event.cancel();

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -212,6 +212,7 @@ mod tests {
                 &mut cmds,
                 &mut systems,
                 &mut components,
+                std::sync::Arc::new(basalt_world::World::new_memory(42)),
             );
             plugin.on_enable(&mut registrar);
         }

--- a/plugins/physics/Cargo.toml
+++ b/plugins/physics/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "basalt-plugin-physics"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+basalt-api = { workspace = true }
+basalt-ecs = { workspace = true }
+basalt-world = { workspace = true }
+log = { workspace = true }

--- a/plugins/physics/src/lib.rs
+++ b/plugins/physics/src/lib.rs
@@ -1,0 +1,287 @@
+//! Physics plugin — gravity, AABB collision, and movement resolution.
+//!
+//! Registers a `PhysicsSystem` in the Simulate phase that applies
+//! gravity to entities with [`Velocity`], resolves movement against
+//! solid blocks via AABB collision, and updates [`Position`].
+//!
+//! Requires a shared `Arc<World>` captured in the system closure
+//! for block solidity checks.
+
+use basalt_api::prelude::*;
+use basalt_ecs::{BoundingBox, Phase, Position, Velocity};
+use basalt_world::World;
+use basalt_world::collision::{Aabb, resolve_movement};
+
+/// Minecraft gravity constant: -0.08 blocks per tick² (downward).
+const GRAVITY: f64 = 0.08;
+
+/// Physics plugin: gravity, collision, and movement resolution.
+///
+/// Entities need [`Position`], [`Velocity`], and [`BoundingBox`]
+/// components to be affected by physics. The world is obtained
+/// via `registrar.world()` — same API as any other plugin.
+pub struct PhysicsPlugin;
+
+impl Plugin for PhysicsPlugin {
+    fn metadata(&self) -> PluginMetadata {
+        PluginMetadata {
+            name: "physics",
+            version: "0.1.0",
+            author: Some("Basalt"),
+            dependencies: &[],
+        }
+    }
+
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
+        let world = registrar.world();
+
+        registrar
+            .system("physics")
+            .phase(Phase::Simulate)
+            .every(1)
+            .reads::<BoundingBox>()
+            .writes::<Position>()
+            .writes::<Velocity>()
+            .run(move |ecs| {
+                physics_tick(ecs, &world);
+            });
+    }
+}
+
+/// Runs one physics tick: gravity → collision resolution → position update.
+///
+/// Iterates all entities with Position + Velocity. Entities without
+/// BoundingBox are treated as points (no collision, just gravity + move).
+fn physics_tick(ecs: &mut basalt_ecs::Ecs, world: &World) {
+    // Collect entity IDs to avoid borrow conflicts during mutation
+    let entities: Vec<basalt_ecs::EntityId> = ecs.iter::<Velocity>().map(|(id, _)| id).collect();
+
+    for id in entities {
+        let Some(vel) = ecs.get_mut::<Velocity>(id) else {
+            continue;
+        };
+
+        // Apply gravity
+        vel.dy -= GRAVITY;
+
+        let dx = vel.dx;
+        let dy = vel.dy;
+        let dz = vel.dz;
+
+        let Some(pos) = ecs.get::<Position>(id) else {
+            continue;
+        };
+        let (px, py, pz) = (pos.x, pos.y, pos.z);
+
+        // Resolve movement against solid blocks
+        let (resolved_dx, resolved_dy, resolved_dz) = if let Some(bb) = ecs.get::<BoundingBox>(id) {
+            let aabb = Aabb::from_entity(px, py, pz, bb.width, bb.height);
+            resolve_movement(world, &aabb, dx, dy, dz)
+        } else {
+            // No bounding box — move freely (point entity)
+            (dx, dy, dz)
+        };
+
+        // Update velocity to resolved values (important: if we hit
+        // the ground, dy becomes 0 so we don't accumulate gravity)
+        if let Some(vel) = ecs.get_mut::<Velocity>(id) {
+            if (resolved_dy - dy).abs() > f64::EPSILON {
+                vel.dy = 0.0; // Hit ground or ceiling
+            }
+            if (resolved_dx - dx).abs() > f64::EPSILON {
+                vel.dx = 0.0;
+            }
+            if (resolved_dz - dz).abs() > f64::EPSILON {
+                vel.dz = 0.0;
+            }
+        }
+
+        // Apply resolved movement to position
+        if let Some(pos) = ecs.get_mut::<Position>(id) {
+            pos.x += resolved_dx;
+            pos.y += resolved_dy;
+            pos.z += resolved_dz;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use basalt_ecs::Ecs;
+
+    fn test_world() -> std::sync::Arc<World> {
+        std::sync::Arc::new(World::flat())
+    }
+
+    #[test]
+    fn gravity_applies_to_velocity() {
+        let world = test_world();
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Position {
+                x: 0.0,
+                y: -40.0,
+                z: 0.0,
+            },
+        );
+        ecs.set(
+            e,
+            Velocity {
+                dx: 0.0,
+                dy: 0.0,
+                dz: 0.0,
+            },
+        );
+        // No bounding box = point entity, no collision
+
+        physics_tick(&mut ecs, &world);
+
+        let vel = ecs.get::<Velocity>(e).unwrap();
+        // After one tick: dy should be -GRAVITY (0.08 downward)
+        // But since no collision, velocity stays at -0.08
+        assert!((vel.dy - (-GRAVITY)).abs() < f64::EPSILON);
+
+        let pos = ecs.get::<Position>(e).unwrap();
+        // Position moved by the velocity
+        assert!((pos.y - (-40.0 - GRAVITY)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn entity_lands_on_ground() {
+        let world = test_world();
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        // Start just above ground (flat world grass at y=-61, spawn at y=-60)
+        ecs.set(
+            e,
+            Position {
+                x: 0.5,
+                y: -59.9,
+                z: 0.5,
+            },
+        );
+        ecs.set(
+            e,
+            Velocity {
+                dx: 0.0,
+                dy: -1.0,
+                dz: 0.0,
+            },
+        );
+        ecs.set(
+            e,
+            BoundingBox {
+                width: 0.6,
+                height: 1.8,
+            },
+        );
+
+        physics_tick(&mut ecs, &world);
+
+        let pos = ecs.get::<Position>(e).unwrap();
+        // Should have landed on ground (y=-60), not fallen through
+        assert!(
+            pos.y >= -60.0,
+            "entity should land on ground, got y={}",
+            pos.y
+        );
+
+        let vel = ecs.get::<Velocity>(e).unwrap();
+        // Vertical velocity should be zeroed after hitting ground
+        assert_eq!(vel.dy, 0.0);
+    }
+
+    #[test]
+    fn entity_falls_in_air() {
+        let world = test_world();
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Position {
+                x: 0.5,
+                y: -40.0,
+                z: 0.5,
+            },
+        );
+        ecs.set(
+            e,
+            Velocity {
+                dx: 0.0,
+                dy: 0.0,
+                dz: 0.0,
+            },
+        );
+        ecs.set(
+            e,
+            BoundingBox {
+                width: 0.6,
+                height: 1.8,
+            },
+        );
+
+        // Run several ticks
+        for _ in 0..10 {
+            physics_tick(&mut ecs, &world);
+        }
+
+        let pos = ecs.get::<Position>(e).unwrap();
+        // Should have fallen significantly
+        assert!(pos.y < -40.0, "entity should have fallen");
+        assert!(pos.y > -60.0, "entity should not have reached ground yet");
+    }
+
+    #[test]
+    fn entity_without_velocity_unaffected() {
+        let world = test_world();
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Position {
+                x: 5.0,
+                y: -40.0,
+                z: 5.0,
+            },
+        );
+        // No Velocity component
+
+        physics_tick(&mut ecs, &world);
+
+        let pos = ecs.get::<Position>(e).unwrap();
+        assert_eq!(pos.y, -40.0); // Unchanged
+    }
+
+    #[test]
+    fn horizontal_movement() {
+        let world = test_world();
+        let mut ecs = Ecs::new();
+        let e = ecs.spawn();
+        ecs.set(
+            e,
+            Position {
+                x: 0.0,
+                y: -40.0,
+                z: 0.0,
+            },
+        );
+        ecs.set(
+            e,
+            Velocity {
+                dx: 1.0,
+                dy: 0.0,
+                dz: 0.5,
+            },
+        );
+
+        physics_tick(&mut ecs, &world);
+
+        let pos = ecs.get::<Position>(e).unwrap();
+        // Horizontal movement applied (gravity also kicks in)
+        assert!((pos.x - 1.0).abs() < f64::EPSILON);
+        assert!((pos.z - 0.5).abs() < f64::EPSILON);
+    }
+}


### PR DESCRIPTION
## Summary

- New plugin: basalt-plugin-physics — first ECS system plugin, registers PhysicsSystem in Simulate phase
- Gravity (-0.08 dy/tick), AABB-vs-block collision, per-axis movement resolution
- Collision utilities in basalt-world: Aabb, check_overlap, ray_cast, resolve_movement
- block::is_solid() for block solidity checks
- PluginRegistrar.world() — all plugins can access the world during on_enable(), no backdoor constructors
- Physics plugin uses the same API as any external plugin

Closes #114

## Test plan

- [ ] Collision tests pass (overlap, ray cast, movement resolution against flat world)
- [ ] Physics tests pass (gravity, ground landing, free fall, horizontal movement)
- [ ] All existing tests pass (no regression)
- [ ] Coverage above 90%
- [ ] Clippy clean
- [ ] Connect with Minecraft client — server still works (physics runs but no player entities have Velocity+BoundingBox yet)
