### PR TITLE
fix(codegen): anonOptionalNbt generates NbtCompound without bool prefix

### DIFF
--- a/crates/basalt-protocol/src/packets/play/world.rs
+++ b/crates/basalt-protocol/src/packets/play/world.rs
@@ -196,8 +196,7 @@ pub struct ClientboundPlayMapChunkChunkblockentity {
     pub y: i16,
     #[field(varint)]
     pub r#type: i32,
-    #[field(optional)]
-    pub nbt_data: Option<NbtCompound>,
+    pub nbt_data: NbtCompound,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -237,8 +236,7 @@ pub struct ClientboundPlayMultiBlockChange {
 pub struct ClientboundPlayNbtQueryResponse {
     #[field(varint)]
     pub transaction_id: i32,
-    #[field(optional)]
-    pub nbt: Option<NbtCompound>,
+    pub nbt: NbtCompound,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -254,8 +252,7 @@ pub struct ClientboundPlayTileEntityData {
     pub location: Position,
     #[field(varint)]
     pub action: i32,
-    #[field(optional)]
-    pub nbt_data: Option<NbtCompound>,
+    pub nbt_data: NbtCompound,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/xtask/src/types.rs
+++ b/xtask/src/types.rs
@@ -135,7 +135,7 @@ impl ProtocolType {
             Self::Uuid => ("Uuid".into(), None),
             Self::Position => ("Position".into(), None),
             Self::NbtCompound => ("NbtCompound".into(), None),
-            Self::OptionalNbt => ("Option<NbtCompound>".into(), Some("optional".into())),
+            Self::OptionalNbt => ("NbtCompound".into(), None),
             Self::Slot => ("Slot".into(), None),
             Self::Vec2f => ("Vec2f".into(), None),
             Self::Vec3f => ("Vec3f".into(), None),
@@ -258,7 +258,7 @@ mod tests {
         );
         assert_eq!(
             ProtocolType::OptionalNbt.to_rust(),
-            ("Option<NbtCompound>".into(), Some("optional".into()))
+            ("NbtCompound".into(), None)
         );
     }
 


### PR DESCRIPTION
## Summary

anonOptionalNbt was mapped to Option<NbtCompound> with #[field(optional)], which encodes a boolean prefix before the NBT data. The actual MC protocol always has NBT present (compound or empty) — no bool prefix.

Changed to NbtCompound with no attribute. Affects TileEntityData.nbt_data and MapChunk block_entities.nbt_data.

## Test plan

- [x] All tests pass
- [x] Clippy clean
- [x] Codegen drift check passes (regenerated packets match)

Closes #140
