### PR TITLE
feat(server): full 36-slot inventory with sync, click handling, and item drop

### DIFF
--- a/crates/basalt-ecs/src/components.rs
+++ b/crates/basalt-ecs/src/components.rs
@@ -120,57 +120,114 @@ pub struct PickupDelay {
 }
 impl Component for PickupDelay {}
 
-/// Player hotbar inventory.
+/// Player inventory — 36 slots (27 main + 9 hotbar).
 ///
-/// Tracks the 9 hotbar slots and which one is currently selected.
-/// The held item determines block placement state.
+/// Slot layout matches the Minecraft player inventory window:
+/// - Slots 0–26: main inventory (3 rows of 9)
+/// - Slots 27–35: hotbar (bottom row)
+///
+/// In the protocol window, these map to:
+/// - Protocol slots 9–35: main inventory (our 0–26)
+/// - Protocol slots 36–44: hotbar (our 27–35)
 #[derive(Debug, Clone)]
 pub struct Inventory {
-    /// Currently selected hotbar slot (0-8).
+    /// Currently selected hotbar index (0-8, relative to hotbar start).
     pub held_slot: u8,
-    /// Hotbar items (slots 0-8).
-    pub hotbar: [basalt_types::Slot; 9],
+    /// All 36 inventory slots.
+    pub slots: [basalt_types::Slot; 36],
 }
 
 impl Inventory {
+    /// First hotbar slot index within `slots`.
+    pub const HOTBAR_START: usize = 27;
+
     /// Creates an empty inventory with slot 0 selected.
     pub fn empty() -> Self {
         Self {
             held_slot: 0,
-            hotbar: std::array::from_fn(|_| basalt_types::Slot::empty()),
+            slots: std::array::from_fn(|_| basalt_types::Slot::empty()),
         }
     }
 
-    /// Returns the currently held item.
+    /// Returns the currently held item (from the hotbar).
     pub fn held_item(&self) -> &basalt_types::Slot {
-        &self.hotbar[self.held_slot as usize]
+        &self.slots[Self::HOTBAR_START + self.held_slot as usize]
     }
 
-    /// Tries to insert an item into the hotbar.
+    /// Returns a reference to the hotbar (9 slots).
+    pub fn hotbar(&self) -> &[basalt_types::Slot] {
+        &self.slots[Self::HOTBAR_START..]
+    }
+
+    /// Returns a mutable reference to the hotbar (9 slots).
+    pub fn hotbar_mut(&mut self) -> &mut [basalt_types::Slot] {
+        &mut self.slots[Self::HOTBAR_START..]
+    }
+
+    /// Converts a protocol slot index to an internal slot index.
     ///
-    /// First looks for a matching slot (same item_id, count < 64),
-    /// then for an empty slot. Returns `Some(hotbar_index)` if inserted,
-    /// `None` if no space available.
-    pub fn try_insert(&mut self, item_id: i32, count: i32) -> Option<u8> {
-        // First pass: stack with existing matching item
-        for (i, slot) in self.hotbar.iter_mut().enumerate() {
+    /// Protocol layout: 9-35 = main, 36-44 = hotbar.
+    /// Internal layout: 0-26 = main, 27-35 = hotbar.
+    /// Returns `None` for out-of-range or non-inventory slots (0-8 = crafting/armor).
+    pub fn protocol_to_index(protocol_slot: i16) -> Option<usize> {
+        match protocol_slot {
+            9..=35 => Some((protocol_slot - 9) as usize), // main
+            36..=44 => Some((protocol_slot - 36 + 27) as usize), // hotbar
+            _ => None,
+        }
+    }
+
+    /// Converts an internal slot index to a protocol slot index.
+    pub fn index_to_protocol(index: usize) -> Option<i16> {
+        match index {
+            0..=26 => Some(index as i16 + 9),        // main
+            27..=35 => Some(index as i16 - 27 + 36), // hotbar
+            _ => None,
+        }
+    }
+
+    /// Tries to insert an item into the inventory.
+    ///
+    /// Searches hotbar first (for convenience), then main inventory.
+    /// Tries matching stacks (count < 64) first, then empty slots.
+    /// Returns `Some(internal_index)` if inserted, `None` if full.
+    pub fn try_insert(&mut self, item_id: i32, count: i32) -> Option<usize> {
+        // Hotbar first, then main — matching stacks
+        let search_order = (Self::HOTBAR_START..36).chain(0..Self::HOTBAR_START);
+        for i in search_order {
+            let slot = &mut self.slots[i];
             if slot.item_id == Some(item_id) && slot.item_count < 64 {
                 let space = 64 - slot.item_count;
                 let to_add = count.min(space);
                 slot.item_count += to_add;
                 if to_add == count {
-                    return Some(i as u8);
+                    return Some(i);
                 }
             }
         }
-        // Second pass: empty slot
-        for (i, slot) in self.hotbar.iter_mut().enumerate() {
-            if slot.is_empty() {
-                *slot = basalt_types::Slot::new(item_id, count);
-                return Some(i as u8);
+        // Hotbar first, then main — empty slots
+        let search_order = (Self::HOTBAR_START..36).chain(0..Self::HOTBAR_START);
+        for i in search_order {
+            if self.slots[i].is_empty() {
+                self.slots[i] = basalt_types::Slot::new(item_id, count);
+                return Some(i);
             }
         }
         None
+    }
+
+    /// Builds the 46-slot protocol representation for SetContainerContent.
+    ///
+    /// Protocol slot layout for player inventory window (id=0):
+    /// 0 = crafting output, 1-4 = crafting grid, 5-8 = armor,
+    /// 9-35 = main inventory, 36-44 = hotbar, 45 = offhand.
+    pub fn to_protocol_slots(&self) -> Vec<basalt_types::Slot> {
+        let mut protocol = vec![basalt_types::Slot::empty(); 46];
+        // Main inventory: internal 0-26 → protocol 9-35
+        protocol[9..36].clone_from_slice(&self.slots[..27]);
+        // Hotbar: internal 27-35 → protocol 36-44
+        protocol[36..45].clone_from_slice(&self.slots[27..]);
+        protocol
     }
 }
 impl Component for Inventory {}
@@ -237,6 +294,13 @@ mod tests {
             },
         );
 
+        ecs.set(
+            e,
+            PickupDelay {
+                remaining_ticks: 10,
+            },
+        );
+
         assert!(ecs.has::<Position>(e));
         assert!(ecs.has::<Rotation>(e));
         assert!(ecs.has::<Velocity>(e));
@@ -245,5 +309,96 @@ mod tests {
         assert!(ecs.has::<Health>(e));
         assert!(ecs.has::<Lifetime>(e));
         assert!(ecs.has::<PlayerRef>(e));
+        assert!(ecs.has::<PickupDelay>(e));
+    }
+
+    #[test]
+    fn inventory_try_insert_empty_hotbar() {
+        let mut inv = Inventory::empty();
+        let idx = inv.try_insert(1, 1);
+        assert_eq!(idx, Some(Inventory::HOTBAR_START)); // first hotbar slot
+        assert_eq!(inv.slots[Inventory::HOTBAR_START].item_id, Some(1));
+    }
+
+    #[test]
+    fn inventory_try_insert_stacks() {
+        let mut inv = Inventory::empty();
+        inv.try_insert(1, 32);
+        let idx = inv.try_insert(1, 16);
+        assert_eq!(idx, Some(Inventory::HOTBAR_START)); // same slot
+        assert_eq!(inv.slots[Inventory::HOTBAR_START].item_count, 48);
+    }
+
+    #[test]
+    fn inventory_try_insert_full_returns_none() {
+        let mut inv = Inventory::empty();
+        for i in 0..36 {
+            inv.slots[i] = basalt_types::Slot::new(i as i32 + 100, 64);
+        }
+        assert_eq!(inv.try_insert(999, 1), None);
+    }
+
+    #[test]
+    fn inventory_protocol_slot_conversion() {
+        // Main: protocol 9-35 → internal 0-26
+        assert_eq!(Inventory::protocol_to_index(9), Some(0));
+        assert_eq!(Inventory::protocol_to_index(35), Some(26));
+        // Hotbar: protocol 36-44 → internal 27-35
+        assert_eq!(Inventory::protocol_to_index(36), Some(27));
+        assert_eq!(Inventory::protocol_to_index(44), Some(35));
+        // Out of range
+        assert_eq!(Inventory::protocol_to_index(0), None);
+        assert_eq!(Inventory::protocol_to_index(45), None);
+        // Roundtrip
+        assert_eq!(Inventory::index_to_protocol(0), Some(9));
+        assert_eq!(Inventory::index_to_protocol(27), Some(36));
+    }
+
+    #[test]
+    fn inventory_to_protocol_slots_length() {
+        let inv = Inventory::empty();
+        assert_eq!(inv.to_protocol_slots().len(), 46);
+    }
+
+    #[test]
+    fn inventory_to_protocol_slots_maps_correctly() {
+        let mut inv = Inventory::empty();
+        inv.slots[0] = basalt_types::Slot::new(1, 1); // main slot 0
+        inv.slots[27] = basalt_types::Slot::new(2, 2); // hotbar slot 0
+        let proto = inv.to_protocol_slots();
+        assert_eq!(proto[9].item_id, Some(1)); // main → protocol 9
+        assert_eq!(proto[36].item_id, Some(2)); // hotbar → protocol 36
+    }
+
+    #[test]
+    fn inventory_held_item_and_hotbar() {
+        let mut inv = Inventory::empty();
+        inv.slots[Inventory::HOTBAR_START + 3] = basalt_types::Slot::new(5, 10);
+        inv.held_slot = 3;
+        assert_eq!(inv.held_item().item_id, Some(5));
+        assert_eq!(inv.hotbar().len(), 9);
+        assert_eq!(inv.hotbar()[3].item_count, 10);
+    }
+
+    #[test]
+    fn inventory_try_insert_main_when_hotbar_full() {
+        let mut inv = Inventory::empty();
+        // Fill hotbar
+        for i in 0..9 {
+            inv.slots[Inventory::HOTBAR_START + i] = basalt_types::Slot::new(i as i32, 64);
+        }
+        // Should go to main inventory (slot 0)
+        let idx = inv.try_insert(999, 1);
+        assert_eq!(idx, Some(0));
+        assert_eq!(inv.slots[0].item_id, Some(999));
+    }
+
+    #[test]
+    fn inventory_index_to_protocol_roundtrip() {
+        for i in 0..36 {
+            let proto = Inventory::index_to_protocol(i).unwrap();
+            let back = Inventory::protocol_to_index(proto).unwrap();
+            assert_eq!(back, i);
+        }
     }
 }

--- a/crates/basalt-ecs/src/components.rs
+++ b/crates/basalt-ecs/src/components.rs
@@ -122,66 +122,72 @@ impl Component for PickupDelay {}
 
 /// Player inventory — 36 slots (27 main + 9 hotbar).
 ///
-/// Slot layout matches the Minecraft player inventory window:
-/// - Slots 0–26: main inventory (3 rows of 9)
-/// - Slots 27–35: hotbar (bottom row)
+/// Slot layout matches Minecraft's raw player inventory:
+/// - Slots 0–8: hotbar
+/// - Slots 9–35: main inventory (3 rows of 9)
 ///
-/// In the protocol window, these map to:
-/// - Protocol slots 9–35: main inventory (our 0–26)
-/// - Protocol slots 36–44: hotbar (our 27–35)
+/// This matches the `SetPlayerInventory` packet (1.21.4) directly —
+/// no slot conversion needed when syncing individual slots.
+///
+/// For the player inventory *window* (SetContainerContent), slots remap:
+/// window 9-35 = main (our 9-35, same), window 36-44 = hotbar (our 0-8).
 #[derive(Debug, Clone)]
 pub struct Inventory {
-    /// Currently selected hotbar index (0-8, relative to hotbar start).
+    /// Currently selected hotbar index (0-8).
     pub held_slot: u8,
-    /// All 36 inventory slots.
+    /// All 36 inventory slots (0-8 hotbar, 9-35 main).
     pub slots: [basalt_types::Slot; 36],
+    /// Item currently held on the mouse cursor (in an open window).
+    pub cursor: basalt_types::Slot,
 }
 
 impl Inventory {
     /// First hotbar slot index within `slots`.
-    pub const HOTBAR_START: usize = 27;
+    pub const HOTBAR_START: usize = 0;
+    /// First main inventory slot index within `slots`.
+    pub const MAIN_START: usize = 9;
 
     /// Creates an empty inventory with slot 0 selected.
     pub fn empty() -> Self {
         Self {
             held_slot: 0,
             slots: std::array::from_fn(|_| basalt_types::Slot::empty()),
+            cursor: basalt_types::Slot::empty(),
         }
     }
 
     /// Returns the currently held item (from the hotbar).
     pub fn held_item(&self) -> &basalt_types::Slot {
-        &self.slots[Self::HOTBAR_START + self.held_slot as usize]
+        &self.slots[self.held_slot as usize]
     }
 
     /// Returns a reference to the hotbar (9 slots).
     pub fn hotbar(&self) -> &[basalt_types::Slot] {
-        &self.slots[Self::HOTBAR_START..]
+        &self.slots[..9]
     }
 
     /// Returns a mutable reference to the hotbar (9 slots).
     pub fn hotbar_mut(&mut self) -> &mut [basalt_types::Slot] {
-        &mut self.slots[Self::HOTBAR_START..]
+        &mut self.slots[..9]
     }
 
-    /// Converts a protocol slot index to an internal slot index.
+    /// Converts a protocol window slot to an internal slot index.
     ///
-    /// Protocol layout: 9-35 = main, 36-44 = hotbar.
-    /// Internal layout: 0-26 = main, 27-35 = hotbar.
-    /// Returns `None` for out-of-range or non-inventory slots (0-8 = crafting/armor).
-    pub fn protocol_to_index(protocol_slot: i16) -> Option<usize> {
-        match protocol_slot {
-            9..=35 => Some((protocol_slot - 9) as usize), // main
-            36..=44 => Some((protocol_slot - 36 + 27) as usize), // hotbar
+    /// Window layout: 9-35 = main, 36-44 = hotbar.
+    /// Internal layout: 0-8 = hotbar, 9-35 = main.
+    pub fn window_to_index(window_slot: i16) -> Option<usize> {
+        match window_slot {
+            9..=35 => Some(window_slot as usize), // main: same numbering
+            36..=44 => Some((window_slot - 36) as usize), // hotbar: window 36-44 → 0-8
             _ => None,
         }
     }
 
-    /// Converts an internal slot index to a protocol slot index.
-    pub fn index_to_protocol(index: usize) -> Option<i16> {
+    /// Converts an internal slot index to a protocol window slot.
+    pub fn index_to_window(index: usize) -> Option<i16> {
         match index {
-            0..=26 => Some(index as i16 + 9),        // main
-            27..=35 => Some(index as i16 - 27 + 36), // hotbar
+            0..=8 => Some(index as i16 + 36), // hotbar → window 36-44
+            9..=35 => Some(index as i16),     // main: same numbering
             _ => None,
         }
     }
@@ -193,7 +199,7 @@ impl Inventory {
     /// Returns `Some(internal_index)` if inserted, `None` if full.
     pub fn try_insert(&mut self, item_id: i32, count: i32) -> Option<usize> {
         // Hotbar first, then main — matching stacks
-        let search_order = (Self::HOTBAR_START..36).chain(0..Self::HOTBAR_START);
+        let search_order = (0..9).chain(Self::MAIN_START..36);
         for i in search_order {
             let slot = &mut self.slots[i];
             if slot.item_id == Some(item_id) && slot.item_count < 64 {
@@ -206,7 +212,7 @@ impl Inventory {
             }
         }
         // Hotbar first, then main — empty slots
-        let search_order = (Self::HOTBAR_START..36).chain(0..Self::HOTBAR_START);
+        let search_order = (0..9).chain(Self::MAIN_START..36);
         for i in search_order {
             if self.slots[i].is_empty() {
                 self.slots[i] = basalt_types::Slot::new(item_id, count);
@@ -218,15 +224,15 @@ impl Inventory {
 
     /// Builds the 46-slot protocol representation for SetContainerContent.
     ///
-    /// Protocol slot layout for player inventory window (id=0):
+    /// Window slot layout for player inventory (id=0):
     /// 0 = crafting output, 1-4 = crafting grid, 5-8 = armor,
     /// 9-35 = main inventory, 36-44 = hotbar, 45 = offhand.
     pub fn to_protocol_slots(&self) -> Vec<basalt_types::Slot> {
         let mut protocol = vec![basalt_types::Slot::empty(); 46];
-        // Main inventory: internal 0-26 → protocol 9-35
-        protocol[9..36].clone_from_slice(&self.slots[..27]);
-        // Hotbar: internal 27-35 → protocol 36-44
-        protocol[36..45].clone_from_slice(&self.slots[27..]);
+        // Main: internal 9-35 → window 9-35 (same)
+        protocol[9..36].clone_from_slice(&self.slots[9..]);
+        // Hotbar: internal 0-8 → window 36-44
+        protocol[36..45].clone_from_slice(&self.slots[..9]);
         protocol
     }
 }
@@ -339,19 +345,19 @@ mod tests {
     }
 
     #[test]
-    fn inventory_protocol_slot_conversion() {
-        // Main: protocol 9-35 → internal 0-26
-        assert_eq!(Inventory::protocol_to_index(9), Some(0));
-        assert_eq!(Inventory::protocol_to_index(35), Some(26));
-        // Hotbar: protocol 36-44 → internal 27-35
-        assert_eq!(Inventory::protocol_to_index(36), Some(27));
-        assert_eq!(Inventory::protocol_to_index(44), Some(35));
+    fn inventory_slot_conversion() {
+        // Main: window 9-35 → internal 9-35 (same)
+        assert_eq!(Inventory::window_to_index(9), Some(9));
+        assert_eq!(Inventory::window_to_index(35), Some(35));
+        // Hotbar: window 36-44 → internal 0-8
+        assert_eq!(Inventory::window_to_index(36), Some(0));
+        assert_eq!(Inventory::window_to_index(44), Some(8));
         // Out of range
-        assert_eq!(Inventory::protocol_to_index(0), None);
-        assert_eq!(Inventory::protocol_to_index(45), None);
-        // Roundtrip
-        assert_eq!(Inventory::index_to_protocol(0), Some(9));
-        assert_eq!(Inventory::index_to_protocol(27), Some(36));
+        assert_eq!(Inventory::window_to_index(0), None);
+        assert_eq!(Inventory::window_to_index(45), None);
+        // Reverse
+        assert_eq!(Inventory::index_to_window(0), Some(36)); // hotbar 0 → window 36
+        assert_eq!(Inventory::index_to_window(9), Some(9)); // main 9 → window 9
     }
 
     #[test]
@@ -363,17 +369,17 @@ mod tests {
     #[test]
     fn inventory_to_protocol_slots_maps_correctly() {
         let mut inv = Inventory::empty();
-        inv.slots[0] = basalt_types::Slot::new(1, 1); // main slot 0
-        inv.slots[27] = basalt_types::Slot::new(2, 2); // hotbar slot 0
+        inv.slots[0] = basalt_types::Slot::new(1, 1); // hotbar slot 0
+        inv.slots[9] = basalt_types::Slot::new(2, 2); // main slot 0
         let proto = inv.to_protocol_slots();
-        assert_eq!(proto[9].item_id, Some(1)); // main → protocol 9
-        assert_eq!(proto[36].item_id, Some(2)); // hotbar → protocol 36
+        assert_eq!(proto[36].item_id, Some(1)); // hotbar 0 → window 36
+        assert_eq!(proto[9].item_id, Some(2)); // main 0 → window 9
     }
 
     #[test]
     fn inventory_held_item_and_hotbar() {
         let mut inv = Inventory::empty();
-        inv.slots[Inventory::HOTBAR_START + 3] = basalt_types::Slot::new(5, 10);
+        inv.slots[3] = basalt_types::Slot::new(5, 10); // hotbar slot 3
         inv.held_slot = 3;
         assert_eq!(inv.held_item().item_id, Some(5));
         assert_eq!(inv.hotbar().len(), 9);
@@ -383,21 +389,21 @@ mod tests {
     #[test]
     fn inventory_try_insert_main_when_hotbar_full() {
         let mut inv = Inventory::empty();
-        // Fill hotbar
+        // Fill hotbar (slots 0-8)
         for i in 0..9 {
-            inv.slots[Inventory::HOTBAR_START + i] = basalt_types::Slot::new(i as i32, 64);
+            inv.slots[i] = basalt_types::Slot::new(i as i32, 64);
         }
-        // Should go to main inventory (slot 0)
+        // Should go to main inventory (slot 9)
         let idx = inv.try_insert(999, 1);
-        assert_eq!(idx, Some(0));
-        assert_eq!(inv.slots[0].item_id, Some(999));
+        assert_eq!(idx, Some(Inventory::MAIN_START));
+        assert_eq!(inv.slots[Inventory::MAIN_START].item_id, Some(999));
     }
 
     #[test]
-    fn inventory_index_to_protocol_roundtrip() {
+    fn inventory_window_roundtrip() {
         for i in 0..36 {
-            let proto = Inventory::index_to_protocol(i).unwrap();
-            let back = Inventory::protocol_to_index(proto).unwrap();
+            let window = Inventory::index_to_window(i).unwrap();
+            let back = Inventory::window_to_index(window).unwrap();
             assert_eq!(back, i);
         }
     }

--- a/crates/basalt-server/src/game/tick.rs
+++ b/crates/basalt-server/src/game/tick.rs
@@ -127,17 +127,50 @@ impl GameLoop {
     pub fn tick(&mut self, tick: u64) {
         self.drain_game_input();
         self.ecs.run_all(tick);
-        self.tick_pickup_delays();
+        self.broadcast_item_movement();
         self.tick_item_pickup();
-        self.tick_lifetimes();
+        self.collect_expired_entities();
         self.flush_dirty_chunks_if_due(tick);
     }
 
-    /// Decrements pickup delays on dropped items.
-    fn tick_pickup_delays(&mut self) {
-        for (_, delay) in self.ecs.iter_mut::<basalt_ecs::PickupDelay>() {
-            if delay.remaining_ticks > 0 {
-                delay.remaining_ticks -= 1;
+    /// Broadcasts position updates for non-player entities that have velocity.
+    ///
+    /// After physics runs (via ecs.run_all), entities may have moved.
+    /// Players get movement broadcast via handle_movement, but non-player
+    /// entities (dropped items) need separate broadcasts.
+    fn broadcast_item_movement(&mut self) {
+        let moving: Vec<(basalt_ecs::EntityId, f64, f64, f64)> = self
+            .ecs
+            .iter::<basalt_ecs::DroppedItem>()
+            .filter_map(|(eid, _)| {
+                let vel = self.ecs.get::<basalt_ecs::Velocity>(eid)?;
+                // Only broadcast if actually moving
+                if vel.dx.abs() < 0.001 && vel.dy.abs() < 0.001 && vel.dz.abs() < 0.001 {
+                    return None;
+                }
+                let pos = self.ecs.get::<basalt_ecs::Position>(eid)?;
+                Some((eid, pos.x, pos.y, pos.z))
+            })
+            .collect();
+
+        if moving.is_empty() {
+            return;
+        }
+
+        for (eid, x, y, z) in moving {
+            let bc = Arc::new(SharedBroadcast::new(BroadcastEvent::EntityMoved {
+                entity_id: eid as i32,
+                x,
+                y,
+                z,
+                yaw: 0.0,
+                pitch: 0.0,
+                on_ground: false,
+            }));
+            for (player_eid, _) in self.ecs.iter::<OutputHandle>() {
+                self.send_to(player_eid, |tx| {
+                    let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&bc)));
+                });
             }
         }
     }
@@ -194,21 +227,20 @@ impl GameLoop {
                 }
 
                 // Try to insert into player inventory
-                let (hotbar_idx, slot_after) = {
+                let (inv_idx, slot_after) = {
                     let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(*player_eid) else {
                         continue;
                     };
                     let Some(idx) = inv.try_insert(*item_id, *count) else {
                         continue;
                     };
-                    (idx, inv.hotbar[idx as usize].clone())
+                    (idx, inv.slots[idx].clone())
                 };
 
-                // Send SetSlot to the picker to sync their client inventory
-                // Hotbar slots are 36-44 in the protocol window
+                // Send SetSlot to sync (raw internal index = SetPlayerInventory slot)
                 self.send_to(*player_eid, |tx| {
                     let _ = tx.try_send(ServerOutput::SetSlot {
-                        slot: 36 + hotbar_idx as i16,
+                        slot: inv_idx as i16,
                         item: slot_after,
                     });
                 });
@@ -236,18 +268,16 @@ impl GameLoop {
         }
     }
 
-    /// Decrements lifetimes and despawns expired entities.
+    /// Despawns entities whose lifetime has expired.
     ///
-    /// Entities with a [`Lifetime`] component have their counter
-    /// decremented each tick. When it reaches zero, the entity is
-    /// despawned and an EntityDestroy broadcast is sent.
-    fn tick_lifetimes(&mut self) {
+    /// The lifetime decrement is handled by the `lifetime_system` ECS
+    /// system (registered in lib.rs). This method collects entities
+    /// that reached zero and handles the side effects (broadcast + despawn).
+    fn collect_expired_entities(&mut self) {
         let mut expired = Vec::new();
-        for (eid, lt) in self.ecs.iter_mut::<basalt_ecs::Lifetime>() {
+        for (eid, lt) in self.ecs.iter::<basalt_ecs::Lifetime>() {
             if lt.remaining_ticks == 0 {
                 expired.push(eid);
-            } else {
-                lt.remaining_ticks -= 1;
             }
         }
 
@@ -380,11 +410,11 @@ impl GameLoop {
                     y,
                     z,
                     sequence,
-                } => {
-                    if status == 0 {
-                        self.handle_block_dig(uuid, x, y, z, sequence);
-                    }
-                }
+                } => match status {
+                    0 => self.handle_block_dig(uuid, x, y, z, sequence),
+                    3 | 4 => self.handle_item_drop(uuid, status == 3),
+                    _ => {}
+                },
                 GameInput::BlockPlace {
                     uuid,
                     x,
@@ -406,16 +436,206 @@ impl GameLoop {
                     }
                 }
                 GameInput::SetCreativeSlot { uuid, slot, item } => {
-                    if let Some(eid) = self.ecs.find_by_uuid(uuid)
-                        && let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid)
-                    {
-                        let hotbar_idx = slot - 36;
-                        if (0..9).contains(&hotbar_idx) {
-                            inv.hotbar[hotbar_idx as usize] = item;
+                    if slot == -1 {
+                        // Creative drop: slot -1 means drop the item
+                        if let Some(item_id) = item.item_id
+                            && let Some(eid) = self.ecs.find_by_uuid(uuid)
+                            && let Some(pos) = self.ecs.get::<basalt_ecs::Position>(eid)
+                        {
+                            self.spawn_item_entity(
+                                pos.x as i32,
+                                pos.y as i32 + 1,
+                                pos.z as i32,
+                                item_id,
+                                item.item_count,
+                            );
                         }
+                    } else if let Some(eid) = self.ecs.find_by_uuid(uuid)
+                        && let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid)
+                        && let Some(idx) = basalt_ecs::Inventory::window_to_index(slot)
+                    {
+                        inv.slots[idx] = item;
+                    }
+                }
+                GameInput::WindowClick {
+                    uuid,
+                    changed_slots,
+                    cursor_item,
+                    mode,
+                    slot,
+                    button,
+                    ..
+                } => {
+                    self.handle_window_click(uuid, slot, button, mode, changed_slots, cursor_item);
+                }
+            }
+        }
+    }
+
+    /// Handles a player inventory click.
+    ///
+    /// The Minecraft client sends the expected result of the click in
+    /// `changed_slots`. We trust the client's calculation and apply it
+    /// Handles dropping the held item via BlockDig status 3/4 (Q key).
+    ///
+    /// Status 3 = drop entire stack, status 4 = drop single item.
+    fn handle_item_drop(&mut self, uuid: Uuid, drop_stack: bool) {
+        let Some(eid) = self.ecs.find_by_uuid(uuid) else {
+            return;
+        };
+        let (item_id, drop_count, held_idx) = {
+            let Some(inv) = self.ecs.get::<basalt_ecs::Inventory>(eid) else {
+                return;
+            };
+            let held_idx = inv.held_slot as usize;
+            let item = &inv.slots[held_idx];
+            let Some(item_id) = item.item_id else {
+                return;
+            };
+            let count = if drop_stack { item.item_count } else { 1 };
+            (item_id, count, held_idx)
+        };
+
+        // Decrement or clear the slot
+        if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+            if drop_count >= inv.slots[held_idx].item_count {
+                inv.slots[held_idx] = basalt_types::Slot::empty();
+            } else {
+                inv.slots[held_idx].item_count -= drop_count;
+            }
+        }
+
+        // Spawn the dropped item entity
+        if let Some(pos) = self.ecs.get::<basalt_ecs::Position>(eid) {
+            self.spawn_item_entity(
+                pos.x as i32,
+                pos.y as i32 + 1,
+                pos.z as i32,
+                item_id,
+                drop_count,
+            );
+        }
+
+        // Sync the changed slot (raw internal index = SetPlayerInventory slot)
+        let slot_after = self
+            .ecs
+            .get::<basalt_ecs::Inventory>(eid)
+            .map(|inv| inv.slots[held_idx].clone())
+            .unwrap_or_default();
+        self.send_to(eid, |tx| {
+            let _ = tx.try_send(ServerOutput::SetSlot {
+                slot: held_idx as i16,
+                item: slot_after,
+            });
+        });
+    }
+
+    /// Handles a player inventory click.
+    ///
+    /// Handles a player inventory click.
+    ///
+    /// The client sends the expected result in `changed_slots` and
+    /// `cursor_item`. We apply them server-side and handle drops.
+    ///
+    /// Key flows:
+    /// - Click outside (slot -999): drop the OLD cursor item
+    /// - Mode 4 (Q key in inventory): drop from hovered slot
+    /// - All others: apply changed_slots + update cursor
+    fn handle_window_click(
+        &mut self,
+        uuid: Uuid,
+        slot: i16,
+        button: i8,
+        mode: i32,
+        changed_slots: Vec<(i16, basalt_types::Slot)>,
+        cursor_item: basalt_types::Slot,
+    ) {
+        let Some(eid) = self.ecs.find_by_uuid(uuid) else {
+            return;
+        };
+
+        // Click outside window (slot -999): drop what was on the cursor
+        if slot == -999 {
+            let old_cursor = {
+                let Some(inv) = self.ecs.get::<basalt_ecs::Inventory>(eid) else {
+                    return;
+                };
+                inv.cursor.clone()
+            };
+            if let Some(item_id) = old_cursor.item_id
+                && let Some(pos) = self.ecs.get::<basalt_ecs::Position>(eid)
+            {
+                self.spawn_item_entity(
+                    pos.x as i32,
+                    pos.y as i32 + 1,
+                    pos.z as i32,
+                    item_id,
+                    old_cursor.item_count,
+                );
+            }
+            // Update cursor (now empty) and apply any changed_slots
+            if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+                inv.cursor = cursor_item;
+                for (window_slot, item) in &changed_slots {
+                    if let Some(idx) = basalt_ecs::Inventory::window_to_index(*window_slot) {
+                        inv.slots[idx] = item.clone();
                     }
                 }
             }
+            return;
+        }
+
+        // Mode 4: Q key while hovering a slot in open inventory
+        if mode == 4 && slot >= 0 {
+            if let Some(idx) = basalt_ecs::Inventory::window_to_index(slot) {
+                let item = {
+                    let Some(inv) = self.ecs.get::<basalt_ecs::Inventory>(eid) else {
+                        return;
+                    };
+                    inv.slots[idx].clone()
+                };
+                if let Some(item_id) = item.item_id {
+                    let drop_count = if button == 0 { 1 } else { item.item_count };
+                    if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+                        if drop_count >= inv.slots[idx].item_count {
+                            inv.slots[idx] = basalt_types::Slot::empty();
+                        } else {
+                            inv.slots[idx].item_count -= drop_count;
+                        }
+                    }
+                    if let Some(pos) = self.ecs.get::<basalt_ecs::Position>(eid) {
+                        self.spawn_item_entity(
+                            pos.x as i32,
+                            pos.y as i32 + 1,
+                            pos.z as i32,
+                            item_id,
+                            drop_count,
+                        );
+                    }
+                    let slot_after = self
+                        .ecs
+                        .get::<basalt_ecs::Inventory>(eid)
+                        .map(|inv| inv.slots[idx].clone())
+                        .unwrap_or_default();
+                    self.send_to(eid, |tx| {
+                        let _ = tx.try_send(ServerOutput::SetSlot {
+                            slot: idx as i16,
+                            item: slot_after,
+                        });
+                    });
+                }
+            }
+            return;
+        }
+
+        // All other clicks: apply changed_slots + update cursor
+        if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+            for (window_slot, item) in &changed_slots {
+                if let Some(idx) = basalt_ecs::Inventory::window_to_index(*window_slot) {
+                    inv.slots[idx] = item.clone();
+                }
+            }
+            inv.cursor = cursor_item;
         }
     }
 
@@ -674,6 +894,16 @@ impl GameLoop {
                 pitch: 0.0,
             });
         });
+
+        // Sync full inventory
+        if let Some(inv) = self.ecs.get::<basalt_ecs::Inventory>(eid) {
+            let protocol_slots = inv.to_protocol_slots();
+            self.send_to(eid, |tx| {
+                let _ = tx.try_send(ServerOutput::SyncInventory {
+                    slots: protocol_slots,
+                });
+            });
+        }
     }
 
     /// Handles a player disconnection.
@@ -1311,7 +1541,32 @@ mod tests {
             basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
         }
 
-        let ecs = basalt_ecs::Ecs::new();
+        let mut ecs = basalt_ecs::Ecs::new();
+        // Register core systems (same as lib.rs)
+        ecs.add_system(
+            basalt_ecs::SystemBuilder::new("lifetime")
+                .phase(basalt_ecs::Phase::Simulate)
+                .every(1)
+                .run(|ecs: &mut basalt_ecs::Ecs| {
+                    for (_, lt) in ecs.iter_mut::<basalt_ecs::Lifetime>() {
+                        if lt.remaining_ticks > 0 {
+                            lt.remaining_ticks -= 1;
+                        }
+                    }
+                }),
+        );
+        ecs.add_system(
+            basalt_ecs::SystemBuilder::new("pickup_delay")
+                .phase(basalt_ecs::Phase::Simulate)
+                .every(1)
+                .run(|ecs: &mut basalt_ecs::Ecs| {
+                    for (_, delay) in ecs.iter_mut::<basalt_ecs::PickupDelay>() {
+                        if delay.remaining_ticks > 0 {
+                            delay.remaining_ticks -= 1;
+                        }
+                    }
+                }),
+        );
         let game_loop = GameLoop::new(
             bus,
             world,
@@ -1568,7 +1823,7 @@ mod tests {
 
         let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
         if let Some(inv) = game_loop.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
-            inv.hotbar[0] = basalt_types::Slot {
+            inv.hotbar_mut()[0] = basalt_types::Slot {
                 item_id: Some(1),
                 item_count: 1,
                 component_data: vec![],
@@ -1610,8 +1865,8 @@ mod tests {
 
         let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
         let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
-        assert_eq!(inv.hotbar[0].item_id, Some(1));
-        assert_eq!(inv.hotbar[0].item_count, 64);
+        assert_eq!(inv.hotbar()[0].item_id, Some(1));
+        assert_eq!(inv.hotbar()[0].item_count, 64);
     }
 
     #[test]
@@ -1633,7 +1888,7 @@ mod tests {
 
         let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
         let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
-        assert!(inv.hotbar[0].item_id.is_none());
+        assert!(inv.hotbar()[0].item_id.is_none());
     }
 
     #[test]
@@ -1741,5 +1996,234 @@ mod tests {
             view.loaded_chunks.contains(&(new_cx, 0)),
             "chunk view should contain the new center chunk"
         );
+    }
+
+    #[test]
+    fn q_key_drop_single_item() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Give 10 stone in hotbar slot 0
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .slots[0] = basalt_types::Slot::new(1, 10);
+
+        while rx.try_recv().is_ok() {}
+
+        // Q key = BlockDig status 4 (drop single)
+        let _ = game_tx.send(GameInput::BlockDig {
+            uuid,
+            status: 4,
+            x: 0,
+            y: 0,
+            z: 0,
+            sequence: 0,
+        });
+        game_loop.tick(1);
+
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert_eq!(inv.slots[0].item_count, 9, "should have 9 after dropping 1");
+
+        // Should receive SetSlot + SpawnEntity broadcast
+        let mut got_set_slot = false;
+        let mut got_spawn = false;
+        while let Ok(msg) = rx.try_recv() {
+            match &msg {
+                ServerOutput::SetSlot { slot, item } => {
+                    assert_eq!(*slot, 0);
+                    assert_eq!(item.item_count, 9);
+                    got_set_slot = true;
+                }
+                ServerOutput::Broadcast(_) => got_spawn = true,
+                _ => {}
+            }
+        }
+        assert!(got_set_slot, "should sync hotbar slot");
+        assert!(got_spawn, "should spawn dropped item entity");
+    }
+
+    #[test]
+    fn ctrl_q_drop_full_stack() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .slots[0] = basalt_types::Slot::new(1, 32);
+
+        while rx.try_recv().is_ok() {}
+
+        // Ctrl+Q = BlockDig status 3 (drop stack)
+        let _ = game_tx.send(GameInput::BlockDig {
+            uuid,
+            status: 3,
+            x: 0,
+            y: 0,
+            z: 0,
+            sequence: 0,
+        });
+        game_loop.tick(1);
+
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert!(
+            inv.slots[0].is_empty(),
+            "slot should be empty after full drop"
+        );
+    }
+
+    #[test]
+    fn creative_drop_slot_minus_one() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        // Creative drop: SetCreativeSlot with slot -1
+        let _ = game_tx.send(GameInput::SetCreativeSlot {
+            uuid,
+            slot: -1,
+            item: basalt_types::Slot::new(1, 5),
+        });
+        game_loop.tick(1);
+
+        // Should spawn a dropped item entity
+        let mut got_spawn = false;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(&msg, ServerOutput::Broadcast(_)) {
+                got_spawn = true;
+            }
+        }
+        assert!(got_spawn, "creative drop should spawn item entity");
+    }
+
+    #[test]
+    fn window_click_outside_drops_cursor() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Set cursor item directly
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .cursor = basalt_types::Slot::new(1, 16);
+
+        while rx.try_recv().is_ok() {}
+
+        // Click outside window (slot -999)
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: -999,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(1);
+
+        // Cursor should be empty
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert!(
+            inv.cursor.is_empty(),
+            "cursor should be empty after drop outside"
+        );
+
+        // Should spawn item entity
+        let mut got_spawn = false;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(&msg, ServerOutput::Broadcast(_)) {
+                got_spawn = true;
+            }
+        }
+        assert!(got_spawn, "should spawn dropped item from cursor");
+    }
+
+    #[test]
+    fn window_click_applies_changed_slots() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .slots[0] = basalt_types::Slot::new(1, 10);
+
+        // Swap hotbar slot 0 to main slot 9 (window: 36 → 9)
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 36,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![
+                (36, basalt_types::Slot::empty()),
+                (9, basalt_types::Slot::new(1, 10)),
+            ],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(1);
+
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert!(inv.slots[0].is_empty(), "hotbar 0 should be empty");
+        assert_eq!(inv.slots[9].item_id, Some(1), "main 0 should have item");
+        assert_eq!(inv.slots[9].item_count, 10);
+    }
+
+    #[test]
+    fn lifetime_system_despawns_expired() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Manually spawn an entity with lifetime = 2
+        let eid = 999u32;
+        game_loop.ecs.spawn_with_id(eid);
+        game_loop.ecs.set(
+            eid,
+            basalt_ecs::Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+        );
+        game_loop
+            .ecs
+            .set(eid, basalt_ecs::Lifetime { remaining_ticks: 2 });
+
+        game_loop.tick(1); // system: 2 → 1, collect: not 0 → alive
+        assert!(game_loop.ecs.has::<basalt_ecs::Lifetime>(eid));
+
+        game_loop.tick(2); // system: 1 → 0, collect: 0 → despawned
+        assert!(
+            !game_loop.ecs.has::<basalt_ecs::Lifetime>(eid),
+            "entity should be despawned after lifetime reaches 0"
+        );
+    }
+
+    #[test]
+    fn player_connect_syncs_inventory() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let mut got_sync = false;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(&msg, ServerOutput::SyncInventory { .. }) {
+                got_sync = true;
+            }
+        }
+        assert!(got_sync, "should receive SyncInventory on connect");
     }
 }

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -112,6 +112,8 @@ impl Server {
         ecs.register_component::<basalt_ecs::EntityKind>();
         ecs.register_component::<basalt_ecs::Health>();
         ecs.register_component::<basalt_ecs::Lifetime>();
+        ecs.register_component::<basalt_ecs::PickupDelay>();
+        ecs.register_component::<basalt_ecs::DroppedItem>();
         ecs.register_component::<basalt_ecs::PlayerRef>();
         ecs.register_component::<basalt_ecs::Inventory>();
         for reg in &plugin_components {
@@ -120,6 +122,32 @@ impl Server {
         for system in plugin_systems {
             ecs.add_system(system);
         }
+
+        // Core ECS systems (not plugins — infrastructure)
+        ecs.add_system(
+            basalt_ecs::SystemBuilder::new("lifetime")
+                .phase(basalt_ecs::Phase::Simulate)
+                .every(1)
+                .run(|ecs: &mut basalt_ecs::Ecs| {
+                    for (_, lt) in ecs.iter_mut::<basalt_ecs::Lifetime>() {
+                        if lt.remaining_ticks > 0 {
+                            lt.remaining_ticks -= 1;
+                        }
+                    }
+                }),
+        );
+        ecs.add_system(
+            basalt_ecs::SystemBuilder::new("pickup_delay")
+                .phase(basalt_ecs::Phase::Simulate)
+                .every(1)
+                .run(|ecs: &mut basalt_ecs::Ecs| {
+                    for (_, delay) in ecs.iter_mut::<basalt_ecs::PickupDelay>() {
+                        if delay.remaining_ticks > 0 {
+                            delay.remaining_ticks -= 1;
+                        }
+                    }
+                }),
+        );
 
         // Game loop — single dedicated OS thread
         let persistence_interval_ticks =

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -128,10 +128,25 @@ pub enum GameInput {
     SetCreativeSlot {
         /// UUID of the player.
         uuid: Uuid,
-        /// Inventory slot index.
+        /// Inventory slot index (protocol slot).
         slot: i16,
         /// The item to place in the slot.
         item: Slot,
+    },
+    /// Player clicked in their inventory window.
+    WindowClick {
+        /// UUID of the player.
+        uuid: Uuid,
+        /// Protocol slot that was clicked (-999 for outside window).
+        slot: i16,
+        /// Mouse button (0 = left, 1 = right).
+        button: i8,
+        /// Click mode (0 = normal, 1 = shift, 4 = drop).
+        mode: i32,
+        /// Slots changed by the client.
+        changed_slots: Vec<(i16, Slot)>,
+        /// Item on the cursor after the click.
+        cursor_item: Slot,
     },
 }
 
@@ -195,10 +210,15 @@ pub enum ServerOutput {
     },
     /// Update a single inventory slot on the client.
     SetSlot {
-        /// Protocol slot index (36-44 for hotbar).
+        /// Protocol slot index.
         slot: i16,
         /// The item in the slot.
         item: basalt_types::Slot,
+    },
+    /// Sync the full player inventory to the client.
+    SyncInventory {
+        /// All 46 protocol slots (crafting + armor + main + hotbar + offhand).
+        slots: Vec<basalt_types::Slot>,
     },
 
     // ── Chunk path (cache-based, zero alloc) ──────────────────────────

--- a/crates/basalt-server/src/net/task.rs
+++ b/crates/basalt-server/src/net/task.rs
@@ -237,14 +237,24 @@ async fn write_server_output(
                 .await?;
         }
         ServerOutput::SetSlot { slot, item } => {
-            use basalt_protocol::packets::play::inventory::ClientboundPlaySetSlot;
-            let packet = ClientboundPlaySetSlot {
-                window_id: 0, // player inventory
-                state_id: 0,
-                slot: *slot,
-                item: item.clone(),
+            use basalt_protocol::packets::play::inventory::ClientboundPlaySetPlayerInventory;
+            // Internal slot = raw MC slot (0-8 hotbar, 9-35 main), no conversion needed
+            let packet = ClientboundPlaySetPlayerInventory {
+                slot_id: i32::from(*slot),
+                contents: item.clone(),
             };
-            conn.write_packet_typed(ClientboundPlaySetSlot::PACKET_ID, &packet)
+            conn.write_packet_typed(ClientboundPlaySetPlayerInventory::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::SyncInventory { slots } => {
+            use basalt_protocol::packets::play::inventory::ClientboundPlayWindowItems;
+            let packet = ClientboundPlayWindowItems {
+                window_id: 0,
+                state_id: 0,
+                items: slots.clone(),
+                carried_item: basalt_types::Slot::empty(),
+            };
+            conn.write_packet_typed(ClientboundPlayWindowItems::PACKET_ID, &packet)
                 .await?;
         }
         // ── Chunk path: cache-based ──────────────────────────────────
@@ -631,6 +641,22 @@ async fn handle_packet(
                 uuid,
                 slot: creative.slot,
                 item: creative.item,
+            });
+        }
+
+        // -- Game loop: window click --
+        ServerboundPlayPacket::WindowClick(click) => {
+            let _ = game_tx.send(GameInput::WindowClick {
+                uuid,
+                slot: click.slot,
+                button: click.mouse_button,
+                mode: click.mode,
+                changed_slots: click
+                    .changed_slots
+                    .into_iter()
+                    .map(|cs| (cs.location, cs.item))
+                    .collect(),
+                cursor_item: click.cursor_item,
             });
         }
 

--- a/crates/basalt-server/tests/e2e.rs
+++ b/crates/basalt-server/tests/e2e.rs
@@ -888,3 +888,210 @@ async fn e2e_movement_broadcast_to_other_player() {
     }
     assert!(got_movement, "should receive movement broadcast");
 }
+
+// -- Test helpers for async game loop synchronization --
+
+/// Reads packets from the stream until one with the given `target_id`
+/// is found. Returns all packets received (including the target).
+/// Uses a 5-second overall timeout — generous enough for any CI runner.
+///
+/// This replaces sleep-based polling: we block on the TCP read until
+/// the game loop has processed the request and sent the response.
+async fn read_until_packet(
+    client: &mut TcpStream,
+    target_id: i32,
+) -> Vec<basalt_net::framing::RawPacket> {
+    let mut collected = Vec::new();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, framing::read_raw_packet(client)).await {
+            Ok(Ok(Some(raw))) => {
+                let found = raw.id == target_id;
+                collected.push(raw);
+                if found {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    collected
+}
+
+/// Helper: give an item to a connected player via SetCreativeSlot,
+/// then wait for the game loop to process it by reading until we
+/// see a SetPlayerInventory response confirming the slot was set.
+async fn give_creative_item(client: &mut TcpStream, protocol_slot: i16, item_id: i32, count: i32) {
+    use basalt_protocol::packets::play::ServerboundPlaySetCreativeSlot;
+    send_packet(
+        client,
+        ServerboundPlaySetCreativeSlot::PACKET_ID,
+        &ServerboundPlaySetCreativeSlot {
+            slot: protocol_slot,
+            item: basalt_types::Slot::new(item_id, count),
+        },
+    )
+    .await;
+    // The server doesn't send a response for SetCreativeSlot, so we
+    // need a small delay for the game loop to process it.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // Drain any packets that arrived during the wait
+    while let Ok(Ok(Some(_))) = tokio::time::timeout(
+        std::time::Duration::from_millis(10),
+        framing::read_raw_packet(client),
+    )
+    .await
+    {}
+}
+
+// -- Item drop e2e tests --
+
+#[tokio::test]
+async fn e2e_drop_single_item_q_key() {
+    use basalt_protocol::packets::play::inventory::ClientboundPlaySetPlayerInventory;
+    use basalt_protocol::packets::play::world::ServerboundPlayBlockDig;
+
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Give 10 stone in hotbar slot 0 (window slot 36)
+    give_creative_item(&mut client, 36, 1, 10).await;
+
+    // Q key = BlockDig status 4 (drop single item)
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockDig::PACKET_ID,
+        &ServerboundPlayBlockDig {
+            status: 4,
+            location: basalt_types::Position::new(0, 0, 0),
+            face: 0,
+            sequence: 0,
+        },
+    )
+    .await;
+
+    // Wait for SetPlayerInventory — the game loop sends it after processing
+    let packets =
+        read_until_packet(&mut client, ClientboundPlaySetPlayerInventory::PACKET_ID).await;
+
+    let inv_pkt = packets
+        .iter()
+        .find(|p| p.id == ClientboundPlaySetPlayerInventory::PACKET_ID)
+        .expect("should receive SetPlayerInventory after Q drop");
+
+    let mut cursor = inv_pkt.payload.as_slice();
+    let pkt = ClientboundPlaySetPlayerInventory::decode(&mut cursor).unwrap();
+    assert_eq!(pkt.slot_id, 0, "should update hotbar slot 0");
+    assert_eq!(
+        pkt.contents.item_count, 9,
+        "should have 9 after dropping 1 from 10"
+    );
+}
+
+#[tokio::test]
+async fn e2e_drop_full_stack_ctrl_q() {
+    use basalt_protocol::packets::play::inventory::ClientboundPlaySetPlayerInventory;
+    use basalt_protocol::packets::play::world::ServerboundPlayBlockDig;
+
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    give_creative_item(&mut client, 36, 1, 32).await;
+
+    // Ctrl+Q = BlockDig status 3 (drop full stack)
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockDig::PACKET_ID,
+        &ServerboundPlayBlockDig {
+            status: 3,
+            location: basalt_types::Position::new(0, 0, 0),
+            face: 0,
+            sequence: 0,
+        },
+    )
+    .await;
+
+    let packets =
+        read_until_packet(&mut client, ClientboundPlaySetPlayerInventory::PACKET_ID).await;
+
+    let inv_pkt = packets
+        .iter()
+        .find(|p| p.id == ClientboundPlaySetPlayerInventory::PACKET_ID)
+        .expect("should receive SetPlayerInventory after Ctrl+Q drop");
+
+    let mut cursor = inv_pkt.payload.as_slice();
+    let pkt = ClientboundPlaySetPlayerInventory::decode(&mut cursor).unwrap();
+    assert_eq!(pkt.slot_id, 0);
+    assert!(
+        pkt.contents.is_empty(),
+        "slot should be empty after full stack drop"
+    );
+}
+
+#[tokio::test]
+async fn e2e_block_break_spawns_item_entity() {
+    use basalt_protocol::packets::play::entity::ClientboundPlaySpawnEntity;
+    use basalt_protocol::packets::play::world::{
+        ServerboundPlayBlockDig, ServerboundPlayBlockPlace,
+    };
+
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Place a stone block so we have something guaranteed to break
+    give_creative_item(&mut client, 36, 1, 1).await;
+
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockPlace::PACKET_ID,
+        &ServerboundPlayBlockPlace {
+            hand: 0,
+            location: basalt_types::Position::new(2, -60, 2),
+            direction: 1,
+            cursor_x: 0.5,
+            cursor_y: 1.0,
+            cursor_z: 0.5,
+            inside_block: false,
+            world_border_hit: false,
+            sequence: 50,
+        },
+    )
+    .await;
+
+    // Wait for block place to be processed (ack arrives)
+    use basalt_protocol::packets::play::world::ClientboundPlayAcknowledgePlayerDigging;
+    read_until_packet(
+        &mut client,
+        ClientboundPlayAcknowledgePlayerDigging::PACKET_ID,
+    )
+    .await;
+
+    // Break the placed block
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockDig::PACKET_ID,
+        &ServerboundPlayBlockDig {
+            status: 0,
+            location: basalt_types::Position::new(2, -59, 2),
+            face: 1,
+            sequence: 51,
+        },
+    )
+    .await;
+
+    // Wait for SpawnEntity (the dropped item)
+    let packets = read_until_packet(&mut client, ClientboundPlaySpawnEntity::PACKET_ID).await;
+
+    let spawn_pkt = packets
+        .iter()
+        .find(|p| p.id == ClientboundPlaySpawnEntity::PACKET_ID)
+        .expect("breaking a block should spawn an item entity");
+
+    let mut cursor = spawn_pkt.payload.as_slice();
+    let pkt = ClientboundPlaySpawnEntity::decode(&mut cursor).unwrap();
+    assert_eq!(pkt.r#type, 68, "spawned entity should be type 68 (item)");
+}


### PR DESCRIPTION
## Summary

- **Inventory expanded to 36 slots** (0-8 hotbar, 9-35 main) aligned with Minecraft raw inventory numbering — SetPlayerInventory works without slot conversion
- **Cursor tracking**: Inventory.cursor tracks the item held on the mouse. Drop outside window (slot -999) uses the tracked cursor, not the packet's cursor_item field
- **SyncInventory on connect**: sends SetContainerContent with all 46 protocol window slots
- **WindowClick handling**: applies changed_slots + updates cursor. Click outside spawns dropped item from cursor. Mode 4 (Q key in inventory) drops from hovered slot
- **Creative drop**: SetCreativeSlot with slot -1 spawns dropped item entity
- **Item entity movement broadcast**: after physics runs, broadcasts EntityMoved for items with non-zero velocity
- **Lifetime + PickupDelay as ECS systems**: registered in lib.rs, cleanup (despawn + broadcast) stays in game loop
- **3 e2e tests**: drop single (Q), drop stack (Ctrl+Q), block break spawns item
- **10 unit tests**: slot conversion, insert, stacking, roundtrip, held item, protocol mapping

## Test plan

- [x] All 560+ tests pass
- [x] Clippy clean
- [x] Coverage 90%+
- [x] E2e: Q drop single item with correct count
- [x] E2e: Ctrl+Q drop full stack, slot emptied
- [x] E2e: block break spawns item entity type 68
- [x] Manual: Q key drop in survival
- [x] Manual: inventory open, click outside to drop
- [x] Manual: creative menu drop (slot -1)
- [x] Manual: pickup adds correct count to inventory

Closes #132
