### PR TITLE
refactor(test): simplify plugin tests with PluginTestHarness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,8 @@ name = "basalt-plugin-command"
 version = "0.1.0"
 dependencies = [
  "basalt-api",
- "basalt-command",
+ "basalt-test-utils",
  "basalt-types",
- "basalt-world",
 ]
 
 [[package]]
@@ -301,6 +300,7 @@ name = "basalt-test-utils"
 version = "0.1.0"
 dependencies = [
  "basalt-api",
+ "basalt-command",
  "basalt-events",
  "basalt-types",
  "basalt-world",

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -26,11 +26,13 @@ pub mod prelude {
     pub use basalt_command::{Arg, CommandArgs, Validation};
     pub use basalt_core::{BroadcastMessage, Context, Gamemode, PlayerSnapshot};
 
-    pub use crate::context::ServerContext;
+    pub use basalt_types::Uuid;
+
+    pub use crate::context::{Response, ServerContext};
     pub use crate::events::{
         BlockBrokenEvent, BlockPlacedEvent, ChatMessageEvent, CommandEvent, PlayerJoinedEvent,
         PlayerLeftEvent, PlayerMovedEvent,
     };
     pub use crate::plugin::{Plugin, PluginMetadata, PluginRegistrar};
-    pub use basalt_events::Stage;
+    pub use basalt_events::{Event, Stage};
 }

--- a/crates/basalt-test-utils/Cargo.toml
+++ b/crates/basalt-test-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 basalt-api = { workspace = true }
+basalt-command = { workspace = true }
 basalt-world = { workspace = true }
 basalt-types = { workspace = true }
 basalt-events = { workspace = true }

--- a/crates/basalt-test-utils/src/lib.rs
+++ b/crates/basalt-test-utils/src/lib.rs
@@ -3,44 +3,50 @@
 //! Provides [`PluginTestHarness`] to eliminate the duplicated test
 //! scaffolding (world creation, event bus, plugin registration, dispatch)
 //! that appears in every plugin's test module.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let mut harness = PluginTestHarness::new();
+//! harness.register(MyPlugin);
+//!
+//! // Dispatch an event
+//! let mut event = BlockBrokenEvent { x: 5, y: 64, z: 3, ... };
+//! let responses = harness.dispatch(&mut event);
+//! assert_eq!(responses.len(), 2);
+//!
+//! // Execute a command
+//! let responses = harness.dispatch_command("tp 10 64 -5");
+//! assert!(matches!(responses[0], Response::SendPosition { .. }));
+//! ```
 
 use std::sync::Arc;
 
 use basalt_api::context::ServerContext;
 use basalt_api::plugin::PluginRegistrar;
 use basalt_api::{EventBus, Plugin, Response};
-use basalt_events::Event;
+use basalt_events::{Event, EventRouting, Stage};
 use basalt_types::Uuid;
 use basalt_world::World;
 
-/// Test harness that encapsulates the common plugin test setup.
+/// Test harness for plugin development.
 ///
-/// Creates a world, event bus, and server context, then registers a
-/// plugin and dispatches events — all in a few method calls instead
-/// of 10+ lines of boilerplate per test.
-///
-/// # Example
-///
-/// ```ignore
-/// let mut harness = PluginTestHarness::new();
-/// harness.register(MyPlugin);
-/// let mut event = SomeEvent { ... };
-/// let responses = harness.dispatch(&mut event);
-/// assert_eq!(responses.len(), 1);
-/// ```
+/// Provides a simple API for testing plugins without importing
+/// internal types. Handles world creation, event bus setup, plugin
+/// registration, event dispatch, and command execution.
 pub struct PluginTestHarness {
     /// Shared world instance for the test.
     world: Arc<World>,
-    /// Event bus for network events (movement, chat, commands).
+    /// Event bus for instant events (chat, commands).
     instant_bus: EventBus,
-    /// Event bus for game events (blocks, world mutations).
+    /// Event bus for game events (blocks, movement, lifecycle).
     game_bus: EventBus,
-    /// Collected command entries (not used in most tests, but needed for registration).
+    /// Collected command entries.
     commands: Vec<basalt_api::CommandEntry>,
 }
 
 impl PluginTestHarness {
-    /// Creates a new test harness with a memory-only noise world (seed 42).
+    /// Creates a new test harness with a memory-only world (seed 42).
     pub fn new() -> Self {
         Self {
             world: Arc::new(World::new_memory(42)),
@@ -75,9 +81,41 @@ impl PluginTestHarness {
             &mut self.commands,
             &mut systems,
             &mut components,
-            std::sync::Arc::clone(&self.world),
+            Arc::clone(&self.world),
         );
         plugin.on_enable(&mut registrar);
+    }
+
+    /// Registers an ad-hoc event handler (for testing cancellation, custom logic, etc.).
+    ///
+    /// The handler is routed to the correct bus based on `E::BUS`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Register a Validate handler that cancels the event
+    /// harness.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, _ctx| {
+    ///     event.cancel();
+    /// });
+    /// ```
+    pub fn on<E>(
+        &mut self,
+        stage: Stage,
+        priority: i32,
+        handler: impl Fn(&mut E, &ServerContext) + Send + Sync + 'static,
+    ) where
+        E: Event + EventRouting + 'static,
+    {
+        match E::BUS {
+            basalt_events::BusKind::Instant => {
+                self.instant_bus
+                    .on::<E, ServerContext>(stage, priority, handler);
+            }
+            basalt_events::BusKind::Game => {
+                self.game_bus
+                    .on::<E, ServerContext>(stage, priority, handler);
+            }
+        }
     }
 
     /// Creates a default server context for "Steve" with entity ID 1.
@@ -104,15 +142,11 @@ impl PluginTestHarness {
         )
     }
 
-    /// Dispatches an event to the correct bus and returns queued responses.
-    ///
-    /// Routes game events (BlockBroken, BlockPlaced) to the game bus
-    /// and all other events to the network bus.
+    /// Dispatches an event and returns the queued responses.
     pub fn dispatch(&self, event: &mut dyn Event) -> Vec<Response> {
         let ctx = self.context();
         self.dispatch_routed(event, &ctx);
         let responses = ctx.drain_responses();
-        // Execute PersistChunk responses synchronously in tests
         for response in &responses {
             if let Response::PersistChunk { cx, cz } = response {
                 self.world.persist_chunk(*cx, *cz);
@@ -127,17 +161,49 @@ impl PluginTestHarness {
         ctx.drain_responses()
     }
 
-    /// Routes a type-erased event to the correct bus using [`Event::bus_kind()`].
-    fn dispatch_routed(&self, event: &mut dyn Event, ctx: &ServerContext) {
-        match event.bus_kind() {
-            basalt_events::BusKind::Instant => self.instant_bus.dispatch_dyn(event, ctx),
-            basalt_events::BusKind::Game => self.game_bus.dispatch_dyn(event, ctx),
+    /// Executes a command by name and returns the responses.
+    ///
+    /// Looks up the command in registered commands, parses arguments,
+    /// and calls the handler. Returns empty if the command is not found.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let responses = harness.dispatch_command("tp 10 64 -5");
+    /// ```
+    pub fn dispatch_command(&self, command: &str) -> Vec<Response> {
+        let ctx = self.context();
+        ctx.set_command_list(
+            self.commands
+                .iter()
+                .map(|c| (c.name.clone(), c.description.clone()))
+                .collect(),
+        );
+
+        let parts: Vec<&str> = command.splitn(2, ' ').collect();
+        let name = parts[0];
+        let args = parts.get(1).copied().unwrap_or("");
+
+        if let Some(entry) = self.commands.iter().find(|c| c.name == name)
+            && let Ok(parsed) =
+                basalt_command::parse_command_args(args, &entry.args, &entry.variants)
+        {
+            (entry.handler)(&parsed, &ctx);
         }
+        ctx.drain_responses()
     }
 
     /// Returns a reference to the collected command entries.
     pub fn commands(&self) -> &[basalt_api::CommandEntry] {
         &self.commands
+    }
+
+    /// Routes a type-erased event to the correct bus.
+    fn dispatch_routed(&self, event: &mut dyn Event, ctx: &ServerContext) {
+        match event.bus_kind() {
+            basalt_events::BusKind::Instant => self.instant_bus.dispatch_dyn(event, ctx),
+            basalt_events::BusKind::Game => self.game_bus.dispatch_dyn(event, ctx),
+        }
     }
 }
 

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -6,9 +6,6 @@
 use basalt_api::prelude::*;
 
 /// Handles block breaking and placing in the world.
-///
-/// - **Process**: sets the block in the world (AIR for break, block_state for place)
-/// - **Post**: sends acknowledgement and broadcasts the change
 pub struct BlockPlugin;
 
 impl Plugin for BlockPlugin {
@@ -58,10 +55,7 @@ impl Plugin for BlockPlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::context::ServerContext;
-    use basalt_api::{Event, EventBus, Response};
     use basalt_test_utils::PluginTestHarness;
-    use basalt_types::Uuid;
 
     use super::*;
 
@@ -82,14 +76,12 @@ mod tests {
             cancelled: false,
         };
 
-        let ctx = harness.context();
-        let responses = harness.dispatch_with(&mut event, &ctx);
+        let responses = harness.dispatch(&mut event);
 
         assert_eq!(
             harness.world().get_block(5, 64, 3),
             basalt_world::block::AIR
         );
-
         assert_eq!(responses.len(), 2);
         assert!(matches!(
             responses[0],
@@ -103,10 +95,17 @@ mod tests {
 
     #[test]
     fn cancelled_block_break_skips_mutation() {
-        let world = std::sync::Arc::new(basalt_world::World::new_memory(42));
-        world.set_block(8, 64, 8, basalt_world::block::STONE);
+        let mut harness = PluginTestHarness::new();
+        harness
+            .world()
+            .set_block(8, 64, 8, basalt_world::block::STONE);
 
-        let ctx = ServerContext::new(world.clone(), Uuid::default(), 1, "Steve".into(), 0.0, 0.0);
+        // Register a Validate handler that cancels before BlockPlugin runs
+        harness.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, _ctx| {
+            event.cancel();
+        });
+        harness.register(BlockPlugin);
+
         let mut event = BlockBrokenEvent {
             x: 8,
             y: 64,
@@ -116,27 +115,12 @@ mod tests {
             cancelled: false,
         };
 
-        let mut instant_bus = EventBus::new();
-        let mut game_bus = EventBus::new();
-        // Validate handler cancels before BlockPlugin runs
-        let mut cmds = Vec::new();
-        let mut systems = Vec::new();
-        let mut components = Vec::new();
-        let mut registrar = basalt_api::plugin::PluginRegistrar::new(
-            &mut instant_bus,
-            &mut game_bus,
-            &mut cmds,
-            &mut systems,
-            &mut components,
-            std::sync::Arc::new(basalt_world::World::new_memory(42)),
-        );
-        registrar.on::<BlockBrokenEvent>(Stage::Validate, 0, |event, _| {
-            event.cancel();
-        });
-        BlockPlugin.on_enable(&mut registrar);
-        game_bus.dispatch(&mut event, &ctx);
+        let responses = harness.dispatch(&mut event);
 
-        assert_eq!(world.get_block(8, 64, 8), basalt_world::block::STONE);
-        assert!(ctx.drain_responses().is_empty());
+        assert_eq!(
+            harness.world().get_block(8, 64, 8),
+            basalt_world::block::STONE
+        );
+        assert!(responses.is_empty());
     }
 }

--- a/plugins/command/Cargo.toml
+++ b/plugins/command/Cargo.toml
@@ -10,5 +10,4 @@ basalt-api = { workspace = true }
 basalt-types = { workspace = true }
 
 [dev-dependencies]
-basalt-command = { workspace = true }
-basalt-world = { workspace = true }
+basalt-test-utils = { workspace = true }

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -181,51 +181,19 @@ impl Default for CommandPlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::context::ServerContext;
-    use basalt_api::{EventBus, Response};
-    use basalt_command::parse_command_args;
-    use basalt_types::Uuid;
+    use basalt_api::Response;
+    use basalt_test_utils::PluginTestHarness;
 
     use super::*;
 
-    fn test_world() -> std::sync::Arc<basalt_world::World> {
-        std::sync::Arc::new(basalt_world::World::new_memory(42))
-    }
-
-    fn test_ctx() -> ServerContext {
-        ServerContext::new(test_world(), Uuid::default(), 1, "Steve".into(), 0.0, 0.0)
+    fn harness() -> PluginTestHarness {
+        let mut h = PluginTestHarness::new();
+        h.register(CommandPlugin);
+        h
     }
 
     fn dispatch_command(cmd: &str) -> Vec<Response> {
-        let ctx = test_ctx();
-
-        let plugin = CommandPlugin;
-        let mut instant_bus = EventBus::new();
-        let mut game_bus = EventBus::new();
-        let mut cmds = Vec::new();
-        let mut systems = Vec::new();
-        let mut components = Vec::new();
-        {
-            let mut registrar = PluginRegistrar::new(
-                &mut instant_bus,
-                &mut game_bus,
-                &mut cmds,
-                &mut systems,
-                &mut components,
-                std::sync::Arc::new(basalt_world::World::new_memory(42)),
-            );
-            plugin.on_enable(&mut registrar);
-        }
-
-        let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
-        let name = parts[0];
-        let args = parts.get(1).copied().unwrap_or("");
-        if let Some(entry) = cmds.iter().find(|c| c.name == name)
-            && let Ok(parsed) = parse_command_args(args, &entry.args, &entry.variants)
-        {
-            (entry.handler)(&parsed, &ctx);
-        }
-        ctx.drain_responses()
+        harness().dispatch_command(cmd)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extend PluginTestHarness with on() for ad-hoc handler registration and dispatch_command() for command execution
- Migrate block plugin tests to use harness exclusively — zero internal imports (no EventBus, PluginRegistrar, ServerContext)
- Migrate command plugin tests to use harness.dispatch_command() — 35 lines of boilerplate replaced by 3 lines
- Add Event, Response, Uuid to the basalt-api prelude for convenience
- External plugin developers can now test with just basalt-test-utils + basalt-api prelude

## Test plan

- [x] Block plugin tests pass (2 tests including cancellation)
- [x] Command plugin tests pass (12 tests)
- [x] All 55 unit tests pass
- [x] Clippy clean
