### PR TITLE
refactor(server): move packet encoding from game loop to net tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ basalt-derive → basalt-protocol → basalt-net → basalt-server → plugins/*
 | `basalt-core` | `Context` trait, `BroadcastMessage`, `PlayerSnapshot`, `PluginLogger` | `basalt-types`, `basalt-world` |
 | `basalt-command` | Typed argument API (Arg, Validation, parsing), `Command` trait | `basalt-core` |
 | `basalt-api` | Public plugin API: `Plugin` trait, `ServerContext` (impl Context), events, `PluginRegistrar` | `basalt-core`, `basalt-command`, `basalt-events` |
-| `basalt-world` | World generation, chunk storage, paletted containers, block state registry | `basalt-types`, `basalt-protocol`, `basalt-storage` |
+| `basalt-world` | World generation, chunk storage, paletted containers, block state registry | `basalt-types`, `basalt-storage` |
 | `basalt-storage` | BSR region file format with LZ4 compression for chunk persistence | `lz4_flex` |
 | `basalt-ecs` | In-house Entity Component System: entities, components, systems, UUID index | `basalt-types` |
 | `basalt-server` | Server runtime: game loop, net tasks, I/O thread, plugin registration | `basalt-api`, `basalt-ecs`, `basalt-net`, all plugin crates |
@@ -104,18 +104,19 @@ crates/basalt-server/
 │   ├── lib.rs               # Server struct, startup orchestration
 │   ├── config.rs            # ServerConfig: TOML, plugin flags, tick_rate, crash_on_plugin_panic
 │   ├── error.rs             # Error type
-│   ├── messages.rs          # GameInput, ServerOutput enums (shared between net/ and game/)
-│   ├── helpers.rs           # angle_to_byte, RawPayload
+│   ├── messages.rs          # GameInput, ServerOutput (game events), BroadcastEvent, EncodablePacket
+│   ├── helpers.rs           # angle_to_byte, RawPayload, RawSlice
 │   ├── state.rs             # ServerState: entity ID counter, DeclareCommands builder
 │   ├── net/
 │   │   ├── mod.rs
 │   │   ├── connection.rs    # Handshake → Login → Config → net task
-│   │   ├── task.rs          # Per-player net task: TCP I/O, instant chat/commands
+│   │   ├── task.rs          # Per-player net task: TCP I/O, instant events, packet encoding
+│   │   ├── chunk_cache.rs   # ChunkPacketCache: shared DashMap of pre-encoded chunk bytes
 │   │   ├── channels.rs      # SharedState: game channel, broadcast, player registry
 │   │   └── skin.rs          # Mojang API skin fetching
 │   ├── game/
 │   │   ├── mod.rs
-│   │   └── tick.rs          # Game loop (20 TPS): movement, blocks, chunks, ECS, lifecycle
+│   │   └── tick.rs          # Game loop (20 TPS): movement, blocks, chunks, ECS, lifecycle (zero encoding)
 │   └── runtime/
 │       ├── mod.rs
 │       ├── tick.rs          # TickLoop: fixed-rate OS thread with drift correction
@@ -128,8 +129,10 @@ crates/basalt-server/
 
 ### Server architecture
 
-- **Game loop** (single dedicated OS thread, 20 TPS): handles all tick-based simulation — movement broadcasting, block operations, chunk streaming, player lifecycle, ECS systems (physics, AI). Owns the ECS and world.
-- **Net tasks** (one tokio task per player): handle TCP I/O, keep-alive, tab-complete. Instant events (chat, commands) are dispatched directly in the net task via `Arc<EventBus>` for zero latency. Game-relevant packets are forwarded to the game loop via channel.
+- **Game loop** (single dedicated OS thread, 20 TPS): handles all tick-based simulation — movement, block operations, chunk streaming, player lifecycle, ECS systems (physics, AI). Owns the ECS and world. Produces `ServerOutput` game events (zero encoding — no protocol knowledge).
+- **Net tasks** (one tokio task per player): handle TCP I/O, keep-alive, tab-complete, and **all packet encoding**. Receive `ServerOutput` game events from the game loop, construct protocol packets, encode, and write to TCP. Instant events (chat, commands) are dispatched directly via `Arc<EventBus>` for zero latency. Game-relevant packets are forwarded to the game loop via channel.
+- **ChunkPacketCache** (shared `DashMap`): caches pre-encoded chunk bytes. Net tasks look up on `SendChunk`; game loop invalidates on block change. Avoids redundant chunk encoding across players.
+- **SharedBroadcast** (`OnceLock`): broadcasts (movement, block changes) are encoded once by the first net task consumer; subsequent consumers read cached bytes.
 - **I/O thread** (dedicated OS thread): receives chunk persist requests via channel, writes BSR region files without blocking the game loop.
 - Two event buses: **instant bus** (chat, commands — dispatched in net tasks) and **game bus** (blocks, movement, lifecycle — dispatched in game loop).
 - Handlers are sync. They interact with the server through `ServerContext` methods which queue deferred responses.
@@ -168,7 +171,7 @@ crates/basalt-world/
 ├── src/
 │   ├── lib.rs           # Module declarations, re-exports
 │   ├── world.rs         # World: DashMap chunk cache, LRU eviction, lazy generation
-│   ├── chunk.rs         # ChunkColumn: 24 sections, set/get block, to_packet()
+│   ├── chunk.rs         # ChunkColumn: 24 sections, set/get block, encode_sections(), compute_heightmaps()
 │   ├── palette.rs       # PalettedContainer: single-value + indirect palette encoding
 │   ├── collision.rs     # AABB collision, ray_cast, resolve_movement
 │   ├── block.rs         # Block state IDs, is_solid()
@@ -177,7 +180,8 @@ crates/basalt-world/
 │   └── noise_gen.rs     # NoiseTerrainGenerator: Perlin noise terrain
 ```
 
-- `World::get_chunk_packet(cx, cz)` generates on first access, caches in memory
+- `World::with_chunk(cx, cz, |col| ...)` ensures loaded (generate or disk) and gives access to the `ChunkColumn`
+- `ChunkColumn::encode_sections()` and `compute_heightmaps()` provide raw data; protocol packet construction lives in basalt-server's `ChunkPacketCache`
 - `PalettedContainer` handles single-value optimization and indirect palettes with proper bits-per-entry
 - Chunk streaming: server tracks player chunk position, sends new chunks on boundary crossing, unloads old ones via `UnloadChunk`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,6 @@ dependencies = [
 name = "basalt-world"
 version = "0.1.0"
 dependencies = [
- "basalt-protocol",
  "basalt-storage",
  "basalt-types",
  "dashmap",

--- a/crates/basalt-server/src/game/tick.rs
+++ b/crates/basalt-server/src/game/tick.rs
@@ -3,7 +3,7 @@
 //! Runs at 20 TPS. Each tick:
 //! 1. Drains the [`GameInput`] channel (connect, disconnect, movement, blocks, inventory)
 //! 2. Runs ECS systems (physics, AI, pathfinding)
-//! 3. Produces output packets to player net tasks via [`OutputHandle`]
+//! 3. Produces [`ServerOutput`] game events to player net tasks (zero encoding)
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -15,24 +15,14 @@ use basalt_api::events::{
 };
 use basalt_events::Event;
 use basalt_protocol::packets::play::chat::ClientboundPlayDeclareCommands;
-use basalt_protocol::packets::play::entity::{
-    ClientboundPlayEntityDestroy, ClientboundPlayEntityHeadRotation, ClientboundPlaySpawnEntity,
-    ClientboundPlaySyncEntityPosition,
-};
-use basalt_protocol::packets::play::player::{
-    ClientboundPlayGameStateChange, ClientboundPlayLogin, ClientboundPlayLoginSpawninfo,
-    ClientboundPlayPlayerInfo, ClientboundPlayPlayerRemove, ClientboundPlayPosition,
-};
-use basalt_protocol::packets::play::world::{
-    ClientboundPlayAcknowledgePlayerDigging, ClientboundPlayBlockChange,
-    ClientboundPlayChunkBatchFinished, ClientboundPlayChunkBatchStart,
-    ClientboundPlaySpawnPosition, ClientboundPlayUnloadChunk, ClientboundPlayUpdateViewPosition,
-};
-use basalt_types::{Encode, EncodedSize, Position, Uuid, VarInt, Vec3i16};
+use basalt_protocol::packets::play::entity::ClientboundPlaySpawnEntity;
+use basalt_protocol::packets::play::player::{ClientboundPlayLogin, ClientboundPlayLoginSpawninfo};
+use basalt_types::{Encode, Position, Uuid, VarInt, Vec3i16};
 use tokio::sync::mpsc;
 
 use crate::helpers::angle_to_byte;
-use crate::messages::{GameInput, ServerOutput};
+use crate::messages::{BroadcastEvent, EncodablePacket, GameInput, ServerOutput, SharedBroadcast};
+use crate::net::chunk_cache::ChunkPacketCache;
 
 /// View distance radius in chunks.
 const VIEW_RADIUS: i32 = 5;
@@ -80,6 +70,8 @@ pub(crate) struct GameLoop {
     bus: EventBus,
     /// World — sole owner for writes, concurrent reads by net tasks.
     world: Arc<basalt_world::World>,
+    /// Shared chunk packet cache — invalidated on block mutations.
+    chunk_cache: Arc<ChunkPacketCache>,
     /// Entity Component System: entities, components, systems.
     ecs: basalt_ecs::Ecs,
     /// Receiver for net task → game loop messages.
@@ -95,6 +87,7 @@ impl GameLoop {
     pub fn new(
         bus: EventBus,
         world: Arc<basalt_world::World>,
+        chunk_cache: Arc<ChunkPacketCache>,
         game_rx: mpsc::UnboundedReceiver<GameInput>,
         io_tx: mpsc::UnboundedSender<crate::runtime::io_thread::IoRequest>,
         ecs: basalt_ecs::Ecs,
@@ -103,6 +96,7 @@ impl GameLoop {
         Self {
             bus,
             world,
+            chunk_cache,
             ecs,
             game_rx,
             io_tx,
@@ -332,7 +326,10 @@ impl GameLoop {
                     .color(basalt_types::TextColor::Named(
                         basalt_types::NamedColor::Yellow,
                     ));
-                send_system_chat(tx, &msg, false);
+                let _ = tx.try_send(ServerOutput::SystemChat {
+                    content: msg.to_nbt(),
+                    action_bar: false,
+                });
             });
         }
 
@@ -341,7 +338,10 @@ impl GameLoop {
             let msg = basalt_types::TextComponent::text(format!("Welcome, {username}!")).color(
                 basalt_types::TextColor::Named(basalt_types::NamedColor::Gold),
             );
-            send_system_chat(tx, &msg, false);
+            let _ = tx.try_send(ServerOutput::SystemChat {
+                content: msg.to_nbt(),
+                action_bar: false,
+            });
         });
 
         // Dispatch PlayerJoinedEvent
@@ -384,14 +384,17 @@ impl GameLoop {
             enforces_secure_chat: false,
         };
         self.send_to(eid, |tx| {
-            let _ = tx.try_send(encode_packet(ClientboundPlayLogin::PACKET_ID, &login));
+            let _ = tx.try_send(ServerOutput::Packet(EncodablePacket::new(
+                ClientboundPlayLogin::PACKET_ID,
+                login,
+            )));
         });
 
         // DeclareCommands
         if !self.declare_commands.is_empty() {
             let dc = self.declare_commands.clone();
             self.send_to(eid, |tx| {
-                let _ = tx.try_send(ServerOutput::SendPacket {
+                let _ = tx.try_send(ServerOutput::Raw {
                     id: ClientboundPlayDeclareCommands::PACKET_ID,
                     data: dc,
                 });
@@ -401,62 +404,46 @@ impl GameLoop {
         // SpawnPosition
         let spawn_y = self.world.spawn_y() as i32;
         self.send_to(eid, |tx| {
-            let _ = tx.try_send(encode_packet(
-                ClientboundPlaySpawnPosition::PACKET_ID,
-                &ClientboundPlaySpawnPosition {
+            let _ = tx.try_send(ServerOutput::Packet(EncodablePacket::new(
+                basalt_protocol::packets::play::world::ClientboundPlaySpawnPosition::PACKET_ID,
+                basalt_protocol::packets::play::world::ClientboundPlaySpawnPosition {
                     location: Position::new(0, spawn_y, 0),
                     angle: 0.0,
                 },
-            ));
+            )));
         });
 
         // GameEvent (wait for chunks)
         self.send_to(eid, |tx| {
-            let _ = tx.try_send(encode_packet(
-                ClientboundPlayGameStateChange::PACKET_ID,
-                &ClientboundPlayGameStateChange {
-                    reason: 13,
-                    game_mode: 0.0,
-                },
-            ));
+            let _ = tx.try_send(ServerOutput::GameStateChange {
+                reason: 13,
+                value: 0.0,
+            });
         });
 
         // UpdateViewPosition + chunks
         let cx = (position.0 as i32) >> 4;
         let cz = (position.2 as i32) >> 4;
         self.send_to(eid, |tx| {
-            let _ = tx.try_send(encode_packet(
-                ClientboundPlayUpdateViewPosition::PACKET_ID,
-                &ClientboundPlayUpdateViewPosition {
-                    chunk_x: cx,
-                    chunk_z: cz,
-                },
-            ));
-            let _ = tx.try_send(encode_packet(
-                ClientboundPlayChunkBatchStart::PACKET_ID,
-                &ClientboundPlayChunkBatchStart,
-            ));
+            let _ = tx.try_send(ServerOutput::UpdateViewPosition { cx, cz });
+            let _ = tx.try_send(ServerOutput::ChunkBatchStart);
         });
 
         let mut count = 0i32;
         for dx in -VIEW_RADIUS..=VIEW_RADIUS {
             for dz in -VIEW_RADIUS..=VIEW_RADIUS {
-                let packet = self.world.get_chunk_packet(cx + dx, cz + dz);
                 self.send_to(eid, |tx| {
-                    let _ = tx.try_send(encode_packet(
-                        basalt_protocol::packets::play::world::ClientboundPlayMapChunk::PACKET_ID,
-                        &packet,
-                    ));
+                    let _ = tx.try_send(ServerOutput::SendChunk {
+                        cx: cx + dx,
+                        cz: cz + dz,
+                    });
                 });
                 count += 1;
             }
         }
 
         self.send_to(eid, |tx| {
-            let _ = tx.try_send(encode_packet(
-                ClientboundPlayChunkBatchFinished::PACKET_ID,
-                &ClientboundPlayChunkBatchFinished { batch_size: count },
-            ));
+            let _ = tx.try_send(ServerOutput::ChunkBatchFinished { batch_size: count });
         });
 
         // Track loaded chunks
@@ -470,21 +457,14 @@ impl GameLoop {
 
         // Position
         self.send_to(eid, |tx| {
-            let _ = tx.try_send(encode_packet(
-                ClientboundPlayPosition::PACKET_ID,
-                &ClientboundPlayPosition {
-                    teleport_id: 1,
-                    x: position.0,
-                    y: position.1,
-                    z: position.2,
-                    dx: 0.0,
-                    dy: 0.0,
-                    dz: 0.0,
-                    yaw: 0.0,
-                    pitch: 0.0,
-                    flags: 0,
-                },
-            ));
+            let _ = tx.try_send(ServerOutput::SetPosition {
+                teleport_id: 1,
+                x: position.0,
+                y: position.1,
+                z: position.2,
+                yaw: 0.0,
+                pitch: 0.0,
+            });
         });
     }
 
@@ -514,27 +494,25 @@ impl GameLoop {
         self.ecs.despawn(eid);
 
         // Broadcast leave to remaining players
-        let remove = encode_packet(
-            ClientboundPlayPlayerRemove::PACKET_ID,
-            &ClientboundPlayPlayerRemove {
-                players: vec![uuid],
-            },
-        );
-        let destroy = encode_packet(
-            ClientboundPlayEntityDestroy::PACKET_ID,
-            &ClientboundPlayEntityDestroy {
-                entity_ids: vec![entity_id],
-            },
-        );
+        let remove_players = Arc::new(SharedBroadcast::new(BroadcastEvent::RemovePlayers {
+            uuids: vec![uuid],
+        }));
+        let remove_entities = Arc::new(SharedBroadcast::new(BroadcastEvent::RemoveEntities {
+            entity_ids: vec![entity_id],
+        }));
         let msg = basalt_types::TextComponent::text(format!("{username} left the game")).color(
             basalt_types::TextColor::Named(basalt_types::NamedColor::Yellow),
         );
+        let leave_chat = Arc::new(SharedBroadcast::new(BroadcastEvent::SystemChat {
+            content: msg.to_nbt(),
+            action_bar: false,
+        }));
 
         for (other_eid, _) in self.ecs.iter::<OutputHandle>() {
             self.send_to(other_eid, |tx| {
-                let _ = tx.try_send(remove.clone());
-                let _ = tx.try_send(destroy.clone());
-                send_system_chat(tx, &msg, false);
+                let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&remove_players)));
+                let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&remove_entities)));
+                let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&leave_chat)));
             });
         }
     }
@@ -607,33 +585,19 @@ impl GameLoop {
         self.process_responses(uuid, &responses);
 
         // Broadcast movement to other players
-        let sync = encode_packet(
-            ClientboundPlaySyncEntityPosition::PACKET_ID,
-            &ClientboundPlaySyncEntityPosition {
-                entity_id,
-                x,
-                y,
-                z,
-                dx: 0.0,
-                dy: 0.0,
-                dz: 0.0,
-                yaw,
-                pitch,
-                on_ground,
-            },
-        );
-        let head = encode_packet(
-            ClientboundPlayEntityHeadRotation::PACKET_ID,
-            &ClientboundPlayEntityHeadRotation {
-                entity_id,
-                head_yaw: angle_to_byte(yaw),
-            },
-        );
+        let moved = Arc::new(SharedBroadcast::new(BroadcastEvent::EntityMoved {
+            entity_id,
+            x,
+            y,
+            z,
+            yaw,
+            pitch,
+            on_ground,
+        }));
         for (other_eid, _) in self.ecs.iter::<OutputHandle>() {
             if other_eid != eid {
                 self.send_to(other_eid, |tx| {
-                    let _ = tx.try_send(sync.clone());
-                    let _ = tx.try_send(head.clone());
+                    let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&moved)));
                 });
             }
         }
@@ -649,13 +613,10 @@ impl GameLoop {
     /// Streams chunks when a player crosses a chunk boundary.
     fn stream_chunks(&mut self, eid: basalt_ecs::EntityId, new_cx: i32, new_cz: i32) {
         self.send_to(eid, |tx| {
-            let _ = tx.try_send(encode_packet(
-                ClientboundPlayUpdateViewPosition::PACKET_ID,
-                &ClientboundPlayUpdateViewPosition {
-                    chunk_x: new_cx,
-                    chunk_z: new_cz,
-                },
-            ));
+            let _ = tx.try_send(ServerOutput::UpdateViewPosition {
+                cx: new_cx,
+                cz: new_cz,
+            });
         });
 
         let r = VIEW_RADIUS;
@@ -677,15 +638,9 @@ impl GameLoop {
             .copied()
             .collect();
 
-        for (cx, cz) in &to_unload {
+        for &(cx, cz) in &to_unload {
             self.send_to(eid, |tx| {
-                let _ = tx.try_send(encode_packet(
-                    ClientboundPlayUnloadChunk::PACKET_ID,
-                    &ClientboundPlayUnloadChunk {
-                        chunk_x: *cx,
-                        chunk_z: *cz,
-                    },
-                ));
+                let _ = tx.try_send(ServerOutput::UnloadChunk { cx, cz });
             });
         }
 
@@ -706,27 +661,17 @@ impl GameLoop {
 
         if !to_load.is_empty() {
             self.send_to(eid, |tx| {
-                let _ = tx.try_send(encode_packet(
-                    ClientboundPlayChunkBatchStart::PACKET_ID,
-                    &ClientboundPlayChunkBatchStart,
-                ));
+                let _ = tx.try_send(ServerOutput::ChunkBatchStart);
             });
-            for (cx, cz) in &to_load {
-                let packet = self.world.get_chunk_packet(*cx, *cz);
+            for &(cx, cz) in &to_load {
                 self.send_to(eid, |tx| {
-                    let _ = tx.try_send(encode_packet(
-                        basalt_protocol::packets::play::world::ClientboundPlayMapChunk::PACKET_ID,
-                        &packet,
-                    ));
+                    let _ = tx.try_send(ServerOutput::SendChunk { cx, cz });
                 });
             }
             self.send_to(eid, |tx| {
-                let _ = tx.try_send(encode_packet(
-                    ClientboundPlayChunkBatchFinished::PACKET_ID,
-                    &ClientboundPlayChunkBatchFinished {
-                        batch_size: to_load.len() as i32,
-                    },
-                ));
+                let _ = tx.try_send(ServerOutput::ChunkBatchFinished {
+                    batch_size: to_load.len() as i32,
+                });
             });
         }
     }
@@ -759,13 +704,12 @@ impl GameLoop {
 
         if event.is_cancelled() {
             if let Some(handle) = self.ecs.get::<OutputHandle>(eid) {
-                let _ = handle.tx.try_send(encode_packet(
-                    ClientboundPlayBlockChange::PACKET_ID,
-                    &ClientboundPlayBlockChange {
-                        location: Position::new(x, y, z),
-                        r#type: i32::from(original_state),
-                    },
-                ));
+                let _ = handle.tx.try_send(ServerOutput::BlockChanged {
+                    x,
+                    y,
+                    z,
+                    state: i32::from(original_state),
+                });
             }
             return;
         }
@@ -820,13 +764,12 @@ impl GameLoop {
 
         if event.is_cancelled() {
             if let Some(handle) = self.ecs.get::<OutputHandle>(eid) {
-                let _ = handle.tx.try_send(encode_packet(
-                    ClientboundPlayBlockChange::PACKET_ID,
-                    &ClientboundPlayBlockChange {
-                        location: Position::new(px, py, pz),
-                        r#type: i32::from(basalt_world::block::AIR),
-                    },
-                ));
+                let _ = handle.tx.try_send(ServerOutput::BlockChanged {
+                    x: px,
+                    y: py,
+                    z: pz,
+                    state: i32::from(basalt_world::block::AIR),
+                });
             }
             return;
         }
@@ -846,30 +789,28 @@ impl GameLoop {
                     z,
                     block_state,
                 }) => {
-                    let data = encode_packet(
-                        ClientboundPlayBlockChange::PACKET_ID,
-                        &ClientboundPlayBlockChange {
-                            location: Position::new(*x, *y, *z),
-                            r#type: *block_state,
-                        },
-                    );
+                    // Invalidate chunk cache for this block's chunk
+                    self.chunk_cache.invalidate(*x >> 4, *z >> 4);
+                    let bc = Arc::new(SharedBroadcast::new(BroadcastEvent::BlockChanged {
+                        x: *x,
+                        y: *y,
+                        z: *z,
+                        state: *block_state,
+                    }));
                     for (e, _) in self.ecs.iter::<OutputHandle>() {
                         self.send_to(e, |tx| {
-                            let _ = tx.try_send(data.clone());
+                            let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&bc)));
                         });
                     }
                 }
                 Response::Broadcast(basalt_api::BroadcastMessage::Chat { content }) => {
-                    let data = encode_packet(
-                        basalt_protocol::packets::play::chat::ClientboundPlaySystemChat::PACKET_ID,
-                        &basalt_protocol::packets::play::chat::ClientboundPlaySystemChat {
-                            content: content.clone(),
-                            is_action_bar: false,
-                        },
-                    );
+                    let bc = Arc::new(SharedBroadcast::new(BroadcastEvent::SystemChat {
+                        content: content.clone(),
+                        action_bar: false,
+                    }));
                     for (e, _) in self.ecs.iter::<OutputHandle>() {
                         self.send_to(e, |tx| {
-                            let _ = tx.try_send(data.clone());
+                            let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&bc)));
                         });
                     }
                 }
@@ -878,12 +819,9 @@ impl GameLoop {
                     if let Some(eid) = self.ecs.find_by_uuid(source_uuid)
                         && let Some(handle) = self.ecs.get::<OutputHandle>(eid)
                     {
-                        let _ = handle.tx.try_send(encode_packet(
-                            ClientboundPlayAcknowledgePlayerDigging::PACKET_ID,
-                            &ClientboundPlayAcknowledgePlayerDigging {
-                                sequence_id: *sequence,
-                            },
-                        ));
+                        let _ = handle.tx.try_send(ServerOutput::BlockAck {
+                            sequence: *sequence,
+                        });
                     }
                 }
                 Response::SendSystemChat {
@@ -893,13 +831,10 @@ impl GameLoop {
                     if let Some(eid) = self.ecs.find_by_uuid(source_uuid)
                         && let Some(handle) = self.ecs.get::<OutputHandle>(eid)
                     {
-                        let _ = handle.tx.try_send(encode_packet(
-                            basalt_protocol::packets::play::chat::ClientboundPlaySystemChat::PACKET_ID,
-                            &basalt_protocol::packets::play::chat::ClientboundPlaySystemChat {
-                                content: content.clone(),
-                                is_action_bar: *action_bar,
-                            },
-                        ));
+                        let _ = handle.tx.try_send(ServerOutput::SystemChat {
+                            content: content.clone(),
+                            action_bar: *action_bar,
+                        });
                     }
                 }
                 Response::SendPosition {
@@ -917,21 +852,14 @@ impl GameLoop {
                             pos.z = *z;
                         }
                         if let Some(handle) = self.ecs.get::<OutputHandle>(eid) {
-                            let _ = handle.tx.try_send(encode_packet(
-                                ClientboundPlayPosition::PACKET_ID,
-                                &ClientboundPlayPosition {
-                                    teleport_id: *teleport_id,
-                                    x: *x,
-                                    y: *y,
-                                    z: *z,
-                                    dx: 0.0,
-                                    dy: 0.0,
-                                    dz: 0.0,
-                                    yaw: *yaw,
-                                    pitch: *pitch,
-                                    flags: 0,
-                                },
-                            ));
+                            let _ = handle.tx.try_send(ServerOutput::SetPosition {
+                                teleport_id: *teleport_id,
+                                x: *x,
+                                y: *y,
+                                z: *z,
+                                yaw: *yaw,
+                                pitch: *pitch,
+                            });
                         }
                     }
                 }
@@ -944,13 +872,10 @@ impl GameLoop {
                     if let Some(eid) = self.ecs.find_by_uuid(source_uuid)
                         && let Some(handle) = self.ecs.get::<OutputHandle>(eid)
                     {
-                        let _ = handle.tx.try_send(encode_packet(
-                            ClientboundPlayGameStateChange::PACKET_ID,
-                            &ClientboundPlayGameStateChange {
-                                reason: *reason,
-                                game_mode: *value,
-                            },
-                        ));
+                        let _ = handle.tx.try_send(ServerOutput::GameStateChange {
+                            reason: *reason,
+                            value: *value,
+                        });
                     }
                 }
                 Response::PersistChunk { cx, cz } => {
@@ -1007,18 +932,10 @@ fn face_offset(direction: i32) -> (i32, i32, i32) {
     }
 }
 
-/// Encodes a packet struct into a [`ServerOutput::SendPacket`].
-fn encode_packet<P: Encode + EncodedSize>(packet_id: i32, packet: &P) -> ServerOutput {
-    let mut data = Vec::with_capacity(packet.encoded_size());
-    packet.encode(&mut data).expect("packet encoding failed");
-    ServerOutput::SendPacket {
-        id: packet_id,
-        data,
-    }
-}
-
-/// Sends a PlayerInfo "add player" packet.
+/// Sends a PlayerInfo "add player" packet (manually encoded due to switch fields).
 fn send_player_info_add(output_tx: &mpsc::Sender<ServerOutput>, info: &basalt_api::PlayerSnapshot) {
+    use basalt_protocol::packets::play::player::ClientboundPlayPlayerInfo;
+
     let mut buf = Vec::new();
     let actions: u8 = 0x01 | 0x04 | 0x08;
     actions.encode(&mut buf).unwrap();
@@ -1040,7 +957,7 @@ fn send_player_info_add(output_tx: &mpsc::Sender<ServerOutput>, info: &basalt_ap
     }
     VarInt(1).encode(&mut buf).unwrap(); // gamemode: creative
     true.encode(&mut buf).unwrap(); // listed
-    let _ = output_tx.try_send(ServerOutput::SendPacket {
+    let _ = output_tx.try_send(ServerOutput::Raw {
         id: ClientboundPlayPlayerInfo::PACKET_ID,
         data: buf,
     });
@@ -1061,25 +978,10 @@ fn send_spawn_entity(output_tx: &mpsc::Sender<ServerOutput>, info: &basalt_api::
         object_data: 0,
         velocity: Vec3i16 { x: 0, y: 0, z: 0 },
     };
-    let _ = output_tx.try_send(encode_packet(
+    let _ = output_tx.try_send(ServerOutput::Packet(EncodablePacket::new(
         ClientboundPlaySpawnEntity::PACKET_ID,
-        &packet,
-    ));
-}
-
-/// Sends a system chat message.
-fn send_system_chat(
-    output_tx: &mpsc::Sender<ServerOutput>,
-    component: &basalt_types::TextComponent,
-    action_bar: bool,
-) {
-    let _ = output_tx.try_send(encode_packet(
-        basalt_protocol::packets::play::chat::ClientboundPlaySystemChat::PACKET_ID,
-        &basalt_protocol::packets::play::chat::ClientboundPlaySystemChat {
-            content: component.to_nbt(),
-            is_action_bar: action_bar,
-        },
-    ));
+        packet,
+    )));
 }
 
 #[cfg(test)]
@@ -1093,6 +995,7 @@ mod tests {
         mpsc::UnboundedReceiver<crate::runtime::io_thread::IoRequest>,
     ) {
         let world = Arc::new(basalt_world::World::new_memory(42));
+        let chunk_cache = Arc::new(ChunkPacketCache::new(Arc::clone(&world)));
         let (game_tx, game_rx) = mpsc::unbounded_channel();
         let (io_tx, io_rx) = mpsc::unbounded_channel();
 
@@ -1114,7 +1017,7 @@ mod tests {
         }
 
         let ecs = basalt_ecs::Ecs::new();
-        let game_loop = GameLoop::new(bus, world, game_rx, io_tx, ecs, Vec::new());
+        let game_loop = GameLoop::new(bus, world, chunk_cache, game_rx, io_tx, ecs, Vec::new());
         (game_loop, game_tx, io_rx)
     }
 
@@ -1206,8 +1109,6 @@ mod tests {
         let uuid = Uuid::from_bytes([1; 16]);
         let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
 
-        // Should have received many packets (Login, DeclareCommands,
-        // SpawnPosition, GameEvent, chunks, Position, PlayerInfo, welcome)
         let mut count = 0;
         while rx.try_recv().is_ok() {
             count += 1;
@@ -1277,7 +1178,6 @@ mod tests {
         let rot = game_loop.ecs.get::<basalt_ecs::Rotation>(eid).unwrap();
         assert_eq!(rot.yaw, 180.0);
         assert_eq!(rot.pitch, -30.0);
-        // Position should be unchanged (0, -60, 0 from connect)
         let pos = game_loop.ecs.get::<basalt_ecs::Position>(eid).unwrap();
         assert_eq!(pos.x, 0.0);
     }
@@ -1289,17 +1189,14 @@ mod tests {
         let uuid2 = Uuid::from_bytes([2; 16]);
         let mut rx1 = connect_player(&mut game_loop, &game_tx, uuid1, 1);
 
-        // Drain initial packets for player 1
         while rx1.try_recv().is_ok() {}
 
-        // Player 2 joins — player 1 should receive join broadcast
         let _rx2 = connect_player(&mut game_loop, &game_tx, uuid2, 2);
 
         let mut p1_count = 0;
         while rx1.try_recv().is_ok() {
             p1_count += 1;
         }
-        // Player 1 should get: PlayerInfo + SpawnEntity + join message
         assert!(
             p1_count >= 3,
             "player 1 should receive join broadcast, got {p1_count} packets"
@@ -1314,14 +1211,11 @@ mod tests {
         let mut rx1 = connect_player(&mut game_loop, &game_tx, uuid1, 1);
         let _rx2 = connect_player(&mut game_loop, &game_tx, uuid2, 2);
 
-        // Drain all packets
         while rx1.try_recv().is_ok() {}
 
-        // Player 2 disconnects
         let _ = game_tx.send(GameInput::PlayerDisconnected { uuid: uuid2 });
         game_loop.tick(2);
 
-        // Player 1 should receive leave broadcast
         let mut p1_count = 0;
         while rx1.try_recv().is_ok() {
             p1_count += 1;
@@ -1340,10 +1234,8 @@ mod tests {
         let _rx1 = connect_player(&mut game_loop, &game_tx, uuid1, 1);
         let mut rx2 = connect_player(&mut game_loop, &game_tx, uuid2, 2);
 
-        // Drain initial packets
         while rx2.try_recv().is_ok() {}
 
-        // Player 1 moves
         let _ = game_tx.send(GameInput::Position {
             uuid: uuid1,
             x: 5.0,
@@ -1353,15 +1245,13 @@ mod tests {
         });
         game_loop.tick(2);
 
-        // Player 2 should receive movement broadcast
-        let mut p2_count = 0;
-        while rx2.try_recv().is_ok() {
-            p2_count += 1;
+        let mut got_moved = false;
+        while let Ok(msg) = rx2.try_recv() {
+            if matches!(msg, ServerOutput::Broadcast(_)) {
+                got_moved = true;
+            }
         }
-        assert!(
-            p2_count >= 2,
-            "player 2 should receive sync + head rotation, got {p2_count}"
-        );
+        assert!(got_moved, "player 2 should receive movement broadcast");
     }
 
     #[test]
@@ -1370,7 +1260,6 @@ mod tests {
         let uuid = Uuid::from_bytes([1; 16]);
         let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
 
-        // Give stone in hotbar slot 0
         let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
         if let Some(inv) = game_loop.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
             inv.hotbar[0] = basalt_types::Slot {
@@ -1380,7 +1269,6 @@ mod tests {
             };
         }
 
-        // Place on top of (5, 63, 3)
         let _ = game_tx.send(GameInput::BlockPlace {
             uuid,
             x: 5,
@@ -1426,7 +1314,6 @@ mod tests {
         let uuid = Uuid::from_bytes([1; 16]);
         let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
 
-        // Slot 10 is outside hotbar range (36-44)
         let _ = game_tx.send(GameInput::SetCreativeSlot {
             uuid,
             slot: 10,
@@ -1438,7 +1325,6 @@ mod tests {
         });
         game_loop.tick(1);
 
-        // Hotbar should be unchanged (all empty)
         let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
         let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
         assert!(inv.hotbar[0].item_id.is_none());
@@ -1453,7 +1339,6 @@ mod tests {
             .world
             .set_block(5, 64, 3, basalt_world::block::STONE);
 
-        // Drain initial packets
         while rx.try_recv().is_ok() {}
 
         let _ = game_tx.send(GameInput::BlockDig {
@@ -1468,16 +1353,22 @@ mod tests {
 
         let mut got_ack = false;
         let mut got_block_change = false;
-        while let Ok(ServerOutput::SendPacket { id, .. }) = rx.try_recv() {
-            if id == basalt_protocol::packets::play::world::ClientboundPlayAcknowledgePlayerDigging::PACKET_ID {
-                got_ack = true;
-            }
-            if id == basalt_protocol::packets::play::world::ClientboundPlayBlockChange::PACKET_ID {
-                got_block_change = true;
+        while let Ok(msg) = rx.try_recv() {
+            match &msg {
+                ServerOutput::BlockAck { .. } => got_ack = true,
+                ServerOutput::Broadcast(bc) => {
+                    if matches!(bc.event, BroadcastEvent::BlockChanged { .. }) {
+                        got_block_change = true;
+                    }
+                }
+                _ => {}
             }
         }
         assert!(got_ack, "should have received block ack");
-        assert!(got_block_change, "should have received block change");
+        assert!(
+            got_block_change,
+            "should have received block change broadcast"
+        );
     }
 
     #[test]
@@ -1485,7 +1376,6 @@ mod tests {
         let (mut game_loop, game_tx, _io_rx) = test_game_loop();
         let unknown = Uuid::from_bytes([99; 16]);
 
-        // Should not panic
         let _ = game_tx.send(GameInput::Position {
             uuid: unknown,
             x: 10.0,
@@ -1510,7 +1400,6 @@ mod tests {
             sequence: 1,
         });
         game_loop.tick(0);
-        // No crash = pass
     }
 
     #[test]
@@ -1519,10 +1408,8 @@ mod tests {
         let uuid = Uuid::from_bytes([1; 16]);
         let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
 
-        // Drain initial packets
         while rx.try_recv().is_ok() {}
 
-        // Move to a different chunk (16 blocks away = chunk boundary)
         let _ = game_tx.send(GameInput::Position {
             uuid,
             x: 32.0,
@@ -1532,7 +1419,6 @@ mod tests {
         });
         game_loop.tick(1);
 
-        // Should receive UpdateViewPosition + chunk load/unload packets
         let mut got_packets = false;
         while rx.try_recv().is_ok() {
             got_packets = true;
@@ -1542,7 +1428,6 @@ mod tests {
             "should receive chunk streaming packets on boundary crossing"
         );
 
-        // Verify ChunkView was updated
         let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
         let view = game_loop.ecs.get::<ChunkView>(eid).unwrap();
         let new_cx = (32.0_f64 as i32) >> 4;

--- a/crates/basalt-server/src/helpers.rs
+++ b/crates/basalt-server/src/helpers.rs
@@ -11,7 +11,7 @@ pub(crate) fn angle_to_byte(degrees: f32) -> i8 {
     ((degrees / 360.0 * 256.0) as i32 & 0xFF) as i8
 }
 
-/// A wrapper that writes raw bytes without any framing or encoding.
+/// A wrapper that writes raw owned bytes without any framing or encoding.
 ///
 /// Used when we need to build a packet payload manually (e.g.,
 /// PlayerInfo where the generated struct can't handle conditional
@@ -26,6 +26,25 @@ impl Encode for RawPayload {
 }
 
 impl EncodedSize for RawPayload {
+    fn encoded_size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// A wrapper that writes borrowed bytes without cloning.
+///
+/// Used by the net task to write cached chunk data and broadcast
+/// bytes from [`SharedBroadcast`] without heap allocation.
+pub(crate) struct RawSlice<'a>(pub &'a [u8]);
+
+impl Encode for RawSlice<'_> {
+    fn encode(&self, buf: &mut Vec<u8>) -> basalt_types::Result<()> {
+        buf.extend_from_slice(self.0);
+        Ok(())
+    }
+}
+
+impl EncodedSize for RawSlice<'_> {
     fn encoded_size(&self) -> usize {
         self.0.len()
     }

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -91,6 +91,9 @@ impl Server {
         // Wrap the instant bus in Arc for sharing across net tasks
         let instant_bus = Arc::new(instant_bus);
 
+        // Shared chunk packet cache — net tasks encode on miss, game loop invalidates
+        let chunk_cache = Arc::new(net::chunk_cache::ChunkPacketCache::new(Arc::clone(&world)));
+
         // I/O thread — dedicated OS thread for async chunk persistence
         let io_thread = runtime::io_thread::IoThread::start(Arc::clone(&world));
 
@@ -116,6 +119,7 @@ impl Server {
         let mut game_loop_inst = game::GameLoop::new(
             game_bus,
             Arc::clone(&world),
+            Arc::clone(&chunk_cache),
             shared.game_rx,
             io_thread.sender(),
             ecs,
@@ -155,6 +159,7 @@ impl Server {
             let broadcast_tx = broadcast_tx.clone();
             let player_registry = Arc::clone(&player_registry);
             let world = Arc::clone(&world);
+            let chunk_cache = Arc::clone(&chunk_cache);
             tokio::spawn(async move {
                 if let Err(e) = net::connection::handle_connection(
                     stream,
@@ -165,6 +170,7 @@ impl Server {
                     broadcast_tx,
                     player_registry,
                     world,
+                    chunk_cache,
                 )
                 .await
                 {

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -1,11 +1,17 @@
-//! Message types for net task → game loop communication.
+//! Message types for communication between net tasks and the game loop.
 //!
-//! Net tasks forward game-relevant packets to the game loop via a
-//! shared MPSC channel. Instant events (chat, commands) are handled
-//! directly in the net task and never reach the game loop.
+//! [`GameInput`]: net task -> game loop (game-relevant packets).
+//! [`ServerOutput`]: game loop -> net task (game events to encode and send).
+//!
+//! The game loop expresses **game events**, not encoded packets. Net tasks
+//! are responsible for translating events into protocol packets and encoding
+//! them onto the wire.
+
+use std::sync::Arc;
 
 use basalt_core::broadcast::ProfileProperty;
-use basalt_types::{Slot, Uuid};
+use basalt_types::nbt::NbtCompound;
+use basalt_types::{Encode, EncodedSize, Slot, Uuid};
 use tokio::sync::mpsc;
 
 /// Messages from net tasks to the game loop.
@@ -131,15 +137,246 @@ pub enum GameInput {
 
 /// Output from the game loop to a player's net task.
 ///
-/// Each player has a dedicated bounded channel. The net task reads
-/// from it and writes the encoded packets to the TCP connection.
+/// Represents **game events**, not encoded packets. The net task matches
+/// on each variant, constructs the appropriate protocol packet(s), and
+/// encodes them onto the wire.
+///
+/// Variants are split by allocation cost:
+/// - **Hot path**: small inline structs, zero heap allocation, cloned cheaply for broadcasts.
+/// - **Chunk path**: coordinates only, net task looks up the shared [`ChunkPacketCache`].
+/// - **Cold path**: rare events (connect/disconnect), one Arc alloc per event.
 #[derive(Clone, Debug)]
 pub enum ServerOutput {
-    /// A pre-encoded packet to send to the client.
-    SendPacket {
+    // ── Hot path (targeted, zero alloc) ─────────────────────────────────
+    /// A block changed in the world. Net task sends BlockChange.
+    BlockChanged {
+        /// Block X coordinate.
+        x: i32,
+        /// Block Y coordinate.
+        y: i32,
+        /// Block Z coordinate.
+        z: i32,
+        /// New block state ID.
+        state: i32,
+    },
+    /// Acknowledge a block dig/place sequence. Net task sends AcknowledgePlayerDigging.
+    BlockAck {
+        /// Sequence number to acknowledge.
+        sequence: i32,
+    },
+    /// A system chat message. Net task sends SystemChat.
+    SystemChat {
+        /// NBT-encoded text component content.
+        content: NbtCompound,
+        /// Whether to display as action bar text.
+        action_bar: bool,
+    },
+    /// A game state change. Net task sends GameStateChange.
+    GameStateChange {
+        /// Reason code (e.g., 13 = wait for chunks, 3 = change game mode).
+        reason: u8,
+        /// Associated float value (meaning depends on reason).
+        value: f32,
+    },
+    /// Teleport or set player position. Net task sends Position.
+    SetPosition {
+        /// Teleport confirmation ID.
+        teleport_id: i32,
+        /// Target X coordinate.
+        x: f64,
+        /// Target Y coordinate.
+        y: f64,
+        /// Target Z coordinate.
+        z: f64,
+        /// Target yaw (degrees).
+        yaw: f32,
+        /// Target pitch (degrees).
+        pitch: f32,
+    },
+    // ── Chunk path (cache-based, zero alloc) ──────────────────────────
+    /// Send a chunk to the client. Net task looks up the ChunkPacketCache.
+    SendChunk {
+        /// Chunk X coordinate.
+        cx: i32,
+        /// Chunk Z coordinate.
+        cz: i32,
+    },
+    /// Unload a chunk from the client.
+    UnloadChunk {
+        /// Chunk X coordinate.
+        cx: i32,
+        /// Chunk Z coordinate.
+        cz: i32,
+    },
+    /// Start a chunk batch.
+    ChunkBatchStart,
+    /// Finish a chunk batch with the number of chunks sent.
+    ChunkBatchFinished {
+        /// Number of chunks in the batch.
+        batch_size: i32,
+    },
+    /// Update the client's view position (center chunk).
+    UpdateViewPosition {
+        /// Center chunk X coordinate.
+        cx: i32,
+        /// Center chunk Z coordinate.
+        cz: i32,
+    },
+
+    // ── Broadcast (shared, encoded once by first consumer) ──────────
+    /// A broadcast game event shared across N players via `Arc`.
+    ///
+    /// The first net task to consume it encodes the protocol packets
+    /// into the [`SharedBroadcast`]'s `OnceLock`. All subsequent net
+    /// tasks read the cached bytes — one encode for N players.
+    Broadcast(Arc<SharedBroadcast>),
+
+    // ── Cold path (rare, Arc alloc OK) ────────────────────────────────
+    /// A protocol packet to encode. Used for rare events (login, spawn)
+    /// where a dedicated variant would add enum bloat.
+    Packet(EncodablePacket),
+    /// Pre-encoded packet bytes. Used for packets with manual encoding
+    /// (PlayerInfo switch fields, DeclareCommands).
+    Raw {
         /// Minecraft packet ID.
         id: i32,
-        /// Encoded packet payload (without the packet ID).
+        /// Encoded packet payload (without length prefix).
         data: Vec<u8>,
     },
+}
+
+/// A game event broadcast to multiple players.
+///
+/// Wraps a [`BroadcastEvent`] with lazy encoding: the first net task
+/// to consume it encodes the protocol packets via [`OnceLock`], and
+/// all subsequent consumers read the cached bytes.
+pub struct SharedBroadcast {
+    /// The game event to encode.
+    pub(crate) event: BroadcastEvent,
+    /// Cached encoded packets: `(packet_id, payload_bytes)`.
+    /// Populated by the first net task that processes this broadcast.
+    encoded: std::sync::OnceLock<Vec<(i32, Vec<u8>)>>,
+}
+
+impl SharedBroadcast {
+    /// Creates a new shared broadcast from a game event.
+    pub(crate) fn new(event: BroadcastEvent) -> Self {
+        Self {
+            event,
+            encoded: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Returns the cached encoded packets, encoding on first call.
+    ///
+    /// The `encode_fn` is called at most once (by the first consumer).
+    /// All subsequent calls return the cached result.
+    pub(crate) fn get_or_encode(
+        &self,
+        encode_fn: impl FnOnce(&BroadcastEvent) -> Vec<(i32, Vec<u8>)>,
+    ) -> &[(i32, Vec<u8>)] {
+        self.encoded.get_or_init(|| encode_fn(&self.event))
+    }
+}
+
+impl std::fmt::Debug for SharedBroadcast {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedBroadcast")
+            .field("event", &self.event)
+            .field("encoded", &self.encoded.get().is_some())
+            .finish()
+    }
+}
+
+/// Game events that can be broadcast to multiple players.
+///
+/// Separate from [`ServerOutput`] to avoid recursive enum types.
+/// These represent the subset of game events that are sent to N players
+/// (movement, block changes, chat, player lifecycle).
+#[derive(Clone, Debug)]
+pub enum BroadcastEvent {
+    /// An entity moved.
+    EntityMoved {
+        /// Entity ID.
+        entity_id: i32,
+        /// World X coordinate.
+        x: f64,
+        /// World Y coordinate.
+        y: f64,
+        /// World Z coordinate.
+        z: f64,
+        /// Yaw rotation (degrees).
+        yaw: f32,
+        /// Pitch rotation (degrees).
+        pitch: f32,
+        /// Whether the entity is on the ground.
+        on_ground: bool,
+    },
+    /// A block changed in the world.
+    BlockChanged {
+        /// Block X coordinate.
+        x: i32,
+        /// Block Y coordinate.
+        y: i32,
+        /// Block Z coordinate.
+        z: i32,
+        /// New block state ID.
+        state: i32,
+    },
+    /// A system chat message.
+    SystemChat {
+        /// NBT-encoded text component content.
+        content: NbtCompound,
+        /// Whether to display as action bar text.
+        action_bar: bool,
+    },
+    /// Remove entities from the client.
+    RemoveEntities {
+        /// Entity IDs to remove.
+        entity_ids: Vec<i32>,
+    },
+    /// Remove players from the tab list.
+    RemovePlayers {
+        /// Player UUIDs to remove.
+        uuids: Vec<Uuid>,
+    },
+}
+
+/// Supertrait combining [`Encode`] and [`EncodedSize`] for trait objects.
+///
+/// Rust only allows one non-auto trait in `dyn`, so this combines both
+/// serialization traits into a single trait object-compatible trait.
+pub(crate) trait PacketPayload: Encode + EncodedSize + Send + Sync {}
+impl<T: Encode + EncodedSize + Send + Sync> PacketPayload for T {}
+
+/// A type-erased protocol packet that can be encoded by the net task.
+///
+/// Wraps any packet struct implementing [`Encode`] + [`EncodedSize`]
+/// behind an [`Arc`] for cheap cloning (needed for broadcast channel).
+/// The Arc allocation only happens for cold-path packets (login, spawn).
+#[derive(Clone)]
+pub struct EncodablePacket {
+    /// Minecraft packet ID.
+    pub(crate) id: i32,
+    /// The packet struct, type-erased for channel transport.
+    pub(crate) payload: Arc<dyn PacketPayload>,
+}
+
+impl EncodablePacket {
+    /// Creates a new encodable packet from any protocol packet struct.
+    pub(crate) fn new<P: PacketPayload + 'static>(id: i32, packet: P) -> Self {
+        Self {
+            id,
+            payload: Arc::new(packet),
+        }
+    }
+}
+
+impl std::fmt::Debug for EncodablePacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncodablePacket")
+            .field("id", &self.id)
+            .field("size", &self.payload.encoded_size())
+            .finish()
+    }
 }

--- a/crates/basalt-server/src/net/chunk_cache.rs
+++ b/crates/basalt-server/src/net/chunk_cache.rs
@@ -1,0 +1,137 @@
+//! Shared cache for pre-encoded chunk packets.
+//!
+//! Net tasks look up this cache when they receive a [`ServerOutput::SendChunk`]
+//! event. On cache miss, the chunk is fetched from the [`World`], the protocol
+//! packet is built and encoded, and the result is stored for future reuse.
+//! The game loop invalidates entries when blocks change.
+
+use std::sync::Arc;
+
+use basalt_protocol::packets::play::world::ClientboundPlayMapChunk;
+use basalt_types::{Encode, EncodedSize};
+use basalt_world::chunk::{SECTIONS_PER_CHUNK, build_full_light_mask};
+use dashmap::DashMap;
+
+/// Thread-safe cache mapping chunk coordinates to pre-encoded packet bytes.
+///
+/// Shared across all net tasks via `Arc<ChunkPacketCache>`. The game loop
+/// holds a reference to invalidate entries on block mutations.
+pub(crate) struct ChunkPacketCache {
+    /// Encoded chunk packet bytes keyed by (chunk_x, chunk_z).
+    cache: DashMap<(i32, i32), Arc<Vec<u8>>>,
+    /// Shared world reference for building chunk packets on cache miss.
+    world: Arc<basalt_world::World>,
+}
+
+impl ChunkPacketCache {
+    /// Creates a new empty chunk packet cache.
+    pub fn new(world: Arc<basalt_world::World>) -> Self {
+        Self {
+            cache: DashMap::new(),
+            world,
+        }
+    }
+
+    /// Returns the encoded chunk packet bytes, encoding on cache miss.
+    ///
+    /// On miss: fetches the chunk from the world, builds the protocol
+    /// packet, encodes it, stores the result, and returns it.
+    /// On hit: returns the cached `Arc` (cheap pointer clone).
+    pub fn get_or_encode(&self, cx: i32, cz: i32) -> Arc<Vec<u8>> {
+        if let Some(entry) = self.cache.get(&(cx, cz)) {
+            return Arc::clone(entry.value());
+        }
+
+        let encoded = self.world.with_chunk(cx, cz, |col| {
+            let packet = build_map_chunk_packet(col);
+            let mut buf = Vec::with_capacity(packet.encoded_size());
+            packet
+                .encode(&mut buf)
+                .expect("chunk packet encoding failed");
+            buf
+        });
+        let arc = Arc::new(encoded);
+        self.cache.insert((cx, cz), Arc::clone(&arc));
+        arc
+    }
+
+    /// Invalidates a cached chunk entry after a block mutation.
+    ///
+    /// Called by the game loop when `set_block()` modifies a chunk.
+    /// The next `get_or_encode()` call for this chunk will re-encode.
+    pub fn invalidate(&self, cx: i32, cz: i32) {
+        self.cache.remove(&(cx, cz));
+    }
+}
+
+/// Builds a [`ClientboundPlayMapChunk`] from a [`ChunkColumn`].
+///
+/// This is the protocol packet construction that was previously in
+/// `ChunkColumn::to_packet()`. It lives in basalt-server to keep
+/// basalt-world free of protocol dependencies.
+fn build_map_chunk_packet(col: &basalt_world::chunk::ChunkColumn) -> ClientboundPlayMapChunk {
+    let chunk_data = col.encode_sections();
+    let heightmaps = col.compute_heightmaps();
+
+    // Sky light: all sections get full sunlight (level 15).
+    // 26 entries = 24 sections + 1 below + 1 above.
+    // Each entry is 2048 bytes (4 bits per block, 16x16x16 / 2).
+    let light_sections = SECTIONS_PER_CHUNK + 2;
+    let sky_light_mask = build_full_light_mask(light_sections);
+    let sky_light: Vec<Vec<u8>> = (0..light_sections).map(|_| vec![0xFF; 2048]).collect();
+
+    ClientboundPlayMapChunk {
+        x: col.x,
+        z: col.z,
+        heightmaps,
+        chunk_data,
+        block_entities: vec![],
+        sky_light_mask,
+        block_light_mask: vec![],
+        empty_sky_light_mask: vec![],
+        empty_block_light_mask: vec![],
+        sky_light,
+        block_light: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_hit_returns_same_arc() {
+        let world = Arc::new(basalt_world::World::new_memory(42));
+        let cache = ChunkPacketCache::new(world);
+
+        let first = cache.get_or_encode(0, 0);
+        let second = cache.get_or_encode(0, 0);
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn invalidate_causes_re_encode() {
+        let world = Arc::new(basalt_world::World::new_memory(42));
+        let cache = ChunkPacketCache::new(world);
+
+        let before = cache.get_or_encode(0, 0);
+        cache.invalidate(0, 0);
+        let after = cache.get_or_encode(0, 0);
+        assert!(!Arc::ptr_eq(&before, &after));
+    }
+
+    #[test]
+    fn different_chunks_are_independent() {
+        let world = Arc::new(basalt_world::World::new_memory(42));
+        let cache = ChunkPacketCache::new(world);
+
+        let a = cache.get_or_encode(0, 0);
+        let b = cache.get_or_encode(1, 0);
+        assert!(!Arc::ptr_eq(&a, &b));
+
+        cache.invalidate(0, 0);
+        // (1,0) should still be cached
+        let b2 = cache.get_or_encode(1, 0);
+        assert!(Arc::ptr_eq(&b, &b2));
+    }
+}

--- a/crates/basalt-server/src/net/connection.rs
+++ b/crates/basalt-server/src/net/connection.rs
@@ -52,6 +52,7 @@ pub(crate) async fn handle_connection(
     broadcast_tx: broadcast::Sender<ServerOutput>,
     player_registry: Arc<DashMap<Uuid, mpsc::Sender<ServerOutput>>>,
     world: Arc<basalt_world::World>,
+    chunk_cache: Arc<crate::net::chunk_cache::ChunkPacketCache>,
 ) -> crate::error::Result<()> {
     let conn = Connection::<Handshake>::accept(stream);
 
@@ -71,6 +72,7 @@ pub(crate) async fn handle_connection(
                 broadcast_tx,
                 player_registry,
                 world,
+                chunk_cache,
             )
             .await
         }
@@ -115,6 +117,7 @@ async fn handle_login(
     broadcast_tx: broadcast::Sender<ServerOutput>,
     player_registry: Arc<DashMap<Uuid, mpsc::Sender<ServerOutput>>>,
     world: Arc<basalt_world::World>,
+    chunk_cache: Arc<crate::net::chunk_cache::ChunkPacketCache>,
 ) -> crate::error::Result<()> {
     let (username, player_uuid) = match conn.read_packet().await? {
         ServerboundLoginPacket::LoginStart(login) => {
@@ -147,6 +150,7 @@ async fn handle_login(
         broadcast_tx,
         player_registry,
         world,
+        chunk_cache,
     )
     .await
 }
@@ -164,6 +168,7 @@ async fn handle_configuration(
     broadcast_tx: broadcast::Sender<ServerOutput>,
     player_registry: Arc<DashMap<Uuid, mpsc::Sender<ServerOutput>>>,
     world: Arc<basalt_world::World>,
+    chunk_cache: Arc<crate::net::chunk_cache::ChunkPacketCache>,
 ) -> crate::error::Result<()> {
     let skin_username = username.to_string();
     let skin_task =
@@ -215,6 +220,7 @@ async fn handle_configuration(
             broadcast_tx,
             player_registry: Arc::clone(&player_registry),
             world,
+            chunk_cache,
             command_args: state.command_args.clone(),
         },
         output_rx,

--- a/crates/basalt-server/src/net/mod.rs
+++ b/crates/basalt-server/src/net/mod.rs
@@ -1,6 +1,7 @@
 //! Network layer — per-player async tasks and shared state.
 
 pub(crate) mod channels;
+pub(crate) mod chunk_cache;
 pub(crate) mod connection;
 pub(crate) mod skin;
 pub(crate) mod task;

--- a/crates/basalt-server/src/net/task.rs
+++ b/crates/basalt-server/src/net/task.rs
@@ -5,7 +5,7 @@
 //! 1. Reads packets from the TCP connection
 //! 2. Handles instant events (chat, commands) via `Arc<EventBus>` dispatch
 //! 3. Forwards game-relevant packets (movement, blocks, inventory) to the game loop
-//! 4. Relays output packets from the game loop + broadcast channel to TCP
+//! 4. Receives [`ServerOutput`] game events, encodes protocol packets, and writes to TCP
 //! 5. Handles keep-alive and tab-complete inline
 
 use std::net::SocketAddr;
@@ -21,12 +21,26 @@ use basalt_protocol::packets::play::chat::{
     ClientboundPlaySystemChat, ClientboundPlayTabComplete, ClientboundPlayTabCompleteMatches,
     ServerboundPlayTabComplete,
 };
+use basalt_protocol::packets::play::entity::{
+    ClientboundPlayEntityDestroy, ClientboundPlayEntityHeadRotation,
+    ClientboundPlaySyncEntityPosition,
+};
 use basalt_protocol::packets::play::misc::ClientboundPlayKeepAlive;
+use basalt_protocol::packets::play::player::{
+    ClientboundPlayGameStateChange, ClientboundPlayPlayerRemove, ClientboundPlayPosition,
+};
+use basalt_protocol::packets::play::world::{
+    ClientboundPlayAcknowledgePlayerDigging, ClientboundPlayBlockChange,
+    ClientboundPlayChunkBatchFinished, ClientboundPlayChunkBatchStart, ClientboundPlayMapChunk,
+    ClientboundPlayUnloadChunk, ClientboundPlayUpdateViewPosition,
+};
 use basalt_types::{Encode, EncodedSize, Uuid};
 use dashmap::DashMap;
 use tokio::sync::{broadcast, mpsc};
 
-use crate::messages::{GameInput, ServerOutput};
+use crate::helpers::{RawPayload, RawSlice, angle_to_byte};
+use crate::messages::{BroadcastEvent, GameInput, ServerOutput};
+use crate::net::chunk_cache::ChunkPacketCache;
 use crate::state::CommandMeta;
 
 /// Per-player net task configuration.
@@ -47,6 +61,8 @@ pub(crate) struct NetTaskConfig {
     pub player_registry: Arc<DashMap<Uuid, mpsc::Sender<ServerOutput>>>,
     /// Shared world reference for context creation.
     pub world: Arc<basalt_world::World>,
+    /// Shared chunk packet cache.
+    pub chunk_cache: Arc<ChunkPacketCache>,
     /// Command metadata for tab-complete and /help.
     pub command_args: Vec<CommandMeta>,
 }
@@ -66,6 +82,7 @@ pub(crate) async fn run_net_task(
     let broadcast_tx = config.broadcast_tx;
     let player_registry = config.player_registry;
     let world = config.world;
+    let chunk_cache = config.chunk_cache;
     let command_args = config.command_args;
 
     let mut broadcast_rx = broadcast_tx.subscribe();
@@ -120,11 +137,11 @@ pub(crate) async fn run_net_task(
                 }
             }
 
-            // Branch 3: Relay output from game loop
+            // Branch 3: Relay game events from game loop
             output = output_rx.recv() => {
                 match output {
-                    Some(ServerOutput::SendPacket { id, data }) => {
-                        conn.write_packet_typed(id, &crate::helpers::RawPayload(data)).await?;
+                    Some(msg) => {
+                        write_server_output(&mut conn, &msg, &chunk_cache).await?;
                     }
                     None => {
                         log::debug!(target: "basalt::net_task", "[{addr}] {username} output channel closed");
@@ -136,8 +153,8 @@ pub(crate) async fn run_net_task(
             // Branch 4: Receive instant broadcasts (chat)
             result = broadcast_rx.recv() => {
                 match result {
-                    Ok(ServerOutput::SendPacket { id, data }) => {
-                        conn.write_packet_typed(id, &crate::helpers::RawPayload(data)).await?;
+                    Ok(msg) => {
+                        write_server_output(&mut conn, &msg, &chunk_cache).await?;
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         log::warn!(target: "basalt::net_task", "[{addr}] {username} missed {n} broadcast messages");
@@ -149,6 +166,218 @@ pub(crate) async fn run_net_task(
     }
 
     Ok(())
+}
+
+/// Encodes and writes a [`ServerOutput`] game event to the TCP connection.
+///
+/// This is where protocol knowledge lives: each game event variant is
+/// translated into one or more protocol packets, encoded, and written.
+async fn write_server_output(
+    conn: &mut Connection<Play>,
+    output: &ServerOutput,
+    chunk_cache: &ChunkPacketCache,
+) -> crate::error::Result<()> {
+    match output {
+        // ── Hot path: targeted events ────────────────────────────────
+        ServerOutput::BlockChanged { x, y, z, state } => {
+            let packet = ClientboundPlayBlockChange {
+                location: basalt_types::Position::new(*x, *y, *z),
+                r#type: *state,
+            };
+            conn.write_packet_typed(ClientboundPlayBlockChange::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::BlockAck { sequence } => {
+            let packet = ClientboundPlayAcknowledgePlayerDigging {
+                sequence_id: *sequence,
+            };
+            conn.write_packet_typed(ClientboundPlayAcknowledgePlayerDigging::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::SystemChat {
+            content,
+            action_bar,
+        } => {
+            let packet = ClientboundPlaySystemChat {
+                content: content.clone(),
+                is_action_bar: *action_bar,
+            };
+            conn.write_packet_typed(ClientboundPlaySystemChat::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::GameStateChange { reason, value } => {
+            let packet = ClientboundPlayGameStateChange {
+                reason: *reason,
+                game_mode: *value,
+            };
+            conn.write_packet_typed(ClientboundPlayGameStateChange::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::SetPosition {
+            teleport_id,
+            x,
+            y,
+            z,
+            yaw,
+            pitch,
+        } => {
+            let packet = ClientboundPlayPosition {
+                teleport_id: *teleport_id,
+                x: *x,
+                y: *y,
+                z: *z,
+                dx: 0.0,
+                dy: 0.0,
+                dz: 0.0,
+                yaw: *yaw,
+                pitch: *pitch,
+                flags: 0,
+            };
+            conn.write_packet_typed(ClientboundPlayPosition::PACKET_ID, &packet)
+                .await?;
+        }
+        // ── Chunk path: cache-based ──────────────────────────────────
+        ServerOutput::SendChunk { cx, cz } => {
+            let bytes = chunk_cache.get_or_encode(*cx, *cz);
+            conn.write_packet_typed(ClientboundPlayMapChunk::PACKET_ID, &RawSlice(&bytes))
+                .await?;
+        }
+        ServerOutput::UnloadChunk { cx, cz } => {
+            let packet = ClientboundPlayUnloadChunk {
+                chunk_x: *cx,
+                chunk_z: *cz,
+            };
+            conn.write_packet_typed(ClientboundPlayUnloadChunk::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::ChunkBatchStart => {
+            conn.write_packet_typed(
+                ClientboundPlayChunkBatchStart::PACKET_ID,
+                &ClientboundPlayChunkBatchStart,
+            )
+            .await?;
+        }
+        ServerOutput::ChunkBatchFinished { batch_size } => {
+            let packet = ClientboundPlayChunkBatchFinished {
+                batch_size: *batch_size,
+            };
+            conn.write_packet_typed(ClientboundPlayChunkBatchFinished::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::UpdateViewPosition { cx, cz } => {
+            let packet = ClientboundPlayUpdateViewPosition {
+                chunk_x: *cx,
+                chunk_z: *cz,
+            };
+            conn.write_packet_typed(ClientboundPlayUpdateViewPosition::PACKET_ID, &packet)
+                .await?;
+        }
+
+        // ── Broadcast: shared, encoded once ──────────────────────────
+        ServerOutput::Broadcast(shared) => {
+            let packets = shared.get_or_encode(encode_broadcast);
+            for (id, data) in packets {
+                conn.write_packet_typed(*id, &RawSlice(data)).await?;
+            }
+        }
+
+        // ── Cold path: rare events ───────────────────────────────────
+        ServerOutput::Packet(ep) => {
+            let mut data = Vec::with_capacity(ep.payload.encoded_size());
+            ep.payload
+                .encode(&mut data)
+                .expect("packet encoding failed");
+            conn.write_packet_typed(ep.id, &RawPayload(data)).await?;
+        }
+        ServerOutput::Raw { id, data } => {
+            conn.write_packet_typed(*id, &RawSlice(data)).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Encodes a [`BroadcastEvent`] into protocol packets.
+///
+/// Called at most once per [`SharedBroadcast`] — the result is cached
+/// in the `OnceLock` and reused by all subsequent consumers.
+fn encode_broadcast(event: &BroadcastEvent) -> Vec<(i32, Vec<u8>)> {
+    match event {
+        BroadcastEvent::EntityMoved {
+            entity_id,
+            x,
+            y,
+            z,
+            yaw,
+            pitch,
+            on_ground,
+        } => {
+            let sync = ClientboundPlaySyncEntityPosition {
+                entity_id: *entity_id,
+                x: *x,
+                y: *y,
+                z: *z,
+                dx: 0.0,
+                dy: 0.0,
+                dz: 0.0,
+                yaw: *yaw,
+                pitch: *pitch,
+                on_ground: *on_ground,
+            };
+            let head = ClientboundPlayEntityHeadRotation {
+                entity_id: *entity_id,
+                head_yaw: angle_to_byte(*yaw),
+            };
+            vec![
+                encode_single(ClientboundPlaySyncEntityPosition::PACKET_ID, &sync),
+                encode_single(ClientboundPlayEntityHeadRotation::PACKET_ID, &head),
+            ]
+        }
+        BroadcastEvent::BlockChanged { x, y, z, state } => {
+            let packet = ClientboundPlayBlockChange {
+                location: basalt_types::Position::new(*x, *y, *z),
+                r#type: *state,
+            };
+            vec![encode_single(
+                ClientboundPlayBlockChange::PACKET_ID,
+                &packet,
+            )]
+        }
+        BroadcastEvent::SystemChat {
+            content,
+            action_bar,
+        } => {
+            let packet = ClientboundPlaySystemChat {
+                content: content.clone(),
+                is_action_bar: *action_bar,
+            };
+            vec![encode_single(ClientboundPlaySystemChat::PACKET_ID, &packet)]
+        }
+        BroadcastEvent::RemoveEntities { entity_ids } => {
+            let packet = ClientboundPlayEntityDestroy {
+                entity_ids: entity_ids.clone(),
+            };
+            vec![encode_single(
+                ClientboundPlayEntityDestroy::PACKET_ID,
+                &packet,
+            )]
+        }
+        BroadcastEvent::RemovePlayers { uuids } => {
+            let packet = ClientboundPlayPlayerRemove {
+                players: uuids.clone(),
+            };
+            vec![encode_single(
+                ClientboundPlayPlayerRemove::PACKET_ID,
+                &packet,
+            )]
+        }
+    }
+}
+
+/// Encodes a single protocol packet into `(packet_id, payload_bytes)`.
+fn encode_single<P: Encode + EncodedSize>(id: i32, packet: &P) -> (i32, Vec<u8>) {
+    let mut data = Vec::with_capacity(packet.encoded_size());
+    packet.encode(&mut data).expect("packet encoding failed");
+    (id, data)
 }
 
 /// Handles a single serverbound packet — instant or forwarded.
@@ -352,14 +581,13 @@ async fn process_instant_responses(
     for response in responses {
         match response {
             Response::Broadcast(basalt_api::BroadcastMessage::Chat { content }) => {
-                let data = encode_packet(
-                    ClientboundPlaySystemChat::PACKET_ID,
-                    &ClientboundPlaySystemChat {
+                let bc = Arc::new(crate::messages::SharedBroadcast::new(
+                    BroadcastEvent::SystemChat {
                         content: content.clone(),
-                        is_action_bar: false,
+                        action_bar: false,
                     },
-                );
-                let _ = broadcast_tx.send(data);
+                ));
+                let _ = broadcast_tx.send(ServerOutput::Broadcast(bc));
             }
             Response::SendSystemChat {
                 content,
@@ -380,7 +608,6 @@ async fn process_instant_responses(
                 yaw,
                 pitch,
             } => {
-                use basalt_protocol::packets::play::player::ClientboundPlayPosition;
                 let packet = ClientboundPlayPosition {
                     teleport_id: *teleport_id,
                     x: *x,
@@ -397,7 +624,6 @@ async fn process_instant_responses(
                     .await?;
             }
             Response::SendGameStateChange { reason, value } => {
-                use basalt_protocol::packets::play::player::ClientboundPlayGameStateChange;
                 let packet = ClientboundPlayGameStateChange {
                     reason: *reason,
                     game_mode: *value,
@@ -413,16 +639,6 @@ async fn process_instant_responses(
         }
     }
     Ok(())
-}
-
-/// Encodes a packet struct into a [`ServerOutput::SendPacket`].
-fn encode_packet<P: Encode + EncodedSize>(packet_id: i32, packet: &P) -> ServerOutput {
-    let mut data = Vec::with_capacity(packet.encoded_size());
-    packet.encode(&mut data).expect("packet encoding failed");
-    ServerOutput::SendPacket {
-        id: packet_id,
-        data,
-    }
 }
 
 /// Handles a TabComplete request inline.

--- a/crates/basalt-world/Cargo.toml
+++ b/crates/basalt-world/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 
 [dependencies]
 basalt-types = { workspace = true }
-basalt-protocol = { workspace = true }
 basalt-storage = { workspace = true }
 dashmap = { workspace = true }
 noise = { workspace = true }

--- a/crates/basalt-world/benches/chunk.rs
+++ b/crates/basalt-world/benches/chunk.rs
@@ -50,20 +50,20 @@ fn palette_encode_diverse(b: &mut Bencher) {
 }
 
 #[bench]
-fn chunk_to_packet_flat(b: &mut Bencher) {
+fn chunk_encode_sections_flat(b: &mut Bencher) {
     let mut col = ChunkColumn::new(0, 0);
     FlatWorldGenerator.generate(&mut col);
     b.iter(|| {
-        black_box(col.to_packet());
+        black_box(col.encode_sections());
     });
 }
 
 #[bench]
-fn chunk_to_packet_noise(b: &mut Bencher) {
+fn chunk_encode_sections_noise(b: &mut Bencher) {
     let noise = NoiseTerrainGenerator::new(42);
     let mut col = ChunkColumn::new(0, 0);
     noise.generate(&mut col);
     b.iter(|| {
-        black_box(col.to_packet());
+        black_box(col.encode_sections());
     });
 }

--- a/crates/basalt-world/src/chunk.rs
+++ b/crates/basalt-world/src/chunk.rs
@@ -1,9 +1,9 @@
-//! Chunk column representation and wire encoding.
+//! Chunk column representation and section encoding.
 //!
 //! A `ChunkColumn` holds 24 sections (y = -64 to 319) and provides
-//! methods to set blocks and encode the column into a protocol packet.
+//! methods to set/get blocks, encode sections, and compute heightmaps.
+//! Protocol packet construction is handled by `basalt-server`.
 
-use basalt_protocol::packets::play::world::ClientboundPlayMapChunk;
 use basalt_types::nbt::{NbtCompound, NbtTag};
 use basalt_types::{Encode, VarInt};
 
@@ -11,10 +11,9 @@ use crate::block;
 
 /// Builds a BitSet where the first `count` bits are set.
 ///
-/// The Minecraft sky light mask is a BitSet encoded as a VarInt length
-/// followed by an array of i64 values. Each bit indicates whether the
-/// corresponding section has light data.
-fn build_full_light_mask(count: usize) -> Vec<i64> {
+/// Used by the sky light mask in chunk packets. Each bit indicates
+/// whether the corresponding section has light data.
+pub fn build_full_light_mask(count: usize) -> Vec<i64> {
     let num_longs = count.div_ceil(64);
     let mut longs = vec![0i64; num_longs];
     for i in 0..count {
@@ -76,37 +75,11 @@ impl ChunkColumn {
         }
     }
 
-    /// Converts this chunk column into a protocol packet ready to send.
-    pub fn to_packet(&self) -> ClientboundPlayMapChunk {
-        let chunk_data = self.encode_sections();
-        let heightmaps = self.compute_heightmaps();
-
-        // Sky light: all sections get full sunlight (level 15).
-        // The light system has 26 entries (24 sections + 1 below + 1 above).
-        // Each entry is a 2048-byte array (4 bits per block, 16×16×16 / 2).
-        let light_sections = SECTIONS_PER_CHUNK + 2;
-        // BitSet marking which sections have sky light data: all of them
-        let sky_light_mask = build_full_light_mask(light_sections);
-        // Full sunlight = all nibbles set to 15 (0xFF bytes)
-        let sky_light: Vec<Vec<u8>> = (0..light_sections).map(|_| vec![0xFF; 2048]).collect();
-
-        ClientboundPlayMapChunk {
-            x: self.x,
-            z: self.z,
-            heightmaps,
-            chunk_data,
-            block_entities: vec![],
-            sky_light_mask,
-            block_light_mask: vec![],
-            empty_sky_light_mask: vec![],
-            empty_block_light_mask: vec![],
-            sky_light,
-            block_light: vec![],
-        }
-    }
-
     /// Encodes all 24 sections into the wire format.
-    fn encode_sections(&self) -> Vec<u8> {
+    ///
+    /// Each section is encoded as: block count (i16) + block states
+    /// paletted container + biomes single-value palette (plains).
+    pub fn encode_sections(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         for section in self.sections.iter() {
             // Block count
@@ -125,8 +98,9 @@ impl ChunkColumn {
     ///
     /// For each column (x, z), finds the highest non-air block and
     /// stores height + 1 (relative to world bottom) as a 9-bit value
-    /// packed into longs.
-    fn compute_heightmaps(&self) -> NbtCompound {
+    /// packed into longs. Returns an [`NbtCompound`] ready for the
+    /// chunk packet.
+    pub fn compute_heightmaps(&self) -> NbtCompound {
         let mut heights = [0u64; 256];
 
         for x in 0..16 {
@@ -184,13 +158,11 @@ mod tests {
     }
 
     #[test]
-    fn to_packet_produces_valid_data() {
+    fn encode_sections_produces_data() {
         let mut chunk = ChunkColumn::new(3, -5);
         chunk.set_block(0, 0, 0, block::BEDROCK);
-        let packet = chunk.to_packet();
-        assert_eq!(packet.x, 3);
-        assert_eq!(packet.z, -5);
-        assert!(!packet.chunk_data.is_empty());
+        let data = chunk.encode_sections();
+        assert!(!data.is_empty());
     }
 
     #[test]

--- a/crates/basalt-world/src/world.rs
+++ b/crates/basalt-world/src/world.rs
@@ -23,8 +23,6 @@ enum Generator {
 struct ChunkEntry {
     /// The chunk column data.
     column: ChunkColumn,
-    /// Cached encoded packet. Invalidated (set to `None`) when a block changes.
-    cached_packet: Option<basalt_protocol::packets::play::world::ClientboundPlayMapChunk>,
     /// Whether this chunk has been modified since the last persist to disk.
     dirty: bool,
     /// Monotonic access counter for approximate LRU eviction.
@@ -114,33 +112,24 @@ impl World {
 
     /// Returns a protocol packet for the chunk at (cx, cz).
     ///
-    /// Load order: packet cache -> encode from chunk -> disk -> generate.
-    /// Newly generated chunks are saved to disk, stored in memory,
-    /// and their encoded packets are cached.
-    pub fn get_chunk_packet(
-        &self,
-        cx: i32,
-        cz: i32,
-    ) -> basalt_protocol::packets::play::world::ClientboundPlayMapChunk {
+    /// Calls a closure with a reference to the chunk column at (cx, cz).
+    ///
+    /// Ensures the chunk is loaded (generating or reading from disk if
+    /// needed), bumps the LRU counter, and passes a reference to the
+    /// [`ChunkColumn`] into the closure. The return value of the closure
+    /// is forwarded to the caller.
+    pub fn with_chunk<R>(&self, cx: i32, cz: i32, f: impl FnOnce(&ChunkColumn) -> R) -> R {
         self.ensure_loaded(cx, cz);
 
         let mut entry = self.chunks.get_mut(&(cx, cz)).unwrap();
         entry.last_accessed = self.tick.fetch_add(1, Ordering::Relaxed);
-
-        if let Some(ref packet) = entry.cached_packet {
-            return packet.clone();
-        }
-
-        let packet = entry.column.to_packet();
-        entry.cached_packet = Some(packet.clone());
-        packet
+        f(&entry.column)
     }
 
     /// Sets a block at absolute world coordinates.
     ///
-    /// Loads the chunk if it isn't already in memory. Invalidates the
-    /// packet cache for the affected chunk so the next `get_chunk_packet`
-    /// call re-encodes it. Marks the chunk as dirty for persist-before-evict.
+    /// Loads the chunk if it isn't already in memory. Marks the chunk
+    /// as dirty for persist-before-evict.
     pub fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
         let cx = x >> 4;
         let cz = z >> 4;
@@ -151,7 +140,6 @@ impl World {
 
         let mut entry = self.chunks.get_mut(&(cx, cz)).unwrap();
         entry.column.set_block(local_x, y, local_z, state);
-        entry.cached_packet = None;
         entry.dirty = true;
         entry.last_accessed = self.tick.fetch_add(1, Ordering::Relaxed);
     }
@@ -214,7 +202,6 @@ impl World {
                 (cx, cz),
                 ChunkEntry {
                     column: col,
-                    cached_packet: None,
                     dirty: false,
                     last_accessed: tick,
                 },
@@ -241,7 +228,6 @@ impl World {
             (cx, cz),
             ChunkEntry {
                 column: col,
-                cached_packet: None,
                 dirty: false,
                 last_accessed: tick,
             },
@@ -301,26 +287,27 @@ mod tests {
         let world = World::new_memory(42);
         assert!(!world.is_chunk_loaded(0, 0));
 
-        let packet = world.get_chunk_packet(0, 0);
-        assert_eq!(packet.x, 0);
-        assert_eq!(packet.z, 0);
+        world.with_chunk(0, 0, |col| {
+            assert_eq!(col.x, 0);
+            assert_eq!(col.z, 0);
+        });
         assert!(world.is_chunk_loaded(0, 0));
     }
 
     #[test]
     fn world_caches_chunks() {
         let world = World::new_memory(42);
-        world.get_chunk_packet(0, 0);
-        world.get_chunk_packet(0, 0);
+        world.with_chunk(0, 0, |_| {});
+        world.with_chunk(0, 0, |_| {});
         assert_eq!(world.chunk_count(), 1);
     }
 
     #[test]
     fn world_generates_different_coords() {
         let world = World::new_memory(42);
-        world.get_chunk_packet(0, 0);
-        world.get_chunk_packet(1, 0);
-        world.get_chunk_packet(0, 1);
+        world.with_chunk(0, 0, |_| {});
+        world.with_chunk(1, 0, |_| {});
+        world.with_chunk(0, 1, |_| {});
         assert_eq!(world.chunk_count(), 3);
     }
 
@@ -336,13 +323,13 @@ mod tests {
         let world = World::new(42, dir.path());
 
         // Generate and save
-        world.get_chunk_packet(0, 0);
-        world.get_chunk_packet(1, 1);
+        world.with_chunk(0, 0, |_| {});
+        world.with_chunk(1, 1, |_| {});
 
         // Create a new world from the same directory — should load from disk
         let world2 = World::new(42, dir.path());
         assert!(!world2.is_chunk_loaded(0, 0)); // not in memory yet
-        world2.get_chunk_packet(0, 0); // loads from disk
+        world2.with_chunk(0, 0, |_| {}); // loads from disk
         assert!(world2.is_chunk_loaded(0, 0));
     }
 
@@ -350,20 +337,10 @@ mod tests {
     fn set_block_modifies_chunk() {
         let world = World::new_memory(42);
         // Load chunk first
-        world.get_chunk_packet(0, 0);
+        world.with_chunk(0, 0, |_| {});
         // Modify a block
         world.set_block(5, 64, 3, crate::block::STONE);
         assert_eq!(world.get_block(5, 64, 3), crate::block::STONE);
-    }
-
-    #[test]
-    fn set_block_invalidates_packet_cache() {
-        let world = World::new_memory(42);
-        let packet1 = world.get_chunk_packet(0, 0);
-        world.set_block(0, 64, 0, crate::block::STONE);
-        let packet2 = world.get_chunk_packet(0, 0);
-        // The re-encoded packet should reflect the new block
-        assert_ne!(packet1.chunk_data, packet2.chunk_data);
     }
 
     #[test]
@@ -421,7 +398,7 @@ mod tests {
 
         // Load 6 chunks — should trigger eviction
         for i in 0..6 {
-            world.get_chunk_packet(i, 0);
+            world.with_chunk(i, 0, |_| {});
         }
 
         // Should have evicted down to ~4-5 (90% of 5 = 4)
@@ -439,7 +416,7 @@ mod tests {
 
         // Load 4 more chunks to trigger eviction of (0,0)
         for i in 1..5 {
-            world.get_chunk_packet(i, 0);
+            world.with_chunk(i, 0, |_| {});
         }
 
         // (0,0) should have been evicted and persisted
@@ -453,15 +430,15 @@ mod tests {
 
         // Load 5 chunks
         for i in 0..5 {
-            world.get_chunk_packet(i, 0);
+            world.with_chunk(i, 0, |_| {});
         }
 
         // Re-access chunk (0,0) to refresh its timestamp
-        world.get_chunk_packet(0, 0);
+        world.with_chunk(0, 0, |_| {});
 
         // Load 2 more to trigger eviction
-        world.get_chunk_packet(5, 0);
-        world.get_chunk_packet(6, 0);
+        world.with_chunk(5, 0, |_| {});
+        world.with_chunk(6, 0, |_| {});
 
         // (0,0) should survive — it was recently accessed
         assert!(world.is_chunk_loaded(0, 0));


### PR DESCRIPTION
## Summary

- **Game loop produces game events, not encoded bytes.** ServerOutput refactored from a single SendPacket{id, data} variant to a multi-variant enum of game events (BlockChanged, BlockAck, SystemChat, SetPosition, SendChunk, etc.). Zero protocol encoding in the game loop.
- **Net tasks handle all packet encoding.** Each ServerOutput variant is matched in the net task, which constructs protocol packet structs and encodes them onto the wire. One game event may produce multiple protocol packets (e.g. EntityMoved produces SyncEntityPosition + EntityHeadRotation).
- **SharedBroadcast with OnceLock** for fan-out broadcasts (movement, block changes, disconnect). The first net task to consume it encodes the protocol packets; all subsequent consumers read the cached bytes. One encode for N players.
- **ChunkPacketCache** (shared DashMap) caches pre-encoded chunk bytes. Net tasks look up on SendChunk; game loop invalidates on block change. Avoids redundant chunk encoding across players.
- **basalt-world decoupled from basalt-protocol.** Removed to_packet(), get_chunk_packet(), and the basalt-protocol dependency. Replaced with with_chunk() + public encode_sections()/compute_heightmaps(). Protocol packet construction moved to basalt-server chunk_cache module.

## Test plan

- [x] All 530+ unit tests pass
- [x] All 15 e2e tests pass (status, login, chat, commands, blocks, multi-player)
- [x] Clippy clean (zero warnings)
- [x] Coverage at 90.94% (above 90% threshold)
- [x] ChunkPacketCache has 3 dedicated tests (cache hit, invalidation, independence)
- [ ] Manual test with Minecraft 1.21.4 client (spawn, move, chat, block break/place, two players)

Closes #125
