### PR TITLE
feat(server): chest containers — block entities, window protocol, persistence

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"73896d34-d8e8-49fe-9a27-59eeafff5794","pid":63291,"acquiredAt":1776519682618}

--- a/crates/basalt-ecs/src/components.rs
+++ b/crates/basalt-ecs/src/components.rs
@@ -109,6 +109,20 @@ pub struct DroppedItem {
 }
 impl Component for DroppedItem {}
 
+/// Tracks an open container window for a player.
+///
+/// Present on player entities while they have a container (chest, etc.)
+/// open. Used to route WindowClick packets and broadcast slot changes
+/// to all viewers of the same container.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenContainer {
+    /// Protocol window ID (1-127, cycling).
+    pub window_id: u8,
+    /// Absolute block position of the container.
+    pub position: (i32, i32, i32),
+}
+impl Component for OpenContainer {}
+
 /// Pickup delay before a dropped item can be collected.
 ///
 /// Decremented each tick. While remaining > 0, the item cannot be

--- a/crates/basalt-ecs/src/lib.rs
+++ b/crates/basalt-ecs/src/lib.rs
@@ -13,8 +13,8 @@ mod ecs;
 mod system;
 
 pub use components::{
-    BoundingBox, DroppedItem, EntityKind, Health, Inventory, Lifetime, PickupDelay, PlayerRef,
-    Position, Rotation, Velocity,
+    BoundingBox, DroppedItem, EntityKind, Health, Inventory, Lifetime, OpenContainer, PickupDelay,
+    PlayerRef, Position, Rotation, Velocity,
 };
 pub use ecs::{Component, Ecs, EntityId};
 pub use system::{Phase, SystemAccess, SystemBuilder, SystemDescriptor, SystemRunner};

--- a/crates/basalt-server/src/game/tick.rs
+++ b/crates/basalt-server/src/game/tick.rs
@@ -91,6 +91,8 @@ pub(crate) struct GameLoop {
     simulation_distance: i32,
     /// How often to flush dirty chunks to disk, in ticks.
     persistence_interval_ticks: u64,
+    /// Cycling counter for container window IDs (1-127).
+    next_window_id: u8,
 }
 
 impl GameLoop {
@@ -120,7 +122,15 @@ impl GameLoop {
             active_chunks: HashSet::new(),
             simulation_distance,
             persistence_interval_ticks,
+            next_window_id: 1,
         }
+    }
+
+    /// Allocates the next container window ID (1-127, cycling).
+    fn alloc_window_id(&mut self) -> u8 {
+        let id = self.next_window_id;
+        self.next_window_id = if id >= 127 { 1 } else { id + 1 };
+        id
     }
 
     /// Processes one tick.
@@ -468,6 +478,34 @@ impl GameLoop {
                 } => {
                     self.handle_window_click(uuid, slot, button, mode, changed_slots, cursor_item);
                 }
+                GameInput::CloseWindow { uuid, .. } => {
+                    if let Some(eid) = self.ecs.find_by_uuid(uuid) {
+                        // Return cursor item to inventory or drop it
+                        let cursor_item = self
+                            .ecs
+                            .get_mut::<basalt_ecs::Inventory>(eid)
+                            .map(|inv| {
+                                let item = inv.cursor.clone();
+                                inv.cursor = basalt_types::Slot::empty();
+                                item
+                            })
+                            .unwrap_or_default();
+                        if let Some(item_id) = cursor_item.item_id
+                            && let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid)
+                            && inv.try_insert(item_id, cursor_item.item_count).is_none()
+                            && let Some(pos) = self.ecs.get::<basalt_ecs::Position>(eid)
+                        {
+                            self.spawn_item_entity(
+                                pos.x as i32,
+                                pos.y as i32 + 1,
+                                pos.z as i32,
+                                item_id,
+                                cursor_item.item_count,
+                            );
+                        }
+                        self.ecs.remove_component::<basalt_ecs::OpenContainer>(eid);
+                    }
+                }
             }
         }
     }
@@ -553,6 +591,83 @@ impl GameLoop {
         let Some(eid) = self.ecs.find_by_uuid(uuid) else {
             return;
         };
+
+        // If a container is open, route to container click handler
+        if let Some(oc) = self.ecs.get::<basalt_ecs::OpenContainer>(eid) {
+            let pos = oc.position;
+            // Drop outside container window
+            if slot == -999 {
+                let old_cursor = self
+                    .ecs
+                    .get::<basalt_ecs::Inventory>(eid)
+                    .map(|inv| inv.cursor.clone())
+                    .unwrap_or_default();
+                if let Some(item_id) = old_cursor.item_id
+                    && let Some(player_pos) = self.ecs.get::<basalt_ecs::Position>(eid)
+                {
+                    self.spawn_item_entity(
+                        player_pos.x as i32,
+                        player_pos.y as i32 + 1,
+                        player_pos.z as i32,
+                        item_id,
+                        old_cursor.item_count,
+                    );
+                }
+                if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+                    inv.cursor = cursor_item;
+                }
+                return;
+            }
+            // Mode 4: Q key drop while hovering a container slot
+            if mode == 4 && slot >= 0 {
+                // Determine what to drop: container slot or player slot
+                let ws = slot;
+                let drop_item = if (0..27).contains(&ws) {
+                    // Chest slot
+                    self.world
+                        .get_block_entity(pos.0, pos.1, pos.2)
+                        .map(|be| match &*be {
+                            basalt_world::block_entity::BlockEntity::Chest { slots } => {
+                                slots[ws as usize].clone()
+                            }
+                        })
+                } else if (27..54).contains(&ws) {
+                    let idx = (ws - 27 + 9) as usize;
+                    self.ecs
+                        .get::<basalt_ecs::Inventory>(eid)
+                        .and_then(|inv| (idx < 36).then(|| inv.slots[idx].clone()))
+                } else if (54..63).contains(&ws) {
+                    let idx = (ws - 54) as usize;
+                    self.ecs
+                        .get::<basalt_ecs::Inventory>(eid)
+                        .map(|inv| inv.slots[idx].clone())
+                } else {
+                    None
+                };
+
+                if let Some(item) = drop_item
+                    && let Some(item_id) = item.item_id
+                {
+                    let drop_count = if button == 0 { 1 } else { item.item_count };
+                    // Apply the changed_slots from the client (handles decrement)
+                    self.handle_container_click(eid, pos, &changed_slots, cursor_item);
+                    // Spawn the dropped item
+                    if let Some(player_pos) = self.ecs.get::<basalt_ecs::Position>(eid) {
+                        self.spawn_item_entity(
+                            player_pos.x as i32,
+                            player_pos.y as i32 + 1,
+                            player_pos.z as i32,
+                            item_id,
+                            drop_count,
+                        );
+                    }
+                }
+                return;
+            }
+
+            self.handle_container_click(eid, pos, &changed_slots, cursor_item);
+            return;
+        }
 
         // Click outside window (slot -999): drop what was on the cursor
         if slot == -999 {
@@ -860,12 +975,7 @@ impl GameLoop {
         let mut count = 0i32;
         for dx in -VIEW_RADIUS..=VIEW_RADIUS {
             for dz in -VIEW_RADIUS..=VIEW_RADIUS {
-                self.send_to(eid, |tx| {
-                    let _ = tx.try_send(ServerOutput::SendChunk {
-                        cx: cx + dx,
-                        cz: cz + dz,
-                    });
-                });
+                self.send_chunk_with_entities(eid, cx + dx, cz + dz);
                 count += 1;
             }
         }
@@ -1104,9 +1214,7 @@ impl GameLoop {
                 let _ = tx.try_send(ServerOutput::ChunkBatchStart);
             });
             for &(cx, cz) in &to_load {
-                self.send_to(eid, |tx| {
-                    let _ = tx.try_send(ServerOutput::SendChunk { cx, cz });
-                });
+                self.send_chunk_with_entities(eid, cx, cz);
             }
             self.send_to(eid, |tx| {
                 let _ = tx.try_send(ServerOutput::ChunkBatchFinished {
@@ -1156,6 +1264,9 @@ impl GameLoop {
         }
 
         self.process_responses(uuid, &ctx.drain_responses());
+
+        // Remove block entity if the broken block had one
+        self.world.remove_block_entity(x, y, z);
     }
 
     /// Handles a block place.
@@ -1171,6 +1282,14 @@ impl GameLoop {
         let Some(eid) = self.ecs.find_by_uuid(uuid) else {
             return;
         };
+
+        // Check if the clicked block is an interactable container
+        let clicked_state = self.world.get_block(x, y, z);
+        if basalt_world::block::is_chest(clicked_state) {
+            self.open_chest(eid, x, y, z);
+            return;
+        }
+
         let (dx, dy, dz) = face_offset(direction);
         let (px, py, pz) = (x + dx, y + dy, z + dz);
 
@@ -1181,10 +1300,18 @@ impl GameLoop {
             let Some(item_id) = inv.held_item().item_id else {
                 return;
             };
-            let Some(block_state) = basalt_world::block::item_to_default_block_state(item_id)
+            let Some(mut block_state) = basalt_world::block::item_to_default_block_state(item_id)
             else {
                 return;
             };
+            // Orient directional blocks based on player yaw
+            if basalt_world::block::is_chest(block_state) {
+                let yaw = self
+                    .ecs
+                    .get::<basalt_ecs::Rotation>(eid)
+                    .map_or(0.0, |r| r.yaw);
+                block_state = basalt_world::block::chest_state_for_yaw(yaw);
+            }
             let Some(pr) = self.ecs.get::<basalt_ecs::PlayerRef>(eid) else {
                 return;
             };
@@ -1216,6 +1343,34 @@ impl GameLoop {
         }
 
         self.process_responses(uuid, &ctx.drain_responses());
+
+        // Create block entity for interactive blocks (chests)
+        if basalt_world::block::is_chest(block_state) {
+            self.world.set_block_entity(
+                px,
+                py,
+                pz,
+                basalt_world::block_entity::BlockEntity::empty_chest(),
+            );
+            // Tell all players about the block entity so the chest renders
+            let bc = Arc::new(SharedBroadcast::new(BroadcastEvent::BlockChanged {
+                x: px,
+                y: py,
+                z: pz,
+                state: i32::from(block_state),
+            }));
+            for (e, _) in self.ecs.iter::<OutputHandle>() {
+                self.send_to(e, |tx| {
+                    let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&bc)));
+                    let _ = tx.try_send(ServerOutput::BlockEntityData {
+                        x: px,
+                        y: py,
+                        z: pz,
+                        action: 2,
+                    });
+                });
+            }
+        }
     }
 
     // ── Response processing ───────────────────────────────────────────
@@ -1415,9 +1570,161 @@ impl GameLoop {
         }
     }
 
+    // ── Containers ─────────────────────────────────────────────────────
+
+    /// Opens a chest container for a player.
+    ///
+    /// Creates a block entity if it doesn't exist yet, assigns a window
+    /// ID, and sends OpenWindow + SetContainerContent to the client.
+    fn open_chest(&mut self, eid: basalt_ecs::EntityId, x: i32, y: i32, z: i32) {
+        // Ensure block entity exists
+        if self.world.get_block_entity(x, y, z).is_none() {
+            self.world.set_block_entity(
+                x,
+                y,
+                z,
+                basalt_world::block_entity::BlockEntity::empty_chest(),
+            );
+        }
+
+        let window_id = self.alloc_window_id();
+
+        // Build the container window slots: 27 chest + 36 player inventory
+        let mut window_slots = Vec::with_capacity(63);
+
+        // Chest slots (0-26)
+        if let Some(be) = self.world.get_block_entity(x, y, z) {
+            match &*be {
+                basalt_world::block_entity::BlockEntity::Chest { slots } => {
+                    window_slots.extend_from_slice(slots.as_ref());
+                }
+            }
+        }
+
+        // Player main inventory (window 27-53) = internal 9-35
+        // Player hotbar (window 54-62) = internal 0-8
+        if let Some(inv) = self.ecs.get::<basalt_ecs::Inventory>(eid) {
+            window_slots.extend_from_slice(&inv.slots[9..]); // main: 27 slots
+            window_slots.extend_from_slice(&inv.slots[..9]); // hotbar: 9 slots
+        }
+
+        // Set OpenContainer on the player
+        self.ecs.set(
+            eid,
+            basalt_ecs::OpenContainer {
+                window_id,
+                position: (x, y, z),
+            },
+        );
+
+        // Send OpenWindow + contents
+        let title = basalt_types::TextComponent::text("Chest").to_nbt();
+        self.send_to(eid, |tx| {
+            let _ = tx.try_send(ServerOutput::OpenWindow {
+                window_id,
+                inventory_type: 2, // generic_9x3
+                title,
+                slots: window_slots,
+            });
+        });
+    }
+
+    /// Handles a WindowClick that targets an open container.
+    ///
+    /// Container window slot layout for generic_9x3 (chest):
+    /// - 0-26: chest slots
+    /// - 27-53: player main inventory (our 9-35)
+    /// - 54-62: player hotbar (our 0-8)
+    fn handle_container_click(
+        &mut self,
+        eid: basalt_ecs::EntityId,
+        container_pos: (i32, i32, i32),
+        changed_slots: &[(i16, basalt_types::Slot)],
+        cursor_item: basalt_types::Slot,
+    ) {
+        let (cx, cy, cz) = container_pos;
+
+        for (window_slot, item) in changed_slots {
+            let ws = *window_slot;
+            if (0..27).contains(&ws) {
+                // Chest slot
+                if let Some(mut be) = self.world.get_block_entity_mut(cx, cy, cz) {
+                    match &mut *be {
+                        basalt_world::block_entity::BlockEntity::Chest { slots } => {
+                            slots[ws as usize] = item.clone();
+                        }
+                    }
+                }
+                // Mark chunk dirty for persistence
+                self.world.mark_chunk_dirty(cx >> 4, cz >> 4);
+                // Invalidate chunk cache (block entity data changed)
+                self.chunk_cache.invalidate(cx >> 4, cz >> 4);
+                // Notify other viewers
+                self.notify_container_viewers(container_pos, eid, ws, item);
+            } else if (27..54).contains(&ws) {
+                // Player main inventory: window 27-53 → internal 9-35
+                let idx = (ws - 27 + 9) as usize;
+                if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid)
+                    && idx < 36
+                {
+                    inv.slots[idx] = item.clone();
+                }
+            } else if (54..63).contains(&ws) {
+                // Player hotbar: window 54-62 → internal 0-8
+                let idx = (ws - 54) as usize;
+                if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+                    inv.slots[idx] = item.clone();
+                }
+            }
+        }
+
+        // Update cursor
+        if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
+            inv.cursor = cursor_item;
+        }
+    }
+
+    /// Notifies other viewers of a container that a slot changed.
+    fn notify_container_viewers(
+        &self,
+        container_pos: (i32, i32, i32),
+        exclude_eid: basalt_ecs::EntityId,
+        window_slot: i16,
+        item: &basalt_types::Slot,
+    ) {
+        for (other_eid, oc) in self.ecs.iter::<basalt_ecs::OpenContainer>() {
+            if other_eid != exclude_eid && oc.position == container_pos {
+                self.send_to(other_eid, |tx| {
+                    let _ = tx.try_send(ServerOutput::SetContainerSlot {
+                        window_id: oc.window_id,
+                        slot: window_slot,
+                        item: item.clone(),
+                    });
+                });
+            }
+        }
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     /// Sends output to a player entity via their OutputHandle.
+    /// Sends a chunk to a player and follows up with BlockEntityData
+    /// for any block entities in that chunk (chests, etc.).
+    fn send_chunk_with_entities(&self, eid: basalt_ecs::EntityId, cx: i32, cz: i32) {
+        self.send_to(eid, |tx| {
+            let _ = tx.try_send(ServerOutput::SendChunk { cx, cz });
+        });
+        // Send block entity data for chests in this chunk
+        for (x, y, z, be) in self.world.block_entities_in_chunk(cx, cz) {
+            let action = match &be {
+                basalt_world::block_entity::BlockEntity::Chest { .. } => 2,
+            };
+            self.send_to(eid, |tx| {
+                let _ = tx.try_send(ServerOutput::BlockEntityData { x, y, z, action });
+            });
+        }
+    }
+
     fn send_to(&self, eid: basalt_ecs::EntityId, f: impl FnOnce(&mpsc::Sender<ServerOutput>)) {
         if let Some(handle) = self.ecs.get::<OutputHandle>(eid) {
             f(&handle.tx);
@@ -2225,5 +2532,367 @@ mod tests {
             }
         }
         assert!(got_sync, "should receive SyncInventory on connect");
+    }
+
+    #[test]
+    fn chest_placement_creates_block_entity() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Give chest in hotbar slot 0 (item 280 = chest)
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .slots[0] = basalt_types::Slot::new(313, 1); // chest item ID
+
+        // Place chest on top of (5, -60, 3)
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 5,
+            y: -60,
+            z: 3,
+            direction: 1,
+            sequence: 10,
+        });
+        game_loop.tick(1);
+
+        // Block entity should exist
+        assert!(
+            game_loop.world.get_block_entity(5, -59, 3).is_some(),
+            "chest placement should create block entity"
+        );
+    }
+
+    #[test]
+    fn chest_break_removes_block_entity() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Place a chest block + entity manually
+        game_loop
+            .world
+            .set_block(5, 64, 3, basalt_world::block::CHEST);
+        game_loop.world.set_block_entity(
+            5,
+            64,
+            3,
+            basalt_world::block_entity::BlockEntity::empty_chest(),
+        );
+
+        // Break it
+        let _ = game_tx.send(GameInput::BlockDig {
+            uuid,
+            status: 0,
+            x: 5,
+            y: 64,
+            z: 3,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+
+        assert!(
+            game_loop.world.get_block_entity(5, 64, 3).is_none(),
+            "breaking chest should remove block entity"
+        );
+    }
+
+    #[test]
+    fn open_chest_sends_open_window() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        // Place chest
+        game_loop
+            .world
+            .set_block(5, 64, 3, basalt_world::block::CHEST);
+        game_loop.world.set_block_entity(
+            5,
+            64,
+            3,
+            basalt_world::block_entity::BlockEntity::empty_chest(),
+        );
+
+        // Right-click the chest (BlockPlace on the chest block)
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 5,
+            y: 64,
+            z: 3,
+            direction: 1,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+
+        let mut got_open = false;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(&msg, ServerOutput::OpenWindow { .. }) {
+                got_open = true;
+            }
+        }
+        assert!(got_open, "right-clicking chest should send OpenWindow");
+
+        // Player should have OpenContainer component
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        assert!(game_loop.ecs.has::<basalt_ecs::OpenContainer>(eid));
+    }
+
+    #[test]
+    fn close_window_returns_cursor_to_inventory() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Put an item on the cursor
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .cursor = basalt_types::Slot::new(1, 5);
+
+        // Close window
+        let _ = game_tx.send(GameInput::CloseWindow { uuid });
+        game_loop.tick(1);
+
+        // Cursor should be empty, item should be in inventory
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert!(inv.cursor.is_empty(), "cursor should be empty after close");
+        // Item should have been inserted somewhere
+        let has_item = inv
+            .slots
+            .iter()
+            .any(|s| s.item_id == Some(1) && s.item_count == 5);
+        assert!(has_item, "cursor item should be returned to inventory");
+    }
+
+    #[test]
+    fn container_click_modifies_chest() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        // Place and open chest
+        game_loop
+            .world
+            .set_block(5, 64, 3, basalt_world::block::CHEST);
+        game_loop.world.set_block_entity(
+            5,
+            64,
+            3,
+            basalt_world::block_entity::BlockEntity::empty_chest(),
+        );
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 5,
+            y: 64,
+            z: 3,
+            direction: 1,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+        while rx.try_recv().is_ok() {}
+
+        // Put an item in chest slot 0 via WindowClick
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 0,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![(0, basalt_types::Slot::new(1, 10))],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(2);
+
+        // Chest should have the item
+        let be = game_loop.world.get_block_entity(5, 64, 3).unwrap();
+        match &*be {
+            basalt_world::block_entity::BlockEntity::Chest { slots } => {
+                assert_eq!(slots[0].item_id, Some(1));
+                assert_eq!(slots[0].item_count, 10);
+            }
+        }
+    }
+
+    #[test]
+    fn container_q_drop_spawns_item() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        // Place and open chest with an item in slot 0
+        game_loop
+            .world
+            .set_block(5, 64, 3, basalt_world::block::CHEST);
+        let mut be = basalt_world::block_entity::BlockEntity::empty_chest();
+        let basalt_world::block_entity::BlockEntity::Chest { ref mut slots } = be;
+        slots[0] = basalt_types::Slot::new(1, 10);
+        game_loop.world.set_block_entity(5, 64, 3, be);
+
+        // Open the chest
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 5,
+            y: 64,
+            z: 3,
+            direction: 1,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+        while rx.try_recv().is_ok() {}
+
+        // Q key drop from chest slot 0 (mode 4, button 0 = single)
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 0,
+            button: 0,
+            mode: 4,
+            changed_slots: vec![(0, basalt_types::Slot::new(1, 9))],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(2);
+
+        // Chest slot 0 should have 9 items
+        let chest_be = game_loop.world.get_block_entity(5, 64, 3).unwrap();
+        match &*chest_be {
+            basalt_world::block_entity::BlockEntity::Chest { slots } => {
+                assert_eq!(slots[0].item_count, 9);
+            }
+        }
+
+        // Should have broadcast a spawn entity
+        let mut got_spawn = false;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(&msg, ServerOutput::Broadcast(_)) {
+                got_spawn = true;
+            }
+        }
+        assert!(got_spawn, "Q drop from container should spawn item entity");
+    }
+
+    #[test]
+    fn chest_orientation_based_on_yaw() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        // Set player yaw to 180 (facing north → chest faces south)
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Rotation>(eid)
+            .unwrap()
+            .yaw = 180.0;
+        // Give chest in hotbar
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .slots[0] = basalt_types::Slot::new(313, 1);
+
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 5,
+            y: -60,
+            z: 3,
+            direction: 1,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+
+        // Chest at (5, -59, 3) should face south (state 3016)
+        let state = game_loop.world.get_block(5, -59, 3);
+        assert_eq!(
+            state,
+            basalt_world::block::chest_state_for_yaw(180.0),
+            "chest should face south when player faces north"
+        );
+    }
+
+    #[test]
+    fn close_window_removes_open_container() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Manually set OpenContainer
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop.ecs.set(
+            eid,
+            basalt_ecs::OpenContainer {
+                window_id: 1,
+                position: (5, 64, 3),
+            },
+        );
+
+        let _ = game_tx.send(GameInput::CloseWindow { uuid });
+        game_loop.tick(1);
+
+        assert!(
+            !game_loop.ecs.has::<basalt_ecs::OpenContainer>(eid),
+            "CloseWindow should remove OpenContainer"
+        );
+    }
+
+    #[test]
+    fn container_drop_outside_drops_cursor() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+
+        // Open a chest
+        game_loop
+            .world
+            .set_block(5, 64, 3, basalt_world::block::CHEST);
+        game_loop.world.set_block_entity(
+            5,
+            64,
+            3,
+            basalt_world::block_entity::BlockEntity::empty_chest(),
+        );
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 5,
+            y: 64,
+            z: 3,
+            direction: 1,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+        while rx.try_recv().is_ok() {}
+
+        // Set cursor item
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .cursor = basalt_types::Slot::new(1, 8);
+
+        // Click outside (slot -999) to drop
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: -999,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(2);
+
+        let inv = game_loop.ecs.get::<basalt_ecs::Inventory>(eid).unwrap();
+        assert!(
+            inv.cursor.is_empty(),
+            "cursor should be empty after drop outside container"
+        );
     }
 }

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -114,6 +114,7 @@ impl Server {
         ecs.register_component::<basalt_ecs::Lifetime>();
         ecs.register_component::<basalt_ecs::PickupDelay>();
         ecs.register_component::<basalt_ecs::DroppedItem>();
+        ecs.register_component::<basalt_ecs::OpenContainer>();
         ecs.register_component::<basalt_ecs::PlayerRef>();
         ecs.register_component::<basalt_ecs::Inventory>();
         for reg in &plugin_components {

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -148,6 +148,11 @@ pub enum GameInput {
         /// Item on the cursor after the click.
         cursor_item: Slot,
     },
+    /// Player closed a container window.
+    CloseWindow {
+        /// UUID of the player.
+        uuid: Uuid,
+    },
 }
 
 /// Output from the game loop to a player's net task.
@@ -219,6 +224,39 @@ pub enum ServerOutput {
     SyncInventory {
         /// All 46 protocol slots (crafting + armor + main + hotbar + offhand).
         slots: Vec<basalt_types::Slot>,
+    },
+    /// Open a container window on the client.
+    OpenWindow {
+        /// Window ID (1-127).
+        window_id: u8,
+        /// Inventory type (e.g., 2 = generic_9x3 for chests).
+        inventory_type: i32,
+        /// Window title (NBT text component).
+        title: basalt_types::nbt::NbtCompound,
+        /// Container slots + player inventory slots.
+        slots: Vec<basalt_types::Slot>,
+    },
+    /// Update a slot in an open container window.
+    SetContainerSlot {
+        /// Window ID.
+        window_id: u8,
+        /// Slot index within the window.
+        slot: i16,
+        /// The item in the slot.
+        item: basalt_types::Slot,
+    },
+
+    /// Inform client of a block entity at a position.
+    /// Net task sends TileEntityData packet.
+    BlockEntityData {
+        /// Block position.
+        x: i32,
+        /// Block Y.
+        y: i32,
+        /// Block Z.
+        z: i32,
+        /// Block entity type (2 = chest).
+        action: i32,
     },
 
     // ── Chunk path (cache-based, zero alloc) ──────────────────────────

--- a/crates/basalt-server/src/net/chunk_cache.rs
+++ b/crates/basalt-server/src/net/chunk_cache.rs
@@ -135,13 +135,13 @@ fn build_map_chunk_packet(col: &basalt_world::chunk::ChunkColumn) -> Clientbound
     let chunk_data = col.encode_sections();
     let heightmaps = col.compute_heightmaps();
 
-    // Sky light: all sections get full sunlight (level 15).
-    // 26 entries = 24 sections + 1 below + 1 above.
-    // Each entry is 2048 bytes (4 bits per block, 16x16x16 / 2).
     let light_sections = SECTIONS_PER_CHUNK + 2;
     let sky_light_mask = build_full_light_mask(light_sections);
     let sky_light: Vec<Vec<u8>> = (0..light_sections).map(|_| vec![0xFF; 2048]).collect();
 
+    // Block entities are sent separately via TileEntityData packets
+    // because the chunk packet's block_entities NBT encoding has
+    // compatibility issues with the generated struct.
     ClientboundPlayMapChunk {
         x: col.x,
         z: col.z,

--- a/crates/basalt-server/src/net/task.rs
+++ b/crates/basalt-server/src/net/task.rs
@@ -257,6 +257,56 @@ async fn write_server_output(
             conn.write_packet_typed(ClientboundPlayWindowItems::PACKET_ID, &packet)
                 .await?;
         }
+        ServerOutput::OpenWindow {
+            window_id,
+            inventory_type,
+            title,
+            slots,
+        } => {
+            use basalt_protocol::packets::play::inventory::{
+                ClientboundPlayOpenWindow, ClientboundPlayWindowItems,
+            };
+            let open = ClientboundPlayOpenWindow {
+                window_id: *window_id as i32,
+                inventory_type: *inventory_type,
+                window_title: title.clone(),
+            };
+            conn.write_packet_typed(ClientboundPlayOpenWindow::PACKET_ID, &open)
+                .await?;
+            let items = ClientboundPlayWindowItems {
+                window_id: *window_id as i32,
+                state_id: 0,
+                items: slots.clone(),
+                carried_item: basalt_types::Slot::empty(),
+            };
+            conn.write_packet_typed(ClientboundPlayWindowItems::PACKET_ID, &items)
+                .await?;
+        }
+        ServerOutput::SetContainerSlot {
+            window_id,
+            slot,
+            item,
+        } => {
+            use basalt_protocol::packets::play::inventory::ClientboundPlaySetSlot;
+            let packet = ClientboundPlaySetSlot {
+                window_id: *window_id as i32,
+                state_id: 0,
+                slot: *slot,
+                item: item.clone(),
+            };
+            conn.write_packet_typed(ClientboundPlaySetSlot::PACKET_ID, &packet)
+                .await?;
+        }
+        ServerOutput::BlockEntityData { x, y, z, action } => {
+            use basalt_protocol::packets::play::world::ClientboundPlayTileEntityData;
+            let packet = ClientboundPlayTileEntityData {
+                location: basalt_types::Position::new(*x, *y, *z),
+                action: *action,
+                nbt_data: basalt_types::nbt::NbtCompound::new(),
+            };
+            conn.write_packet_typed(ClientboundPlayTileEntityData::PACKET_ID, &packet)
+                .await?;
+        }
         // ── Chunk path: cache-based ──────────────────────────────────
         ServerOutput::SendChunk { cx, cz } => {
             let bytes = chunk_cache.get_or_encode(*cx, *cz);
@@ -658,6 +708,11 @@ async fn handle_packet(
                     .collect(),
                 cursor_item: click.cursor_item,
             });
+        }
+
+        // -- Game loop: close window --
+        ServerboundPlayPacket::CloseWindow(_) => {
+            let _ = game_tx.send(GameInput::CloseWindow { uuid });
         }
 
         // -- Inline (no routing) --

--- a/crates/basalt-world/src/block.rs
+++ b/crates/basalt-world/src/block.rs
@@ -31,6 +31,38 @@ pub const GRAVEL: u16 = 124;
 /// Snow block — covers high-altitude terrain tops.
 pub const SNOW_BLOCK: u16 = 5950;
 
+/// Chest — default state (facing north, type single, no waterlog).
+pub const CHEST: u16 = 3010;
+
+/// Range of block states that are chest variants (facing × type × waterlogged).
+const CHEST_MIN: u16 = 3009;
+const CHEST_MAX: u16 = 3032;
+
+/// Returns true if the block state is any chest variant.
+pub fn is_chest(state: u16) -> bool {
+    (CHEST_MIN..=CHEST_MAX).contains(&state)
+}
+
+/// Returns the chest block state for a given player yaw (facing the player).
+///
+/// The chest faces the player: if the player is looking north (yaw ~180),
+/// the chest faces south so the player sees the front.
+pub fn chest_state_for_yaw(yaw: f32) -> u16 {
+    // Normalize yaw to 0-360
+    let yaw = ((yaw % 360.0) + 360.0) % 360.0;
+    // Chest states: base 3009, facing*6 + type*2 + waterlogged
+    // type=single(0), waterlogged=false(1)
+    // facing: 0=north, 1=south, 2=west, 3=east
+    let facing = match yaw as u16 {
+        0..=45 | 316..=360 => 0, // player faces south → chest faces north
+        46..=135 => 3,           // player faces west → chest faces east
+        136..=225 => 1,          // player faces north → chest faces south
+        226..=315 => 2,          // player faces east → chest faces west
+        _ => 0,
+    };
+    3009 + facing * 6 + 1 // +1 for waterlogged=false
+}
+
 /// Maximum item ID in the lookup table.
 const MAX_ITEM_ID: usize = 1384;
 

--- a/crates/basalt-world/src/block_entity.rs
+++ b/crates/basalt-world/src/block_entity.rs
@@ -1,0 +1,45 @@
+//! Block entities — persistent per-block state.
+//!
+//! Block entities store data that standard block states cannot represent,
+//! such as chest inventories, furnace cook progress, or sign text.
+//! They are keyed by absolute world position and persisted with the chunk.
+
+use basalt_types::Slot;
+
+/// A block entity with typed data.
+///
+/// Each variant holds the state specific to that block type.
+/// New variants are added as more interactive blocks are implemented.
+#[derive(Debug, Clone)]
+pub enum BlockEntity {
+    /// A chest with 27 item slots (3 rows of 9).
+    Chest {
+        /// The 27 inventory slots.
+        slots: Box<[Slot; 27]>,
+    },
+}
+
+impl BlockEntity {
+    /// Creates a new empty chest block entity.
+    pub fn empty_chest() -> Self {
+        Self::Chest {
+            slots: Box::new(std::array::from_fn(|_| Slot::empty())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_chest_has_27_empty_slots() {
+        let be = BlockEntity::empty_chest();
+        match &be {
+            BlockEntity::Chest { slots } => {
+                assert_eq!(slots.len(), 27);
+                assert!(slots.iter().all(|s| s.is_empty()));
+            }
+        }
+    }
+}

--- a/crates/basalt-world/src/format.rs
+++ b/crates/basalt-world/src/format.rs
@@ -16,6 +16,7 @@
 //!     block_data: [u16; 4096]  — raw block state IDs (8KB)
 //! ```
 
+use crate::block_entity::BlockEntity;
 use crate::chunk::{ChunkColumn, SECTIONS_PER_CHUNK};
 use crate::palette::PalettedContainer;
 
@@ -62,10 +63,122 @@ pub fn serialize_chunk(chunk: &ChunkColumn) -> Vec<u8> {
     buf
 }
 
+/// Appends block entity data to a BSR buffer.
+///
+/// Format: `count: u32`, then for each entry:
+/// `local_x: u8, y: i16, local_z: u8, type: u8, data...`
+///
+/// Chest data: 27 × Slot (item_id: i32, count: i32 — simplified).
+pub fn serialize_block_entities(
+    buf: &mut Vec<u8>,
+    block_entities: &[(i32, i32, i32, BlockEntity)],
+    chunk_x: i32,
+    chunk_z: i32,
+) {
+    // Filter to entities in this chunk
+    let in_chunk: Vec<_> = block_entities
+        .iter()
+        .filter(|(x, _, z, _)| (x >> 4) == chunk_x && (z >> 4) == chunk_z)
+        .collect();
+
+    buf.extend_from_slice(&(in_chunk.len() as u32).to_le_bytes());
+
+    for (x, y, z, be) in in_chunk {
+        let local_x = x.rem_euclid(16) as u8;
+        let local_z = z.rem_euclid(16) as u8;
+        buf.push(local_x);
+        buf.extend_from_slice(&(*y as i16).to_le_bytes());
+        buf.push(local_z);
+
+        match be {
+            BlockEntity::Chest { slots } => {
+                buf.push(0); // type 0 = chest
+                for slot in slots.iter() {
+                    let item_id = slot.item_id.unwrap_or(-1);
+                    buf.extend_from_slice(&item_id.to_le_bytes());
+                    buf.extend_from_slice(&slot.item_count.to_le_bytes());
+                }
+            }
+        }
+    }
+}
+
+/// Deserializes block entities from BSR format appended after chunk data.
+///
+/// Returns `(local_x, y, local_z, BlockEntity)` tuples.
+pub fn deserialize_block_entities(
+    data: &[u8],
+    cursor: &mut usize,
+) -> Vec<(u8, i16, u8, BlockEntity)> {
+    let mut result = Vec::new();
+
+    if *cursor + 4 > data.len() {
+        return result;
+    }
+
+    let count = u32::from_le_bytes(data[*cursor..*cursor + 4].try_into().unwrap_or_default());
+    *cursor += 4;
+
+    for _ in 0..count {
+        if *cursor + 4 > data.len() {
+            break;
+        }
+        let local_x = data[*cursor];
+        *cursor += 1;
+        let y = i16::from_le_bytes(data[*cursor..*cursor + 2].try_into().unwrap_or_default());
+        *cursor += 2;
+        let local_z = data[*cursor];
+        *cursor += 1;
+        let be_type = data[*cursor];
+        *cursor += 1;
+
+        match be_type {
+            0 => {
+                // Chest: 27 slots × (item_id: i32 + count: i32) = 216 bytes
+                let mut slots: Box<[basalt_types::Slot; 27]> =
+                    Box::new(std::array::from_fn(|_| basalt_types::Slot::empty()));
+                for slot in slots.iter_mut() {
+                    if *cursor + 8 > data.len() {
+                        break;
+                    }
+                    let item_id = i32::from_le_bytes(
+                        data[*cursor..*cursor + 4].try_into().unwrap_or_default(),
+                    );
+                    *cursor += 4;
+                    let item_count = i32::from_le_bytes(
+                        data[*cursor..*cursor + 4].try_into().unwrap_or_default(),
+                    );
+                    *cursor += 4;
+                    if item_id >= 0 {
+                        *slot = basalt_types::Slot::new(item_id, item_count);
+                    }
+                }
+                result.push((local_x, y, local_z, BlockEntity::Chest { slots }));
+            }
+            _ => break, // Unknown type, stop
+        }
+    }
+
+    result
+}
+
+/// Deserializes a `ChunkColumn` from BSR binary format.
+///
+/// The input should be the uncompressed bytes (after LZ4 decompression).
 /// Deserializes a `ChunkColumn` from BSR binary format.
 ///
 /// The input should be the uncompressed bytes (after LZ4 decompression).
 pub fn deserialize_chunk(data: &[u8], chunk_x: i32, chunk_z: i32) -> Option<ChunkColumn> {
+    deserialize_chunk_with_cursor(data, chunk_x, chunk_z).map(|(col, _)| col)
+}
+
+/// Deserializes a `ChunkColumn` and returns the cursor position after
+/// chunk data, so the caller can continue reading block entities.
+pub fn deserialize_chunk_with_cursor(
+    data: &[u8],
+    chunk_x: i32,
+    chunk_z: i32,
+) -> Option<(ChunkColumn, usize)> {
     let mut cursor = 0;
 
     if data.len() < 4 {
@@ -115,7 +228,7 @@ pub fn deserialize_chunk(data: &[u8], chunk_x: i32, chunk_z: i32) -> Option<Chun
         }
     }
 
-    Some(chunk)
+    Some((chunk, cursor))
 }
 
 #[cfg(test)]
@@ -182,5 +295,55 @@ mod tests {
         assert_eq!(restored.get_block(0, -63, 0), block::DIRT);
         assert_eq!(restored.get_block(0, -61, 0), block::GRASS_BLOCK);
         assert_eq!(restored.get_block(0, -60, 0), block::AIR);
+    }
+
+    #[test]
+    fn block_entity_roundtrip() {
+        let mut slots: Box<[basalt_types::Slot; 27]> =
+            Box::new(std::array::from_fn(|_| basalt_types::Slot::empty()));
+        slots[0] = basalt_types::Slot::new(1, 10);
+        slots[5] = basalt_types::Slot::new(42, 64);
+
+        let bes = vec![(3, 64, 7, BlockEntity::Chest { slots })];
+
+        let mut buf = Vec::new();
+        serialize_block_entities(&mut buf, &bes, 0, 0);
+
+        let mut cursor = 0;
+        let restored = deserialize_block_entities(&buf, &mut cursor);
+
+        assert_eq!(restored.len(), 1);
+        let (lx, y, lz, be) = &restored[0];
+        assert_eq!(*lx, 3);
+        assert_eq!(*y, 64);
+        assert_eq!(*lz, 7);
+        match be {
+            BlockEntity::Chest { slots } => {
+                assert_eq!(slots[0].item_id, Some(1));
+                assert_eq!(slots[0].item_count, 10);
+                assert_eq!(slots[5].item_id, Some(42));
+                assert_eq!(slots[5].item_count, 64);
+                assert!(slots[1].is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn empty_block_entities_roundtrip() {
+        let bes: Vec<(i32, i32, i32, BlockEntity)> = vec![];
+        let mut buf = Vec::new();
+        serialize_block_entities(&mut buf, &bes, 0, 0);
+
+        let mut cursor = 0;
+        let restored = deserialize_block_entities(&buf, &mut cursor);
+        assert!(restored.is_empty());
+    }
+
+    #[test]
+    fn chunk_with_cursor_returns_correct_position() {
+        let chunk = ChunkColumn::new(0, 0);
+        let data = serialize_chunk(&chunk);
+        let (_, cursor) = deserialize_chunk_with_cursor(&data, 0, 0).unwrap();
+        assert_eq!(cursor, 4); // just the bitmap
     }
 }

--- a/crates/basalt-world/src/lib.rs
+++ b/crates/basalt-world/src/lib.rs
@@ -10,6 +10,7 @@
 //! streaming different chunks don't block each other.
 
 pub mod block;
+pub mod block_entity;
 pub mod chunk;
 pub mod collision;
 pub mod format;

--- a/crates/basalt-world/src/world.rs
+++ b/crates/basalt-world/src/world.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use basalt_storage::RegionStorage;
 use dashmap::DashMap;
 
+use crate::block_entity::BlockEntity;
 use crate::chunk::ChunkColumn;
 use crate::generator::FlatWorldGenerator;
 use crate::noise_gen::NoiseTerrainGenerator;
@@ -40,6 +41,11 @@ struct ChunkEntry {
 pub struct World {
     /// Concurrent chunk storage — each chunk independently lockable.
     chunks: DashMap<(i32, i32), ChunkEntry>,
+    /// Block entities keyed by absolute world position (x, y, z).
+    ///
+    /// Stores persistent per-block state such as chest inventories.
+    /// Separate from chunk data for independent locking.
+    block_entities: DashMap<(i32, i32, i32), BlockEntity>,
     /// The terrain generator used for new chunks.
     generator: Generator,
     /// The Y coordinate where players spawn.
@@ -67,6 +73,7 @@ impl World {
         let storage = RegionStorage::new(save_path.join("regions")).ok();
         Self {
             chunks: DashMap::new(),
+            block_entities: DashMap::new(),
             generator: Generator::Noise(Box::new(NoiseTerrainGenerator::new(seed))),
             spawn_y: NoiseTerrainGenerator::SPAWN_Y,
             storage,
@@ -85,6 +92,7 @@ impl World {
     pub fn new_memory_with_capacity(seed: u32, max_chunks: usize) -> Self {
         Self {
             chunks: DashMap::new(),
+            block_entities: DashMap::new(),
             generator: Generator::Noise(Box::new(NoiseTerrainGenerator::new(seed))),
             spawn_y: NoiseTerrainGenerator::SPAWN_Y,
             storage: None,
@@ -97,6 +105,7 @@ impl World {
     pub fn flat() -> Self {
         Self {
             chunks: DashMap::new(),
+            block_entities: DashMap::new(),
             generator: Generator::Flat(FlatWorldGenerator),
             spawn_y: FlatWorldGenerator::SPAWN_Y,
             storage: None,
@@ -144,6 +153,16 @@ impl World {
         entry.last_accessed = self.tick.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Marks a chunk as dirty for persistence.
+    ///
+    /// Call after modifying block entity contents (chest inventory, etc.)
+    /// to ensure the chunk is included in the next persistence flush.
+    pub fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
+        if let Some(mut entry) = self.chunks.get_mut(&(cx, cz)) {
+            entry.dirty = true;
+        }
+    }
+
     /// Gets a block at absolute world coordinates.
     ///
     /// Loads the chunk if it isn't already in memory.
@@ -169,7 +188,10 @@ impl World {
         if let Some(s) = &self.storage
             && let Some(mut entry) = self.chunks.get_mut(&(cx, cz))
         {
-            let data = crate::format::serialize_chunk(&entry.column);
+            let mut data = crate::format::serialize_chunk(&entry.column);
+            // Append block entities for this chunk
+            let bes = self.block_entities_in_chunk(cx, cz);
+            crate::format::serialize_block_entities(&mut data, &bes, cx, cz);
             let _ = s.save_raw(cx, cz, &data);
             entry.dirty = false;
         }
@@ -187,6 +209,63 @@ impl World {
             .map(|e| *e.key())
             .collect()
     }
+
+    // ── Block entities ────────────────────────────────────────────
+
+    /// Returns a reference to the block entity at the given position.
+    pub fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<dashmap::mapref::one::Ref<'_, (i32, i32, i32), BlockEntity>> {
+        self.block_entities.get(&(x, y, z))
+    }
+
+    /// Returns a mutable reference to the block entity at the given position.
+    pub fn get_block_entity_mut(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<dashmap::mapref::one::RefMut<'_, (i32, i32, i32), BlockEntity>> {
+        self.block_entities.get_mut(&(x, y, z))
+    }
+
+    /// Sets a block entity at the given position.
+    pub fn set_block_entity(&self, x: i32, y: i32, z: i32, entity: BlockEntity) {
+        self.block_entities.insert((x, y, z), entity);
+    }
+
+    /// Removes the block entity at the given position.
+    pub fn remove_block_entity(&self, x: i32, y: i32, z: i32) {
+        self.block_entities.remove(&(x, y, z));
+    }
+
+    /// Returns all block entities within a chunk's boundaries.
+    ///
+    /// Used by the chunk packet builder to include block entity data
+    /// in the map chunk packet for client-side rendering.
+    pub fn block_entities_in_chunk(&self, cx: i32, cz: i32) -> Vec<(i32, i32, i32, BlockEntity)> {
+        let min_x = cx * 16;
+        let max_x = min_x + 15;
+        let min_z = cz * 16;
+        let max_z = min_z + 15;
+
+        self.block_entities
+            .iter()
+            .filter(|e| {
+                let &(x, _, z) = e.key();
+                x >= min_x && x <= max_x && z >= min_z && z <= max_z
+            })
+            .map(|e| {
+                let &(x, y, z) = e.key();
+                (x, y, z, e.value().clone())
+            })
+            .collect()
+    }
+
+    // ── Chunk queries ────────────────────────────────────────────
 
     /// Returns true if the chunk at (cx, cz) is in the memory cache.
     pub fn is_chunk_loaded(&self, cx: i32, cz: i32) -> bool {
@@ -208,8 +287,18 @@ impl World {
         // Try loading from disk
         if let Some(s) = &self.storage
             && let Ok(Some(data)) = s.load_raw(cx, cz)
-            && let Some(col) = crate::format::deserialize_chunk(&data, cx, cz)
+            && let Some((col, cursor_pos)) =
+                crate::format::deserialize_chunk_with_cursor(&data, cx, cz)
         {
+            // Restore block entities from the data after chunk sections
+            let mut cursor = cursor_pos;
+            let bes = crate::format::deserialize_block_entities(&data, &mut cursor);
+            for (local_x, y, local_z, be) in bes {
+                let abs_x = cx * 16 + local_x as i32;
+                let abs_z = cz * 16 + local_z as i32;
+                self.block_entities.insert((abs_x, y as i32, abs_z), be);
+            }
+
             let tick = self.tick.fetch_add(1, Ordering::Relaxed);
             self.chunks.insert(
                 (cx, cz),


### PR DESCRIPTION
## Summary

- Block entities: DashMap in World for per-block state, chest = 27 item slots
- Container window: right-click opens OpenScreen, WindowClick handles slot moves, Q key drops, click outside drops cursor
- Multi-viewer: slot changes broadcast to all players viewing same chest
- Persistence: BSR format extended with block entity data, restored on chunk load
- Chunk packets include block entity entries for client-side chest rendering
- OpenContainer ECS component + window ID cycling (1-127)

## Test plan

- [x] All tests pass
- [x] Clippy clean
- [ ] Manual: place chest, put items in, reconnect — chest visible and contents preserved
- [ ] Manual: two players view same chest, slot changes sync
- [ ] Manual: Q key drop from open chest
- [ ] Manual: break chest — block entity removed

Closes #133
