### PR TITLE
fix(server): chest visibility, drops, double chests, sneak, ContainerView

### DIFF
--- a/crates/basalt-server/src/game/tick.rs
+++ b/crates/basalt-server/src/game/tick.rs
@@ -43,6 +43,100 @@ impl basalt_ecs::Component for OutputHandle {}
 struct Sneaking;
 impl basalt_ecs::Component for Sneaking {}
 
+/// A part of a container backed by a block entity.
+///
+/// Each part maps a range of window slots to a block entity at a
+/// specific position. A single chest has one part (27 slots), a
+/// double chest has two (27 + 27 = 54).
+#[derive(Debug, Clone)]
+struct ContainerPart {
+    /// Block position of this container part.
+    position: (i32, i32, i32),
+    /// First window slot index for this part.
+    slot_offset: usize,
+    /// Number of slots in this part.
+    slot_count: usize,
+}
+
+/// Describes an open container window.
+///
+/// Abstracts single chests, double chests, and future container types.
+/// The game loop builds a `ContainerView` when opening a container,
+/// and uses it to route window clicks to the correct block entity.
+#[derive(Debug, Clone)]
+struct ContainerView {
+    /// Total number of container slots (before player inventory).
+    size: usize,
+    /// The parts that compose this container.
+    parts: Vec<ContainerPart>,
+    /// Minecraft window inventory type (2 = 9x3, 5 = 9x6, etc.).
+    inventory_type: i32,
+    /// Window title.
+    title: String,
+}
+
+impl ContainerView {
+    /// Creates a view for a single chest.
+    fn single_chest(pos: (i32, i32, i32)) -> Self {
+        Self {
+            size: 27,
+            parts: vec![ContainerPart {
+                position: pos,
+                slot_offset: 0,
+                slot_count: 27,
+            }],
+            inventory_type: 2, // generic_9x3
+            title: "Chest".into(),
+        }
+    }
+
+    /// Creates a view for a double chest (left half first).
+    fn double_chest(left: (i32, i32, i32), right: (i32, i32, i32)) -> Self {
+        Self {
+            size: 54,
+            parts: vec![
+                ContainerPart {
+                    position: left,
+                    slot_offset: 0,
+                    slot_count: 27,
+                },
+                ContainerPart {
+                    position: right,
+                    slot_offset: 27,
+                    slot_count: 27,
+                },
+            ],
+            inventory_type: 5, // generic_9x6
+            title: "Large Chest".into(),
+        }
+    }
+
+    /// Finds which part owns a window slot and returns (position, local_index).
+    fn slot_to_part(&self, window_slot: i16) -> Option<((i32, i32, i32), usize)> {
+        let ws = window_slot as usize;
+        for part in &self.parts {
+            if ws >= part.slot_offset && ws < part.slot_offset + part.slot_count {
+                return Some((part.position, ws - part.slot_offset));
+            }
+        }
+        None
+    }
+
+    /// Maps a window slot to a player inventory index (after container slots).
+    fn slot_to_player_inv(&self, window_slot: i16) -> Option<usize> {
+        let ws = window_slot as usize;
+        if ws >= self.size && ws < self.size + 27 {
+            // Main inventory: internal 9-35
+            Some(ws - self.size + 9)
+        } else if ws >= self.size + 27 && ws < self.size + 36 {
+            // Hotbar: internal 0-8
+            Some(ws - self.size - 27)
+        } else {
+            None
+        }
+    }
+}
+
 /// Mojang skin texture data.
 ///
 /// Server-internal component storing skin properties for broadcasting
@@ -509,6 +603,31 @@ impl GameLoop {
                                 item_id,
                                 cursor_item.item_count,
                             );
+                        }
+                        // Broadcast chest close animation if no other viewers
+                        if let Some(oc) = self.ecs.get::<basalt_ecs::OpenContainer>(eid) {
+                            let pos = oc.position;
+                            let remaining = self
+                                .ecs
+                                .iter::<basalt_ecs::OpenContainer>()
+                                .filter(|(id, oc2)| *id != eid && oc2.position == pos)
+                                .count() as u8;
+                            let view = self.build_chest_view(pos.0, pos.1, pos.2);
+                            for part in &view.parts {
+                                let (px, py, pz) = part.position;
+                                for (e, _) in self.ecs.iter::<OutputHandle>() {
+                                    self.send_to(e, |tx| {
+                                        let _ = tx.try_send(ServerOutput::BlockAction {
+                                            x: px,
+                                            y: py,
+                                            z: pz,
+                                            action_id: 1,
+                                            action_param: remaining,
+                                            block_id: 185,
+                                        });
+                                    });
+                                }
+                            }
                         }
                         self.ecs.remove_component::<basalt_ecs::OpenContainer>(eid);
                     }
@@ -1424,65 +1543,80 @@ impl GameLoop {
                 basalt_world::block_entity::BlockEntity::empty_chest(),
             );
 
-            // Check for adjacent single chest to form a double chest
-            // Sneaking prevents pairing (vanilla behavior)
+            // Double chest pairing logic:
+            // - Not sneaking: scan adjacent blocks for a single chest to pair with
+            // - Sneaking + clicked a chest: pair only with the clicked chest
+            // - Sneaking + clicked non-chest: no pairing (single chest)
             let facing = basalt_world::block::chest_facing(block_state);
-            let offsets = basalt_world::block::chest_adjacent_offsets(facing);
             let mut paired = false;
-            if !is_sneaking {
-                for (dx, dz) in offsets {
-                    let nx = px + dx;
-                    let nz = pz + dz;
-                    let neighbor = self.world.get_block(nx, py, nz);
-                    if basalt_world::block::is_single_chest(neighbor)
-                        && basalt_world::block::chest_facing(neighbor) == facing
-                    {
-                        let (new_type, existing_type) =
-                            basalt_world::block::chest_double_types(facing, dx, dz);
-                        // Update new chest to left/right
-                        let new_state = basalt_world::block::chest_state(facing, new_type);
-                        self.world.set_block(px, py, pz, new_state);
-                        // Update existing chest to the other type
-                        let neighbor_state =
-                            basalt_world::block::chest_state(facing, existing_type);
-                        self.world.set_block(nx, py, nz, neighbor_state);
-                        // Invalidate chunk caches
-                        self.chunk_cache.invalidate(px >> 4, pz >> 4);
-                        self.chunk_cache.invalidate(nx >> 4, nz >> 4);
-                        // Broadcast both block changes
-                        for (e, _) in self.ecs.iter::<OutputHandle>() {
-                            self.send_to(e, |tx| {
-                                let _ = tx.try_send(ServerOutput::BlockChanged {
-                                    x: px,
-                                    y: py,
-                                    z: pz,
-                                    state: i32::from(new_state),
-                                });
-                                let _ = tx.try_send(ServerOutput::BlockEntityData {
-                                    x: px,
-                                    y: py,
-                                    z: pz,
-                                    action: 2,
-                                });
-                                let _ = tx.try_send(ServerOutput::BlockChanged {
-                                    x: nx,
-                                    y: py,
-                                    z: nz,
-                                    state: i32::from(neighbor_state),
-                                });
-                                let _ = tx.try_send(ServerOutput::BlockEntityData {
-                                    x: nx,
-                                    y: py,
-                                    z: nz,
-                                    action: 2,
-                                });
-                            });
-                        }
-                        paired = true;
-                        break;
-                    }
+
+            // Build candidate list: either all adjacent or just the clicked chest
+            let candidates: Vec<(i32, i32)> = if !is_sneaking {
+                basalt_world::block::chest_adjacent_offsets(facing)
+                    .iter()
+                    .map(|&(ddx, ddz)| (px + ddx, pz + ddz))
+                    .collect()
+            } else if basalt_world::block::is_chest(clicked_state) {
+                // Sneaking on a chest: pair only if new chest is lateral (left/right)
+                let valid_offsets = basalt_world::block::chest_adjacent_offsets(facing);
+                let actual_offset = (px - x, pz - z);
+                if valid_offsets.contains(&actual_offset) {
+                    vec![(x, z)]
+                } else {
+                    vec![] // front/back placement: no pairing
                 }
-            } // end if !is_sneaking
+            } else {
+                vec![] // sneaking on non-chest: no pairing
+            };
+
+            for &(nx, nz) in &candidates {
+                let neighbor = self.world.get_block(nx, py, nz);
+                if basalt_world::block::is_single_chest(neighbor)
+                    && basalt_world::block::chest_facing(neighbor) == facing
+                {
+                    // Compute offset from new chest to neighbor
+                    let ddx = nx - px;
+                    let ddz = nz - pz;
+                    let (new_type, existing_type) =
+                        basalt_world::block::chest_double_types(facing, ddx, ddz);
+                    let new_state = basalt_world::block::chest_state(facing, new_type);
+                    self.world.set_block(px, py, pz, new_state);
+                    let neighbor_state = basalt_world::block::chest_state(facing, existing_type);
+                    self.world.set_block(nx, py, nz, neighbor_state);
+                    self.chunk_cache.invalidate(px >> 4, pz >> 4);
+                    self.chunk_cache.invalidate(nx >> 4, nz >> 4);
+                    for (e, _) in self.ecs.iter::<OutputHandle>() {
+                        self.send_to(e, |tx| {
+                            let _ = tx.try_send(ServerOutput::BlockChanged {
+                                x: px,
+                                y: py,
+                                z: pz,
+                                state: i32::from(new_state),
+                            });
+                            let _ = tx.try_send(ServerOutput::BlockEntityData {
+                                x: px,
+                                y: py,
+                                z: pz,
+                                action: 2,
+                            });
+                            let _ = tx.try_send(ServerOutput::BlockChanged {
+                                x: nx,
+                                y: py,
+                                z: nz,
+                                state: i32::from(neighbor_state),
+                            });
+                            let _ = tx.try_send(ServerOutput::BlockEntityData {
+                                x: nx,
+                                y: py,
+                                z: nz,
+                                action: 2,
+                            });
+                        });
+                    }
+                    paired = true;
+                    break;
+                }
+            }
 
             if !paired {
                 // Single chest — broadcast normally
@@ -1719,55 +1853,124 @@ impl GameLoop {
                 basalt_world::block_entity::BlockEntity::empty_chest(),
             );
         }
+        let view = self.build_chest_view(x, y, z);
+        self.open_container(eid, &view);
+    }
 
+    /// Opens a container window for a player using a generic ContainerView.
+    fn open_container(&mut self, eid: basalt_ecs::EntityId, view: &ContainerView) {
         let window_id = self.alloc_window_id();
+        let mut window_slots = Vec::with_capacity(view.size + 36);
 
-        // Build the container window slots: 27 chest + 36 player inventory
-        let mut window_slots = Vec::with_capacity(63);
-
-        // Chest slots (0-26)
-        if let Some(be) = self.world.get_block_entity(x, y, z) {
-            match &*be {
-                basalt_world::block_entity::BlockEntity::Chest { slots } => {
-                    window_slots.extend_from_slice(slots.as_ref());
+        // Container slots from block entities
+        for part in &view.parts {
+            let (px, py, pz) = part.position;
+            if self.world.get_block_entity(px, py, pz).is_none() {
+                self.world.set_block_entity(
+                    px,
+                    py,
+                    pz,
+                    basalt_world::block_entity::BlockEntity::empty_chest(),
+                );
+            }
+            if let Some(be) = self.world.get_block_entity(px, py, pz) {
+                match &*be {
+                    basalt_world::block_entity::BlockEntity::Chest { slots } => {
+                        window_slots.extend_from_slice(&slots[..part.slot_count.min(slots.len())]);
+                    }
                 }
             }
         }
 
-        // Player main inventory (window 27-53) = internal 9-35
-        // Player hotbar (window 54-62) = internal 0-8
+        // Player inventory
         if let Some(inv) = self.ecs.get::<basalt_ecs::Inventory>(eid) {
-            window_slots.extend_from_slice(&inv.slots[9..]); // main: 27 slots
-            window_slots.extend_from_slice(&inv.slots[..9]); // hotbar: 9 slots
+            window_slots.extend_from_slice(&inv.slots[9..]); // main
+            window_slots.extend_from_slice(&inv.slots[..9]); // hotbar
         }
 
-        // Set OpenContainer on the player
+        let container_pos = view.parts.first().map_or((0, 0, 0), |p| p.position);
         self.ecs.set(
             eid,
             basalt_ecs::OpenContainer {
                 window_id,
-                position: (x, y, z),
+                position: container_pos,
             },
         );
 
-        // Send OpenWindow + contents
-        let title = basalt_types::TextComponent::text("Chest").to_nbt();
         self.send_to(eid, |tx| {
             let _ = tx.try_send(ServerOutput::OpenWindow {
                 window_id,
-                inventory_type: 2, // generic_9x3
-                title,
+                inventory_type: view.inventory_type,
+                title: basalt_types::TextComponent::text(&view.title).to_nbt(),
                 slots: window_slots,
             });
         });
+
+        // Broadcast chest open animation to all players
+        // Count how many players are viewing each part
+        for part in &view.parts {
+            let (px, py, pz) = part.position;
+            let viewer_count = self
+                .ecs
+                .iter::<basalt_ecs::OpenContainer>()
+                .filter(|(_, oc)| oc.position == container_pos)
+                .count() as u8;
+            for (e, _) in self.ecs.iter::<OutputHandle>() {
+                self.send_to(e, |tx| {
+                    let _ = tx.try_send(ServerOutput::BlockAction {
+                        x: px,
+                        y: py,
+                        z: pz,
+                        action_id: 1,
+                        action_param: viewer_count.max(1),
+                        block_id: 185, // chest block registry ID
+                    });
+                });
+            }
+        }
+    }
+
+    /// Builds a ContainerView for a chest at the given position.
+    fn build_chest_view(&self, x: i32, y: i32, z: i32) -> ContainerView {
+        let state = self.world.get_block(x, y, z);
+        let ct = basalt_world::block::chest_type(state);
+        if ct == 0 {
+            return ContainerView::single_chest((x, y, z));
+        }
+        let facing = basalt_world::block::chest_facing(state);
+        let other = basalt_world::block::chest_adjacent_offsets(facing)
+            .iter()
+            .find_map(|&(dx, dz)| {
+                let nx = x + dx;
+                let nz = z + dz;
+                let n = self.world.get_block(nx, y, nz);
+                if basalt_world::block::is_chest(n)
+                    && basalt_world::block::chest_facing(n) == facing
+                    && basalt_world::block::chest_type(n) != 0
+                    && basalt_world::block::chest_type(n) != ct
+                {
+                    Some((nx, y, nz))
+                } else {
+                    None
+                }
+            });
+        match other {
+            Some(other_pos) => {
+                let (left, right) = if ct == 1 {
+                    ((x, y, z), other_pos)
+                } else {
+                    (other_pos, (x, y, z))
+                };
+                ContainerView::double_chest(left, right)
+            }
+            None => ContainerView::single_chest((x, y, z)),
+        }
     }
 
     /// Handles a WindowClick that targets an open container.
     ///
-    /// Container window slot layout for generic_9x3 (chest):
-    /// - 0-26: chest slots
-    /// - 27-53: player main inventory (our 9-35)
-    /// - 54-62: player hotbar (our 0-8)
+    /// Uses [`ContainerView`] to generically route slots to the correct
+    /// block entity or player inventory.
     fn handle_container_click(
         &mut self,
         eid: basalt_ecs::EntityId,
@@ -1775,38 +1978,29 @@ impl GameLoop {
         changed_slots: &[(i16, basalt_types::Slot)],
         cursor_item: basalt_types::Slot,
     ) {
-        let (cx, cy, cz) = container_pos;
+        let view = self.build_chest_view(container_pos.0, container_pos.1, container_pos.2);
 
         for (window_slot, item) in changed_slots {
-            let ws = *window_slot;
-            if (0..27).contains(&ws) {
-                // Chest slot
-                if let Some(mut be) = self.world.get_block_entity_mut(cx, cy, cz) {
+            if let Some((pos, local_idx)) = view.slot_to_part(*window_slot) {
+                // Container slot → update block entity
+                if let Some(mut be) = self.world.get_block_entity_mut(pos.0, pos.1, pos.2) {
                     match &mut *be {
                         basalt_world::block_entity::BlockEntity::Chest { slots } => {
-                            slots[ws as usize] = item.clone();
+                            if local_idx < slots.len() {
+                                slots[local_idx] = item.clone();
+                            }
                         }
                     }
                 }
-                // Mark chunk dirty for persistence
-                self.world.mark_chunk_dirty(cx >> 4, cz >> 4);
-                // Invalidate chunk cache (block entity data changed)
-                self.chunk_cache.invalidate(cx >> 4, cz >> 4);
-                // Notify other viewers
-                self.notify_container_viewers(container_pos, eid, ws, item);
-            } else if (27..54).contains(&ws) {
-                // Player main inventory: window 27-53 → internal 9-35
-                let idx = (ws - 27 + 9) as usize;
+                self.world.mark_chunk_dirty(pos.0 >> 4, pos.2 >> 4);
+                self.chunk_cache.invalidate(pos.0 >> 4, pos.2 >> 4);
+                self.notify_container_viewers(container_pos, eid, *window_slot, item);
+            } else if let Some(inv_idx) = view.slot_to_player_inv(*window_slot) {
+                // Player inventory slot
                 if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid)
-                    && idx < 36
+                    && inv_idx < 36
                 {
-                    inv.slots[idx] = item.clone();
-                }
-            } else if (54..63).contains(&ws) {
-                // Player hotbar: window 54-62 → internal 0-8
-                let idx = (ws - 54) as usize;
-                if let Some(inv) = self.ecs.get_mut::<basalt_ecs::Inventory>(eid) {
-                    inv.slots[idx] = item.clone();
+                    inv.slots[inv_idx] = item.clone();
                 }
             }
         }

--- a/crates/basalt-server/src/game/tick.rs
+++ b/crates/basalt-server/src/game/tick.rs
@@ -36,6 +36,13 @@ struct OutputHandle {
 }
 impl basalt_ecs::Component for OutputHandle {}
 
+/// Whether a player is currently sneaking (shift key held).
+///
+/// Affects block interaction: sneaking players place blocks instead
+/// of opening containers.
+struct Sneaking;
+impl basalt_ecs::Component for Sneaking {}
+
 /// Mojang skin texture data.
 ///
 /// Server-internal component storing skin properties for broadcasting
@@ -504,6 +511,19 @@ impl GameLoop {
                             );
                         }
                         self.ecs.remove_component::<basalt_ecs::OpenContainer>(eid);
+                    }
+                }
+                GameInput::EntityAction {
+                    uuid, action_id, ..
+                } => {
+                    if let Some(eid) = self.ecs.find_by_uuid(uuid) {
+                        match action_id {
+                            0 => self.ecs.set(eid, Sneaking), // start sneak
+                            1 => {
+                                self.ecs.remove_component::<Sneaking>(eid);
+                            } // stop sneak
+                            _ => {}
+                        }
                     }
                 }
             }
@@ -1265,8 +1285,57 @@ impl GameLoop {
 
         self.process_responses(uuid, &ctx.drain_responses());
 
-        // Remove block entity if the broken block had one
+        // Collect items to drop from block entity before removing it
+        let items_to_drop: Vec<(i32, i32)> = self
+            .world
+            .get_block_entity(x, y, z)
+            .map(|be| match &*be {
+                basalt_world::block_entity::BlockEntity::Chest { slots } => slots
+                    .iter()
+                    .filter_map(|s| s.item_id.map(|id| (id, s.item_count)))
+                    .collect(),
+            })
+            .unwrap_or_default();
+
         self.world.remove_block_entity(x, y, z);
+
+        // Spawn dropped items for chest contents
+        for (item_id, count) in items_to_drop {
+            self.spawn_item_entity(x, y, z, item_id, count);
+        }
+
+        // If this was part of a double chest, revert the other half to single
+        if basalt_world::block::is_chest(original_state)
+            && basalt_world::block::chest_type(original_state) != 0
+        {
+            let facing = basalt_world::block::chest_facing(original_state);
+            let offsets = basalt_world::block::chest_adjacent_offsets(facing);
+            for (dx, dz) in offsets {
+                let nx = x + dx;
+                let nz = z + dz;
+                let neighbor = self.world.get_block(nx, y, nz);
+                if basalt_world::block::is_chest(neighbor)
+                    && basalt_world::block::chest_facing(neighbor) == facing
+                    && basalt_world::block::chest_type(neighbor) != 0
+                {
+                    let single = basalt_world::block::chest_state(facing, 0);
+                    self.world.set_block(nx, y, nz, single);
+                    self.chunk_cache.invalidate(nx >> 4, nz >> 4);
+                    let bc = Arc::new(SharedBroadcast::new(BroadcastEvent::BlockChanged {
+                        x: nx,
+                        y,
+                        z: nz,
+                        state: i32::from(single),
+                    }));
+                    for (e, _) in self.ecs.iter::<OutputHandle>() {
+                        self.send_to(e, |tx| {
+                            let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&bc)));
+                        });
+                    }
+                    break;
+                }
+            }
+        }
     }
 
     /// Handles a block place.
@@ -1284,8 +1353,10 @@ impl GameLoop {
         };
 
         // Check if the clicked block is an interactable container
+        // Sneaking players skip interaction and place blocks instead
+        let is_sneaking = self.ecs.has::<Sneaking>(eid);
         let clicked_state = self.world.get_block(x, y, z);
-        if basalt_world::block::is_chest(clicked_state) {
+        if !is_sneaking && basalt_world::block::is_chest(clicked_state) {
             self.open_chest(eid, x, y, z);
             return;
         }
@@ -1352,23 +1423,85 @@ impl GameLoop {
                 pz,
                 basalt_world::block_entity::BlockEntity::empty_chest(),
             );
-            // Tell all players about the block entity so the chest renders
-            let bc = Arc::new(SharedBroadcast::new(BroadcastEvent::BlockChanged {
-                x: px,
-                y: py,
-                z: pz,
-                state: i32::from(block_state),
-            }));
-            for (e, _) in self.ecs.iter::<OutputHandle>() {
-                self.send_to(e, |tx| {
-                    let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&bc)));
-                    let _ = tx.try_send(ServerOutput::BlockEntityData {
-                        x: px,
-                        y: py,
-                        z: pz,
-                        action: 2,
+
+            // Check for adjacent single chest to form a double chest
+            // Sneaking prevents pairing (vanilla behavior)
+            let facing = basalt_world::block::chest_facing(block_state);
+            let offsets = basalt_world::block::chest_adjacent_offsets(facing);
+            let mut paired = false;
+            if !is_sneaking {
+                for (dx, dz) in offsets {
+                    let nx = px + dx;
+                    let nz = pz + dz;
+                    let neighbor = self.world.get_block(nx, py, nz);
+                    if basalt_world::block::is_single_chest(neighbor)
+                        && basalt_world::block::chest_facing(neighbor) == facing
+                    {
+                        let (new_type, existing_type) =
+                            basalt_world::block::chest_double_types(facing, dx, dz);
+                        // Update new chest to left/right
+                        let new_state = basalt_world::block::chest_state(facing, new_type);
+                        self.world.set_block(px, py, pz, new_state);
+                        // Update existing chest to the other type
+                        let neighbor_state =
+                            basalt_world::block::chest_state(facing, existing_type);
+                        self.world.set_block(nx, py, nz, neighbor_state);
+                        // Invalidate chunk caches
+                        self.chunk_cache.invalidate(px >> 4, pz >> 4);
+                        self.chunk_cache.invalidate(nx >> 4, nz >> 4);
+                        // Broadcast both block changes
+                        for (e, _) in self.ecs.iter::<OutputHandle>() {
+                            self.send_to(e, |tx| {
+                                let _ = tx.try_send(ServerOutput::BlockChanged {
+                                    x: px,
+                                    y: py,
+                                    z: pz,
+                                    state: i32::from(new_state),
+                                });
+                                let _ = tx.try_send(ServerOutput::BlockEntityData {
+                                    x: px,
+                                    y: py,
+                                    z: pz,
+                                    action: 2,
+                                });
+                                let _ = tx.try_send(ServerOutput::BlockChanged {
+                                    x: nx,
+                                    y: py,
+                                    z: nz,
+                                    state: i32::from(neighbor_state),
+                                });
+                                let _ = tx.try_send(ServerOutput::BlockEntityData {
+                                    x: nx,
+                                    y: py,
+                                    z: nz,
+                                    action: 2,
+                                });
+                            });
+                        }
+                        paired = true;
+                        break;
+                    }
+                }
+            } // end if !is_sneaking
+
+            if !paired {
+                // Single chest — broadcast normally
+                for (e, _) in self.ecs.iter::<OutputHandle>() {
+                    self.send_to(e, |tx| {
+                        let _ = tx.try_send(ServerOutput::BlockChanged {
+                            x: px,
+                            y: py,
+                            z: pz,
+                            state: i32::from(block_state),
+                        });
+                        let _ = tx.try_send(ServerOutput::BlockEntityData {
+                            x: px,
+                            y: py,
+                            z: pz,
+                            action: 2,
+                        });
                     });
-                });
+                }
             }
         }
     }
@@ -1711,6 +1844,9 @@ impl GameLoop {
     /// Sends a chunk to a player and follows up with BlockEntityData
     /// for any block entities in that chunk (chests, etc.).
     fn send_chunk_with_entities(&self, eid: basalt_ecs::EntityId, cx: i32, cz: i32) {
+        // Force chunk + block entities to be loaded from disk before querying
+        self.world.with_chunk(cx, cz, |_| {});
+
         self.send_to(eid, |tx| {
             let _ = tx.try_send(ServerOutput::SendChunk { cx, cz });
         });
@@ -1846,6 +1982,7 @@ mod tests {
                 Arc::clone(&world),
             );
             basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
+            basalt_plugin_drops::DropsPlugin.on_enable(&mut registrar);
         }
 
         let mut ecs = basalt_ecs::Ecs::new();
@@ -2893,6 +3030,165 @@ mod tests {
         assert!(
             inv.cursor.is_empty(),
             "cursor should be empty after drop outside container"
+        );
+    }
+
+    #[test]
+    fn chest_break_drops_contents_and_self() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        // Place chest with items inside
+        game_loop
+            .world
+            .set_block(5, 64, 3, basalt_world::block::CHEST);
+        let mut be = basalt_world::block_entity::BlockEntity::empty_chest();
+        let basalt_world::block_entity::BlockEntity::Chest { ref mut slots } = be;
+        slots[0] = basalt_types::Slot::new(42, 16);
+        game_loop.world.set_block_entity(5, 64, 3, be);
+
+        // Break it
+        let _ = game_tx.send(GameInput::BlockDig {
+            uuid,
+            status: 0,
+            x: 5,
+            y: 64,
+            z: 3,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+
+        // Block entity removed
+        assert!(game_loop.world.get_block_entity(5, 64, 3).is_none());
+
+        // Should have spawned dropped items (chest contents + chest block itself)
+        let mut spawn_count = 0;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(&msg, ServerOutput::Broadcast(bc) if matches!(bc.event, BroadcastEvent::SpawnItemEntity { .. }))
+            {
+                spawn_count += 1;
+            }
+        }
+        // At least 2 spawns: 1 for the item inside + 1 for the chest block itself
+        assert!(
+            spawn_count >= 2,
+            "should drop chest contents + chest block, got {spawn_count} spawns"
+        );
+    }
+
+    #[test]
+    fn double_chest_forms_on_adjacent_placement() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let eid = game_loop.ecs.find_by_uuid(uuid).unwrap();
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Rotation>(eid)
+            .unwrap()
+            .yaw = 0.0; // facing south → chest faces north
+
+        // Place first chest
+        game_loop
+            .ecs
+            .get_mut::<basalt_ecs::Inventory>(eid)
+            .unwrap()
+            .slots[0] = basalt_types::Slot::new(313, 2);
+
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 5,
+            y: -60,
+            z: 3,
+            direction: 1,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+
+        let first_state = game_loop.world.get_block(5, -59, 3);
+        assert!(
+            basalt_world::block::is_single_chest(first_state),
+            "first chest should be single"
+        );
+
+        // Place second chest adjacent (east, +X)
+        let _ = game_tx.send(GameInput::BlockPlace {
+            uuid,
+            x: 6,
+            y: -60,
+            z: 3,
+            direction: 1,
+            sequence: 2,
+        });
+        game_loop.tick(2);
+
+        let left = game_loop.world.get_block(5, -59, 3);
+        let right = game_loop.world.get_block(6, -59, 3);
+        assert!(basalt_world::block::is_chest(left), "left should be chest");
+        assert!(
+            basalt_world::block::is_chest(right),
+            "right should be chest"
+        );
+        assert_ne!(
+            basalt_world::block::chest_type(left),
+            0,
+            "left should not be single"
+        );
+        assert_ne!(
+            basalt_world::block::chest_type(right),
+            0,
+            "right should not be single"
+        );
+        assert_ne!(
+            basalt_world::block::chest_type(left),
+            basalt_world::block::chest_type(right),
+            "left and right should have different types"
+        );
+    }
+
+    #[test]
+    fn breaking_double_chest_reverts_other_to_single() {
+        let (mut game_loop, game_tx, _io_rx) = test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Manually place a double chest (north-facing, left at x=5, right at x=6)
+        let left_state = basalt_world::block::chest_state(0, 1); // north, left
+        let right_state = basalt_world::block::chest_state(0, 2); // north, right
+        game_loop.world.set_block(5, 64, 3, left_state);
+        game_loop.world.set_block(6, 64, 3, right_state);
+        game_loop.world.set_block_entity(
+            5,
+            64,
+            3,
+            basalt_world::block_entity::BlockEntity::empty_chest(),
+        );
+        game_loop.world.set_block_entity(
+            6,
+            64,
+            3,
+            basalt_world::block_entity::BlockEntity::empty_chest(),
+        );
+
+        // Break the left half
+        let _ = game_tx.send(GameInput::BlockDig {
+            uuid,
+            status: 0,
+            x: 5,
+            y: 64,
+            z: 3,
+            sequence: 1,
+        });
+        game_loop.tick(1);
+
+        // Right half should be single now
+        let remaining = game_loop.world.get_block(6, 64, 3);
+        assert!(
+            basalt_world::block::is_single_chest(remaining),
+            "remaining half should revert to single chest"
         );
     }
 }

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -153,6 +153,13 @@ pub enum GameInput {
         /// UUID of the player.
         uuid: Uuid,
     },
+    /// Player started or stopped sneaking.
+    EntityAction {
+        /// UUID of the player.
+        uuid: Uuid,
+        /// Action ID (0 = start sneak, 1 = stop sneak).
+        action_id: i32,
+    },
 }
 
 /// Output from the game loop to a player's net task.

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -253,6 +253,23 @@ pub enum ServerOutput {
         item: basalt_types::Slot,
     },
 
+    /// Trigger a block action (e.g. chest open/close animation).
+    /// Net task sends BlockAction packet.
+    BlockAction {
+        /// Block position.
+        x: i32,
+        /// Block Y.
+        y: i32,
+        /// Block Z.
+        z: i32,
+        /// Action ID (1 for chest open/close).
+        action_id: u8,
+        /// Action parameter (viewer count for chests).
+        action_param: u8,
+        /// Block registry ID (not state ID).
+        block_id: i32,
+    },
+
     /// Inform client of a block entity at a position.
     /// Net task sends TileEntityData packet.
     BlockEntityData {

--- a/crates/basalt-server/src/net/task.rs
+++ b/crates/basalt-server/src/net/task.rs
@@ -715,6 +715,14 @@ async fn handle_packet(
             let _ = game_tx.send(GameInput::CloseWindow { uuid });
         }
 
+        // -- Game loop: entity action (sneak, sprint, etc.) --
+        ServerboundPlayPacket::EntityAction(action) => {
+            let _ = game_tx.send(GameInput::EntityAction {
+                uuid,
+                action_id: action.action_id,
+            });
+        }
+
         // -- Inline (no routing) --
         ServerboundPlayPacket::TeleportConfirm(_)
         | ServerboundPlayPacket::Flying(_)

--- a/crates/basalt-server/src/net/task.rs
+++ b/crates/basalt-server/src/net/task.rs
@@ -297,6 +297,25 @@ async fn write_server_output(
             conn.write_packet_typed(ClientboundPlaySetSlot::PACKET_ID, &packet)
                 .await?;
         }
+        ServerOutput::BlockAction {
+            x,
+            y,
+            z,
+            action_id,
+            action_param,
+            block_id,
+        } => {
+            use basalt_protocol::packets::play::world::ClientboundPlayBlockAction;
+            let packet = ClientboundPlayBlockAction {
+                location: basalt_types::Position::new(*x, *y, *z),
+                byte1: *action_id,
+                byte2: *action_param,
+                block_id: *block_id,
+            };
+            conn.write_packet_typed(ClientboundPlayBlockAction::PACKET_ID, &packet)
+                .await?;
+            // TODO: chest open/close sound — SoundEffect encoding needs investigation
+        }
         ServerOutput::BlockEntityData { x, y, z, action } => {
             use basalt_protocol::packets::play::world::ClientboundPlayTileEntityData;
             let packet = ClientboundPlayTileEntityData {

--- a/crates/basalt-server/tests/e2e.rs
+++ b/crates/basalt-server/tests/e2e.rs
@@ -1095,3 +1095,236 @@ async fn e2e_block_break_spawns_item_entity() {
     let pkt = ClientboundPlaySpawnEntity::decode(&mut cursor).unwrap();
     assert_eq!(pkt.r#type, 68, "spawned entity should be type 68 (item)");
 }
+
+// -- Chest tests --
+
+/// Places a chest via creative slot + BlockPlace, waits for processing.
+async fn place_chest(client: &mut TcpStream, x: i32, y: i32, z: i32) {
+    use basalt_protocol::packets::play::world::ServerboundPlayBlockPlace;
+    // Give chest in hotbar slot 0 (item 313)
+    give_creative_item(client, 36, 313, 1).await;
+    send_packet(
+        client,
+        ServerboundPlayBlockPlace::PACKET_ID,
+        &ServerboundPlayBlockPlace {
+            hand: 0,
+            location: basalt_types::Position::new(x, y, z),
+            direction: 1, // top face
+            cursor_x: 0.5,
+            cursor_y: 1.0,
+            cursor_z: 0.5,
+            inside_block: false,
+            world_border_hit: false,
+            sequence: 100,
+        },
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+}
+
+#[tokio::test]
+async fn e2e_chest_opens_with_right_click() {
+    use basalt_protocol::packets::play::inventory::ClientboundPlayOpenWindow;
+
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Place a chest
+    place_chest(&mut client, 2, -60, 2).await;
+
+    // Drain placement packets
+    while let Ok(Ok(Some(_))) = tokio::time::timeout(
+        std::time::Duration::from_millis(50),
+        framing::read_raw_packet(&mut client),
+    )
+    .await
+    {}
+
+    // Right-click the chest (BlockPlace on the chest position)
+    use basalt_protocol::packets::play::world::ServerboundPlayBlockPlace;
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockPlace::PACKET_ID,
+        &ServerboundPlayBlockPlace {
+            hand: 0,
+            location: basalt_types::Position::new(2, -59, 2),
+            direction: 1,
+            cursor_x: 0.5,
+            cursor_y: 0.5,
+            cursor_z: 0.5,
+            inside_block: false,
+            world_border_hit: false,
+            sequence: 101,
+        },
+    )
+    .await;
+
+    // Should receive OpenWindow
+    let packets = read_until_packet(&mut client, ClientboundPlayOpenWindow::PACKET_ID).await;
+    let open_pkt = packets
+        .iter()
+        .find(|p| p.id == ClientboundPlayOpenWindow::PACKET_ID)
+        .expect("right-clicking chest should send OpenWindow");
+
+    let mut cursor = open_pkt.payload.as_slice();
+    let pkt = ClientboundPlayOpenWindow::decode(&mut cursor).unwrap();
+    assert_eq!(pkt.inventory_type, 2, "single chest = generic_9x3 (type 2)");
+}
+
+#[tokio::test]
+async fn e2e_chest_break_drops_contents_and_block() {
+    use basalt_protocol::packets::play::entity::ClientboundPlaySpawnEntity;
+    use basalt_protocol::packets::play::world::ServerboundPlayBlockDig;
+
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Place a chest
+    place_chest(&mut client, 3, -60, 3).await;
+
+    // Open the chest and put an item in it
+    use basalt_protocol::packets::play::inventory::ClientboundPlayOpenWindow;
+    use basalt_protocol::packets::play::world::ServerboundPlayBlockPlace;
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockPlace::PACKET_ID,
+        &ServerboundPlayBlockPlace {
+            hand: 0,
+            location: basalt_types::Position::new(3, -59, 3),
+            direction: 1,
+            cursor_x: 0.5,
+            cursor_y: 0.5,
+            cursor_z: 0.5,
+            inside_block: false,
+            world_border_hit: false,
+            sequence: 102,
+        },
+    )
+    .await;
+    read_until_packet(&mut client, ClientboundPlayOpenWindow::PACKET_ID).await;
+
+    // Put stone in chest slot 0 via WindowClick
+    use basalt_protocol::packets::play::ServerboundPlayWindowClick;
+    use basalt_protocol::packets::play::ServerboundPlayWindowClickChangedslots;
+    send_packet(
+        &mut client,
+        ServerboundPlayWindowClick::PACKET_ID,
+        &ServerboundPlayWindowClick {
+            window_id: 1,
+            state_id: 0,
+            slot: 0,
+            mouse_button: 0,
+            mode: 0,
+            changed_slots: vec![ServerboundPlayWindowClickChangedslots {
+                location: 0,
+                item: basalt_types::Slot::new(1, 10),
+            }],
+            cursor_item: basalt_types::Slot::empty(),
+        },
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Close the chest
+    use basalt_protocol::packets::play::ServerboundPlayCloseWindow;
+    send_packet(
+        &mut client,
+        ServerboundPlayCloseWindow::PACKET_ID,
+        &ServerboundPlayCloseWindow { window_id: 1 },
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Drain all packets
+    while let Ok(Ok(Some(_))) = tokio::time::timeout(
+        std::time::Duration::from_millis(50),
+        framing::read_raw_packet(&mut client),
+    )
+    .await
+    {}
+
+    // Break the chest
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockDig::PACKET_ID,
+        &ServerboundPlayBlockDig {
+            status: 0,
+            location: basalt_types::Position::new(3, -59, 3),
+            face: 1,
+            sequence: 103,
+        },
+    )
+    .await;
+
+    // Should receive multiple SpawnEntity for dropped items (contents + chest block)
+    // First wait for the initial spawn, then collect more
+    let mut all_packets =
+        read_until_packet(&mut client, ClientboundPlaySpawnEntity::PACKET_ID).await;
+    // Keep reading for additional spawns
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, framing::read_raw_packet(&mut client)).await {
+            Ok(Ok(Some(raw))) => all_packets.push(raw),
+            _ => break,
+        }
+    }
+    let spawn_count = all_packets
+        .iter()
+        .filter(|p| p.id == ClientboundPlaySpawnEntity::PACKET_ID)
+        .count();
+    assert!(
+        spawn_count >= 2,
+        "should drop chest contents + chest block itself, got {spawn_count} spawns"
+    );
+}
+
+#[tokio::test]
+async fn e2e_double_chest_opens_54_slots() {
+    use basalt_protocol::packets::play::inventory::ClientboundPlayOpenWindow;
+
+    let addr = spawn_server().await;
+    let mut client = connect_to_play(addr).await;
+
+    // Place two adjacent chests to form a double
+    place_chest(&mut client, 4, -60, 4).await;
+    place_chest(&mut client, 5, -60, 4).await;
+
+    // Drain packets
+    while let Ok(Ok(Some(_))) = tokio::time::timeout(
+        std::time::Duration::from_millis(50),
+        framing::read_raw_packet(&mut client),
+    )
+    .await
+    {}
+
+    // Open one half
+    use basalt_protocol::packets::play::world::ServerboundPlayBlockPlace;
+    send_packet(
+        &mut client,
+        ServerboundPlayBlockPlace::PACKET_ID,
+        &ServerboundPlayBlockPlace {
+            hand: 0,
+            location: basalt_types::Position::new(4, -59, 4),
+            direction: 1,
+            cursor_x: 0.5,
+            cursor_y: 0.5,
+            cursor_z: 0.5,
+            inside_block: false,
+            world_border_hit: false,
+            sequence: 104,
+        },
+    )
+    .await;
+
+    let packets = read_until_packet(&mut client, ClientboundPlayOpenWindow::PACKET_ID).await;
+    let open_pkt = packets
+        .iter()
+        .find(|p| p.id == ClientboundPlayOpenWindow::PACKET_ID)
+        .expect("right-clicking double chest should send OpenWindow");
+
+    let mut cursor = open_pkt.payload.as_slice();
+    let pkt = ClientboundPlayOpenWindow::decode(&mut cursor).unwrap();
+    assert_eq!(pkt.inventory_type, 5, "double chest = generic_9x6 (type 5)");
+}

--- a/crates/basalt-world/src/block.rs
+++ b/crates/basalt-world/src/block.rs
@@ -43,6 +43,72 @@ pub fn is_chest(state: u16) -> bool {
     (CHEST_MIN..=CHEST_MAX).contains(&state)
 }
 
+/// Returns true if the chest state is a single chest (not part of a double).
+pub fn is_single_chest(state: u16) -> bool {
+    is_chest(state) && chest_type(state) == 0
+}
+
+/// Extracts the facing index from a chest state (0=north, 1=south, 2=west, 3=east).
+pub fn chest_facing(state: u16) -> u16 {
+    if !is_chest(state) {
+        return 0;
+    }
+    (state - CHEST_MIN) / 6
+}
+
+/// Extracts the type from a chest state (0=single, 1=left, 2=right).
+pub fn chest_type(state: u16) -> u16 {
+    if !is_chest(state) {
+        return 0;
+    }
+    ((state - CHEST_MIN) % 6) / 2
+}
+
+/// Builds a chest state from facing, type, and waterlogged=false.
+pub fn chest_state(facing: u16, chest_type: u16) -> u16 {
+    CHEST_MIN + facing * 6 + chest_type * 2 + 1 // +1 for waterlogged=false
+}
+
+/// Returns the adjacent position for double chest pairing based on facing.
+///
+/// For north/south facing: checks east/west (±X).
+/// For east/west facing: checks north/south (±Z).
+/// Returns `(dx1, dz1, dx2, dz2)` — two candidate offsets to check.
+pub fn chest_adjacent_offsets(facing: u16) -> [(i32, i32); 2] {
+    match facing {
+        0 | 1 => [(-1, 0), (1, 0)], // north/south: check west/east
+        2 | 3 => [(0, -1), (0, 1)], // west/east: check north/south
+        _ => [(0, 0), (0, 0)],
+    }
+}
+
+/// Given a facing and the offset direction of the adjacent chest,
+/// returns (type_for_new, type_for_existing).
+///
+/// The "left" chest is the one on the left when looking at the front.
+pub fn chest_double_types(facing: u16, dx: i32, dz: i32) -> (u16, u16) {
+    // (new_type, existing_type)
+    match facing {
+        0 => {
+            // North-facing: front faces north, viewed from south
+            if dx < 0 { (2, 1) } else { (1, 2) } // west neighbor: new=right, existing=left
+        }
+        1 => {
+            // South-facing: front faces south, viewed from north
+            if dx < 0 { (1, 2) } else { (2, 1) }
+        }
+        2 => {
+            // West-facing: front faces west, viewed from east
+            if dz < 0 { (1, 2) } else { (2, 1) }
+        }
+        3 => {
+            // East-facing: front faces east, viewed from west
+            if dz < 0 { (2, 1) } else { (1, 2) }
+        }
+        _ => (0, 0),
+    }
+}
+
 /// Returns the chest block state for a given player yaw (facing the player).
 ///
 /// The chest faces the player: if the player is looking north (yaw ~180),
@@ -193,6 +259,10 @@ pub fn item_to_default_block_state(item_id: i32) -> Option<u16> {
 pub fn block_state_to_item_id(state: u16) -> Option<i32> {
     if state == 0 {
         return None; // air drops nothing
+    }
+    // Blocks with multiple state variants: map any variant to the item
+    if is_chest(state) {
+        return Some(313); // chest item ID
     }
     for (item_id, &block_state) in ITEM_TO_BLOCK_STATE.iter().enumerate() {
         if block_state == state {

--- a/crates/basalt-world/src/block.rs
+++ b/crates/basalt-world/src/block.rs
@@ -75,9 +75,10 @@ pub fn chest_state(facing: u16, chest_type: u16) -> u16 {
 /// For east/west facing: checks north/south (±Z).
 /// Returns `(dx1, dz1, dx2, dz2)` — two candidate offsets to check.
 pub fn chest_adjacent_offsets(facing: u16) -> [(i32, i32); 2] {
+    // Right side first (vanilla pairing priority)
     match facing {
-        0 | 1 => [(-1, 0), (1, 0)], // north/south: check west/east
-        2 | 3 => [(0, -1), (0, 1)], // west/east: check north/south
+        0 | 1 => [(1, 0), (-1, 0)], // north/south: east first, then west
+        2 | 3 => [(0, 1), (0, -1)], // west/east: south first, then north
         _ => [(0, 0), (0, 0)],
     }
 }


### PR DESCRIPTION
## Summary

- **Visibility**: force chunk load before querying block entities (fixes invisible chests after restart)
- **Drops**: chest contents spawn as item entities on break, oriented chests drop correctly
- **Sneak**: EntityAction tracking, sneaking prevents chest opening and auto-pairing
- **Double chests**: adjacent pairing with right-side priority, shift-click pairs with clicked chest only, lateral-only (no front/back merge), breaking one half reverts other to single
- **ContainerView**: generic abstraction replacing chest-specific logic in click handler, double chest opens as 54-slot window
- **Animation**: BlockAction packet broadcast on open/close with viewer count

## Test plan

- [x] All tests pass
- [x] Clippy clean
- [x] Coverage 90%+
- [x] Unit tests: chest placement, break drops, double chest formation, double chest revert, container click, Q drop from container, close window returns cursor
- [x] Manual: chest visible after restart, double chest 54 slots, sneak places single, shift-click pairs specific chest, break drops contents + block
