### PR TITLE
refactor(api): split Context trait into sub-context domains

### DIFF
--- a/crates/basalt-api/src/context.rs
+++ b/crates/basalt-api/src/context.rs
@@ -11,7 +11,10 @@ use std::sync::atomic::{AtomicI32, Ordering};
 
 use basalt_core::broadcast::BroadcastMessage;
 use basalt_core::gamemode::Gamemode;
-use basalt_core::{Context, PluginLogger};
+use basalt_core::{
+    ChatContext, ContainerContext, Context, EntityContext, PlayerContext, PluginLogger,
+    WorldContext,
+};
 use basalt_types::nbt::NbtCompound;
 use basalt_types::{TextComponent, Uuid};
 
@@ -92,72 +95,22 @@ impl ServerContext {
     }
 }
 
-/// Implementation of [`Context`] for in-game player contexts.
-///
-/// All methods queue [`Response`] variants into the interior-mutable
-/// response queue. The play loop drains and executes them after
-/// event dispatch completes.
-impl Context for ServerContext {
-    fn player_uuid(&self) -> Uuid {
+impl PlayerContext for ServerContext {
+    fn uuid(&self) -> Uuid {
         self.player_uuid
     }
-
-    fn player_entity_id(&self) -> i32 {
+    fn entity_id(&self) -> i32 {
         self.player_entity_id
     }
-
-    fn player_username(&self) -> &str {
+    fn username(&self) -> &str {
         &self.player_username
     }
-
-    fn player_yaw(&self) -> f32 {
+    fn yaw(&self) -> f32 {
         self.player_yaw
     }
-
-    fn player_pitch(&self) -> f32 {
+    fn pitch(&self) -> f32 {
         self.player_pitch
     }
-
-    fn logger(&self) -> PluginLogger {
-        PluginLogger::new(&self.plugin_name.borrow())
-    }
-
-    fn world(&self) -> &basalt_world::World {
-        &self.world
-    }
-
-    fn send_message(&self, text: &str) {
-        let component = TextComponent::text(text);
-        self.send_message_component(&component);
-    }
-
-    fn send_message_component(&self, component: &TextComponent) {
-        self.responses.push(Response::SendSystemChat {
-            content: component.to_nbt(),
-            action_bar: false,
-        });
-    }
-
-    fn send_action_bar(&self, text: &str) {
-        let component = TextComponent::text(text);
-        self.responses.push(Response::SendSystemChat {
-            content: component.to_nbt(),
-            action_bar: true,
-        });
-    }
-
-    fn broadcast_message(&self, text: &str) {
-        let component = TextComponent::text(text);
-        self.broadcast_message_component(&component);
-    }
-
-    fn broadcast_message_component(&self, component: &TextComponent) {
-        self.responses
-            .push(Response::Broadcast(BroadcastMessage::Chat {
-                content: component.to_nbt(),
-            }));
-    }
-
     fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32) {
         let teleport_id = self.teleport_counter.fetch_add(1, Ordering::Relaxed);
         self.responses.push(Response::SendPosition {
@@ -169,34 +122,66 @@ impl Context for ServerContext {
             pitch,
         });
     }
-
     fn set_gamemode(&self, mode: Gamemode) {
         self.responses.push(Response::SendGameStateChange {
             reason: GAME_STATE_CHANGE_GAMEMODE,
             value: mode.id() as f32,
         });
     }
-
     fn registered_commands(&self) -> Vec<(String, String)> {
-        // Populated from ServerState command_args at dispatch time
         self.command_list.borrow().clone()
     }
+}
 
+impl ChatContext for ServerContext {
+    fn send(&self, text: &str) {
+        let component = TextComponent::text(text);
+        self.send_component(&component);
+    }
+    fn send_component(&self, component: &TextComponent) {
+        self.responses.push(Response::SendSystemChat {
+            content: component.to_nbt(),
+            action_bar: false,
+        });
+    }
+    fn action_bar(&self, text: &str) {
+        let component = TextComponent::text(text);
+        self.responses.push(Response::SendSystemChat {
+            content: component.to_nbt(),
+            action_bar: true,
+        });
+    }
+    fn broadcast(&self, text: &str) {
+        let component = TextComponent::text(text);
+        self.broadcast_component(&component);
+    }
+    fn broadcast_component(&self, component: &TextComponent) {
+        self.responses
+            .push(Response::Broadcast(BroadcastMessage::Chat {
+                content: component.to_nbt(),
+            }));
+    }
+}
+
+impl WorldContext for ServerContext {
+    fn world(&self) -> &basalt_world::World {
+        &self.world
+    }
     fn send_block_ack(&self, sequence: i32) {
         self.responses.push(Response::SendBlockAck { sequence });
     }
-
     fn stream_chunks(&self, cx: i32, cz: i32) {
         self.responses.push(Response::StreamChunks {
             new_cx: cx,
             new_cz: cz,
         });
     }
-
     fn persist_chunk(&self, cx: i32, cz: i32) {
         self.responses.push(Response::PersistChunk { cx, cz });
     }
+}
 
+impl EntityContext for ServerContext {
     fn spawn_dropped_item(&self, x: i32, y: i32, z: i32, item_id: i32, count: i32) {
         self.responses.push(Response::SpawnDroppedItem {
             x,
@@ -206,9 +191,40 @@ impl Context for ServerContext {
             count,
         });
     }
-
-    fn broadcast(&self, msg: BroadcastMessage) {
+    fn broadcast_raw(&self, msg: BroadcastMessage) {
         self.responses.push(Response::Broadcast(msg));
+    }
+}
+
+impl ContainerContext for ServerContext {
+    fn open_chest(&self, x: i32, y: i32, z: i32) {
+        self.responses.push(Response::OpenChest { x, y, z });
+    }
+}
+
+impl Context for ServerContext {
+    fn logger(&self) -> PluginLogger {
+        PluginLogger::new(&self.plugin_name.borrow())
+    }
+
+    fn player(&self) -> &dyn PlayerContext {
+        self
+    }
+
+    fn chat(&self) -> &dyn ChatContext {
+        self
+    }
+
+    fn world_ctx(&self) -> &dyn WorldContext {
+        self
+    }
+
+    fn entities(&self) -> &dyn EntityContext {
+        self
+    }
+
+    fn containers(&self) -> &dyn ContainerContext {
+        self
     }
 }
 
@@ -298,6 +314,15 @@ pub enum Response {
         /// Item count.
         count: i32,
     },
+    /// Open a chest container at the given position.
+    OpenChest {
+        /// Block X coordinate.
+        x: i32,
+        /// Block Y coordinate.
+        y: i32,
+        /// Block Z coordinate.
+        z: i32,
+    },
 }
 
 #[cfg(test)]
@@ -315,15 +340,15 @@ mod tests {
     #[test]
     fn player_identity() {
         let ctx = test_ctx();
-        assert_eq!(ctx.player_uuid(), Uuid::default());
-        assert_eq!(ctx.player_entity_id(), 1);
-        assert_eq!(ctx.player_username(), "Steve");
+        assert_eq!(ctx.player().uuid(), Uuid::default());
+        assert_eq!(ctx.player().entity_id(), 1);
+        assert_eq!(ctx.player().username(), "Steve");
     }
 
     #[test]
     fn send_message_queues_response() {
         let ctx = test_ctx();
-        ctx.send_message("hello");
+        ctx.chat().send("hello");
         let responses = ctx.drain_responses();
         assert_eq!(responses.len(), 1);
         assert!(matches!(
@@ -338,7 +363,7 @@ mod tests {
     #[test]
     fn teleport_queues_position() {
         let ctx = test_ctx();
-        ctx.teleport(10.0, 64.0, -5.0, 90.0, 0.0);
+        ctx.player().teleport(10.0, 64.0, -5.0, 90.0, 0.0);
         let responses = ctx.drain_responses();
         assert_eq!(responses.len(), 1);
         assert!(matches!(responses[0], Response::SendPosition { .. }));
@@ -347,7 +372,7 @@ mod tests {
     #[test]
     fn set_gamemode_queues_state_change() {
         let ctx = test_ctx();
-        ctx.set_gamemode(Gamemode::Creative);
+        ctx.player().set_gamemode(Gamemode::Creative);
         let responses = ctx.drain_responses();
         assert_eq!(responses.len(), 1);
         assert!(matches!(
@@ -362,7 +387,7 @@ mod tests {
     #[test]
     fn broadcast_message_queues_broadcast() {
         let ctx = test_ctx();
-        ctx.broadcast_message("hello all");
+        ctx.chat().broadcast("hello all");
         let responses = ctx.drain_responses();
         assert_eq!(responses.len(), 1);
         assert!(matches!(
@@ -374,8 +399,8 @@ mod tests {
     #[test]
     fn drain_clears_queue() {
         let ctx = test_ctx();
-        ctx.send_message("a");
-        ctx.send_message("b");
+        ctx.chat().send("a");
+        ctx.chat().send("b");
         assert_eq!(ctx.drain_responses().len(), 2);
         assert!(ctx.drain_responses().is_empty());
     }
@@ -384,7 +409,7 @@ mod tests {
     fn context_trait_is_usable_as_dyn() {
         let ctx = test_ctx();
         let dyn_ctx: &dyn Context = &ctx;
-        dyn_ctx.send_message("via trait");
+        dyn_ctx.chat().send("via trait");
         assert_eq!(ctx.drain_responses().len(), 1);
     }
 }

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -11,7 +11,10 @@ pub mod logger;
 pub mod plugin;
 
 // Re-export core types for convenience.
-pub use basalt_core::{BroadcastMessage, Context, Gamemode, PlayerSnapshot, ProfileProperty};
+pub use basalt_core::{
+    BroadcastMessage, ChatContext, ContainerContext, Context, EntityContext, Gamemode,
+    PlayerContext, PlayerSnapshot, ProfileProperty, WorldContext,
+};
 pub use context::{Response, ServerContext};
 pub use plugin::{CommandEntry, Plugin, PluginMetadata, PluginRegistrar};
 
@@ -24,7 +27,10 @@ pub use basalt_events::{Event, EventBus, Stage};
 /// Prelude module for convenient glob imports.
 pub mod prelude {
     pub use basalt_command::{Arg, CommandArgs, Validation};
-    pub use basalt_core::{BroadcastMessage, Context, Gamemode, PlayerSnapshot};
+    pub use basalt_core::{
+        BroadcastMessage, ChatContext, ContainerContext, Context, EntityContext, Gamemode,
+        PlayerContext, PlayerSnapshot, WorldContext,
+    };
 
     pub use basalt_types::Uuid;
 

--- a/crates/basalt-command/src/command.rs
+++ b/crates/basalt-command/src/command.rs
@@ -23,7 +23,7 @@ use crate::args::CommandArgs;
 ///     fn name(&self) -> &str { "ping" }
 ///     fn description(&self) -> &str { "Responds with pong" }
 ///     fn execute(&self, _args: &CommandArgs, ctx: &dyn Context) {
-///         ctx.send_message("Pong!");
+///         ctx.chat().send("Pong!");
 ///     }
 /// }
 /// ```

--- a/crates/basalt-command/src/registry.rs
+++ b/crates/basalt-command/src/registry.rs
@@ -71,7 +71,9 @@ impl Default for CommandRegistry {
 
 #[cfg(test)]
 mod tests {
-    use basalt_core::PluginLogger;
+    use basalt_core::{
+        ChatContext, ContainerContext, EntityContext, PlayerContext, PluginLogger, WorldContext,
+    };
     use basalt_types::Uuid;
 
     use super::*;
@@ -80,45 +82,81 @@ mod tests {
     /// Minimal test context implementing the Context trait.
     struct TestContext;
 
-    impl Context for TestContext {
-        fn player_uuid(&self) -> Uuid {
+    impl PlayerContext for TestContext {
+        fn uuid(&self) -> Uuid {
             Uuid::default()
         }
-        fn player_entity_id(&self) -> i32 {
+        fn entity_id(&self) -> i32 {
             1
         }
-        fn player_username(&self) -> &str {
+        fn username(&self) -> &str {
             "Steve"
         }
-        fn player_yaw(&self) -> f32 {
+        fn yaw(&self) -> f32 {
             0.0
         }
-        fn player_pitch(&self) -> f32 {
+        fn pitch(&self) -> f32 {
             0.0
         }
-        fn logger(&self) -> PluginLogger {
-            PluginLogger::new("test")
-        }
-        fn world(&self) -> &basalt_world::World {
-            use std::sync::OnceLock;
-            static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-            WORLD.get_or_init(|| basalt_world::World::new_memory(42))
-        }
-        fn send_message(&self, _text: &str) {}
-        fn send_message_component(&self, _component: &basalt_types::TextComponent) {}
-        fn send_action_bar(&self, _text: &str) {}
-        fn broadcast_message(&self, _text: &str) {}
-        fn broadcast_message_component(&self, _component: &basalt_types::TextComponent) {}
         fn teleport(&self, _x: f64, _y: f64, _z: f64, _yaw: f32, _pitch: f32) {}
         fn set_gamemode(&self, _mode: basalt_core::Gamemode) {}
         fn registered_commands(&self) -> Vec<(String, String)> {
             Vec::new()
         }
+    }
+
+    impl ChatContext for TestContext {
+        fn send(&self, _text: &str) {}
+        fn send_component(&self, _component: &basalt_types::TextComponent) {}
+        fn action_bar(&self, _text: &str) {}
+        fn broadcast(&self, _text: &str) {}
+        fn broadcast_component(&self, _component: &basalt_types::TextComponent) {}
+    }
+
+    impl WorldContext for TestContext {
+        fn world(&self) -> &basalt_world::World {
+            use std::sync::OnceLock;
+            static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
+            WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+        }
         fn send_block_ack(&self, _sequence: i32) {}
         fn stream_chunks(&self, _cx: i32, _cz: i32) {}
         fn persist_chunk(&self, _cx: i32, _cz: i32) {}
+    }
+
+    impl EntityContext for TestContext {
         fn spawn_dropped_item(&self, _x: i32, _y: i32, _z: i32, _item_id: i32, _count: i32) {}
-        fn broadcast(&self, _msg: basalt_core::BroadcastMessage) {}
+        fn broadcast_raw(&self, _msg: basalt_core::BroadcastMessage) {}
+    }
+
+    impl ContainerContext for TestContext {
+        fn open_chest(&self, _x: i32, _y: i32, _z: i32) {}
+    }
+
+    impl Context for TestContext {
+        fn logger(&self) -> PluginLogger {
+            PluginLogger::new("test")
+        }
+
+        fn player(&self) -> &dyn PlayerContext {
+            self
+        }
+
+        fn chat(&self) -> &dyn ChatContext {
+            self
+        }
+
+        fn world_ctx(&self) -> &dyn WorldContext {
+            self
+        }
+
+        fn entities(&self) -> &dyn EntityContext {
+            self
+        }
+
+        fn containers(&self) -> &dyn ContainerContext {
+            self
+        }
     }
 
     struct PingCommand;
@@ -130,7 +168,7 @@ mod tests {
             "Responds with pong"
         }
         fn execute(&self, _args: &CommandArgs, ctx: &dyn Context) {
-            ctx.send_message("Pong!");
+            ctx.chat().send("Pong!");
         }
     }
 
@@ -143,7 +181,7 @@ mod tests {
             "Echoes the arguments"
         }
         fn execute(&self, args: &CommandArgs, ctx: &dyn Context) {
-            ctx.send_message(args.raw());
+            ctx.chat().send(args.raw());
         }
     }
 

--- a/crates/basalt-core/src/context.rs
+++ b/crates/basalt-core/src/context.rs
@@ -1,106 +1,102 @@
 //! Shared context trait for command handlers and plugins.
 //!
-//! The [`Context`] trait abstracts over the execution environment,
-//! allowing commands and handlers to work with both in-game players
-//! (`ServerContext`) and future console contexts.
+//! The [`Context`] trait provides sub-contexts for different domains:
+//! [`PlayerContext`], [`ChatContext`], [`WorldContext`], [`EntityContext`],
+//! and [`ContainerContext`]. Plugins access them via `ctx.player()`,
+//! `ctx.chat()`, etc.
 
 use basalt_types::{TextComponent, Uuid};
 
 use crate::broadcast::BroadcastMessage;
 use crate::gamemode::Gamemode;
 
+// ── Sub-context traits ───────────────────────────────────────────────
+
+/// Player identity and state.
+pub trait PlayerContext {
+    /// Returns the UUID of the player who triggered this action.
+    fn uuid(&self) -> Uuid;
+    /// Returns the entity ID of the player.
+    fn entity_id(&self) -> i32;
+    /// Returns the username of the player.
+    fn username(&self) -> &str;
+    /// Returns the player's current yaw rotation (horizontal, degrees).
+    fn yaw(&self) -> f32;
+    /// Returns the player's current pitch rotation (vertical, degrees).
+    fn pitch(&self) -> f32;
+    /// Teleports the current player to the given coordinates.
+    fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32);
+    /// Changes the current player's gamemode.
+    fn set_gamemode(&self, mode: Gamemode);
+    /// Returns a list of (name, description) for all registered commands.
+    fn registered_commands(&self) -> Vec<(String, String)>;
+}
+
+/// Chat and messaging.
+pub trait ChatContext {
+    /// Sends a plain text message to the current player.
+    fn send(&self, text: &str);
+    /// Sends a styled message to the current player.
+    fn send_component(&self, component: &TextComponent);
+    /// Sends an action bar message to the current player.
+    fn action_bar(&self, text: &str);
+    /// Broadcasts a plain text message to ALL connected players.
+    fn broadcast(&self, text: &str);
+    /// Broadcasts a styled message to ALL connected players.
+    fn broadcast_component(&self, component: &TextComponent);
+}
+
+/// World access: blocks, chunks, persistence.
+pub trait WorldContext {
+    /// Returns a reference to the world (chunks, blocks, persistence).
+    fn world(&self) -> &basalt_world::World;
+    /// Sends a block action acknowledgement to the current player.
+    fn send_block_ack(&self, sequence: i32);
+    /// Streams chunks around the given chunk coordinates.
+    fn stream_chunks(&self, cx: i32, cz: i32);
+    /// Schedules a chunk for asynchronous persistence on the I/O thread.
+    fn persist_chunk(&self, cx: i32, cz: i32);
+}
+
+/// Entity management: spawn, despawn, broadcast.
+pub trait EntityContext {
+    /// Spawns a dropped item entity at the given block coordinates.
+    fn spawn_dropped_item(&self, x: i32, y: i32, z: i32, item_id: i32, count: i32);
+    /// Sends a raw broadcast message to all connected players.
+    fn broadcast_raw(&self, msg: BroadcastMessage);
+}
+
+/// Container interaction: chests, future crafting/furnaces.
+pub trait ContainerContext {
+    /// Opens a chest container at the given position for the current player.
+    fn open_chest(&self, x: i32, y: i32, z: i32);
+}
+
+// ── Main Context trait ───────────────────────────────────────────────
+
 /// Execution context for commands and event handlers.
 ///
-/// Provides identity information, messaging, player actions, and
-/// world access. Implemented by `ServerContext` (in-game player)
-/// and potentially `ConsoleContext` (server terminal) in the future.
-pub trait Context {
-    // --- Player identity ---
-
-    /// Returns the UUID of the player who triggered this action.
-    fn player_uuid(&self) -> Uuid;
-
-    /// Returns the entity ID of the player.
-    fn player_entity_id(&self) -> i32;
-
-    /// Returns the username of the player.
-    fn player_username(&self) -> &str;
-
-    /// Returns the player's current yaw rotation (horizontal, degrees).
-    fn player_yaw(&self) -> f32;
-
-    /// Returns the player's current pitch rotation (vertical, degrees).
-    fn player_pitch(&self) -> f32;
-
-    // --- Logger ---
-
+/// Provides sub-context accessors for domain-specific operations.
+/// Implemented by `ServerContext` (in-game player) and potentially
+/// `ConsoleContext` (server terminal) in the future.
+pub trait Context:
+    PlayerContext + ChatContext + WorldContext + EntityContext + ContainerContext
+{
     /// Returns a logger scoped to the current plugin.
     fn logger(&self) -> crate::logger::PluginLogger;
 
-    // --- World access ---
+    /// Access player identity and state.
+    fn player(&self) -> &dyn PlayerContext;
 
-    /// Returns a reference to the world (chunks, blocks, persistence).
-    fn world(&self) -> &basalt_world::World;
+    /// Access chat and messaging.
+    fn chat(&self) -> &dyn ChatContext;
 
-    // --- Chat / messaging ---
+    /// Access world, blocks, chunks, and persistence.
+    fn world_ctx(&self) -> &dyn WorldContext;
 
-    /// Sends a plain text message to the current player.
-    fn send_message(&self, text: &str);
+    /// Access entity management.
+    fn entities(&self) -> &dyn EntityContext;
 
-    /// Sends a styled message to the current player.
-    fn send_message_component(&self, component: &TextComponent);
-
-    /// Sends an action bar message to the current player.
-    fn send_action_bar(&self, text: &str);
-
-    /// Broadcasts a plain text message to ALL connected players.
-    fn broadcast_message(&self, text: &str);
-
-    /// Broadcasts a styled message to ALL connected players.
-    fn broadcast_message_component(&self, component: &TextComponent);
-
-    // --- Player actions ---
-
-    /// Teleports the current player to the given coordinates.
-    fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32);
-
-    /// Changes the current player's gamemode.
-    fn set_gamemode(&self, mode: Gamemode);
-
-    // --- Commands ---
-
-    /// Returns a list of (name, description) for all registered commands.
-    fn registered_commands(&self) -> Vec<(String, String)>;
-
-    // --- Block ---
-
-    /// Sends a block action acknowledgement to the current player.
-    fn send_block_ack(&self, sequence: i32);
-
-    // --- World streaming ---
-
-    /// Streams chunks around the given chunk coordinates.
-    fn stream_chunks(&self, cx: i32, cz: i32);
-
-    // --- Persistence ---
-
-    /// Schedules a chunk for asynchronous persistence on the I/O thread.
-    ///
-    /// The chunk is serialized and written to disk without blocking the
-    /// game loop. This replaces direct `world().persist_chunk()` calls.
-    fn persist_chunk(&self, cx: i32, cz: i32);
-
-    // --- Entity spawning ---
-
-    /// Spawns a dropped item entity at the given block coordinates.
-    ///
-    /// The entity gets Position (block center), random upward Velocity,
-    /// BoundingBox, Lifetime (5 min), DroppedItem, and EntityKind
-    /// components. Broadcast to all connected players.
-    fn spawn_dropped_item(&self, x: i32, y: i32, z: i32, item_id: i32, count: i32);
-
-    // --- Raw broadcast ---
-
-    /// Sends a raw broadcast message to all connected players.
-    fn broadcast(&self, msg: BroadcastMessage);
+    /// Access container interaction.
+    fn containers(&self) -> &dyn ContainerContext;
 }

--- a/crates/basalt-core/src/lib.rs
+++ b/crates/basalt-core/src/lib.rs
@@ -16,6 +16,8 @@ pub mod gamemode;
 pub mod logger;
 
 pub use broadcast::{BroadcastMessage, PlayerSnapshot, ProfileProperty};
-pub use context::Context;
+pub use context::{
+    ChatContext, ContainerContext, Context, EntityContext, PlayerContext, WorldContext,
+};
 pub use gamemode::Gamemode;
 pub use logger::PluginLogger;

--- a/crates/basalt-server/src/game/tick.rs
+++ b/crates/basalt-server/src/game/tick.rs
@@ -1758,6 +1758,11 @@ impl GameLoop {
                 } => {
                     self.spawn_item_entity(*x, *y, *z, *item_id, *count);
                 }
+                Response::OpenChest { x, y, z } => {
+                    if let Some(eid) = self.ecs.find_by_uuid(source_uuid) {
+                        self.open_chest(eid, *x, *y, *z);
+                    }
+                }
             }
         }
     }

--- a/crates/basalt-server/src/net/task.rs
+++ b/crates/basalt-server/src/net/task.rs
@@ -834,7 +834,8 @@ async fn process_instant_responses(
             | Response::SendBlockAck { .. }
             | Response::StreamChunks { .. }
             | Response::PersistChunk { .. }
-            | Response::SpawnDroppedItem { .. } => {}
+            | Response::SpawnDroppedItem { .. }
+            | Response::OpenChest { .. } => {}
         }
     }
     Ok(())

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -110,7 +110,7 @@ impl ServerState {
                             Ok(parsed) => (entry.handler)(&parsed, ctx),
                             Err(msg) => {
                                 let err_msg = format!("/{cmd}: {msg}");
-                                ctx.send_message_component(
+                                ctx.chat().send_component(
                                     &basalt_types::TextComponent::text(err_msg).color(
                                         basalt_types::TextColor::Named(
                                             basalt_types::NamedColor::Red,
@@ -120,7 +120,7 @@ impl ServerState {
                             }
                         }
                     } else {
-                        ctx.send_message_component(
+                        ctx.chat().send_component(
                             &basalt_types::TextComponent::text(format!("Unknown command: /{cmd}"))
                                 .color(basalt_types::TextColor::Named(
                                     basalt_types::NamedColor::Red,

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -21,34 +21,38 @@ impl Plugin for BlockPlugin {
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         // Process: mutate world state
         registrar.on::<BlockBrokenEvent>(Stage::Process, 0, |event, ctx| {
-            ctx.world()
+            ctx.world_ctx()
+                .world()
                 .set_block(event.x, event.y, event.z, basalt_world::block::AIR);
         });
 
         registrar.on::<BlockPlacedEvent>(Stage::Process, 0, |event, ctx| {
-            ctx.world()
+            ctx.world_ctx()
+                .world()
                 .set_block(event.x, event.y, event.z, event.block_state);
         });
 
         // Post: acknowledge + broadcast
         registrar.on::<BlockBrokenEvent>(Stage::Post, 0, |event, ctx| {
-            ctx.send_block_ack(event.sequence);
-            ctx.broadcast(BroadcastMessage::BlockChanged {
-                x: event.x,
-                y: event.y,
-                z: event.z,
-                block_state: basalt_world::block::AIR as i32,
-            });
+            ctx.world_ctx().send_block_ack(event.sequence);
+            ctx.entities()
+                .broadcast_raw(BroadcastMessage::BlockChanged {
+                    x: event.x,
+                    y: event.y,
+                    z: event.z,
+                    block_state: basalt_world::block::AIR as i32,
+                });
         });
 
         registrar.on::<BlockPlacedEvent>(Stage::Post, 0, |event, ctx| {
-            ctx.send_block_ack(event.sequence);
-            ctx.broadcast(BroadcastMessage::BlockChanged {
-                x: event.x,
-                y: event.y,
-                z: event.z,
-                block_state: event.block_state as i32,
-            });
+            ctx.world_ctx().send_block_ack(event.sequence);
+            ctx.entities()
+                .broadcast_raw(BroadcastMessage::BlockChanged {
+                    x: event.x,
+                    y: event.y,
+                    z: event.z,
+                    block_state: event.block_state as i32,
+                });
         });
     }
 }

--- a/plugins/chat/src/lib.rs
+++ b/plugins/chat/src/lib.rs
@@ -24,7 +24,7 @@ impl Plugin for ChatPlugin {
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<ChatMessageEvent>(Stage::Post, 0, |event, ctx| {
             let component = build_chat_component(&event.username, &event.message);
-            ctx.broadcast_message_component(&component);
+            ctx.chat().broadcast_component(&component);
         });
     }
 }

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -39,20 +39,21 @@ impl Plugin for CommandPlugin {
             .variant(|v| v.arg("targets", Arg::Entity).arg("location", Arg::Vec3))
             .handler(|args, ctx| {
                 if let Some((x, y, z)) = args.get_vec3("location") {
-                    ctx.teleport(x, y, z, ctx.player_yaw(), ctx.player_pitch());
-                    ctx.send_message_component(
+                    ctx.player()
+                        .teleport(x, y, z, ctx.player().yaw(), ctx.player().pitch());
+                    ctx.chat().send_component(
                         &TextComponent::text(format!("Teleported to {x}, {y}, {z}"))
                             .color(TextColor::Named(NamedColor::Green)),
                     );
                 } else if let Some(target) = args.get_string("destination") {
-                    ctx.send_message_component(
+                    ctx.chat().send_component(
                         &TextComponent::text(format!(
                             "Teleport to player '{target}' not yet implemented"
                         ))
                         .color(TextColor::Named(NamedColor::Yellow)),
                     );
                 } else if args.get_string("targets").is_some() {
-                    ctx.send_message_component(
+                    ctx.chat().send_component(
                         &TextComponent::text("Teleport targets not yet implemented")
                             .color(TextColor::Named(NamedColor::Yellow)),
                     );
@@ -83,8 +84,8 @@ impl Plugin for CommandPlugin {
                     "adventure" => Gamemode::Adventure,
                     _ => Gamemode::Spectator,
                 };
-                ctx.set_gamemode(mode);
-                ctx.send_message_component(
+                ctx.player().set_gamemode(mode);
+                ctx.chat().send_component(
                     &TextComponent::text(format!("Game mode set to {mode}"))
                         .color(TextColor::Named(NamedColor::Green)),
                 );
@@ -103,7 +104,7 @@ impl Plugin for CommandPlugin {
                     .append(
                         TextComponent::text(message).color(TextColor::Named(NamedColor::White)),
                     );
-                ctx.broadcast_message_component(&msg);
+                ctx.chat().broadcast_component(&msg);
             });
 
         // /stop
@@ -111,7 +112,7 @@ impl Plugin for CommandPlugin {
             .command("stop")
             .description("Stop the server")
             .handler(|_args, ctx| {
-                ctx.broadcast_message_component(
+                ctx.chat().broadcast_component(
                     &TextComponent::text("Server is shutting down...")
                         .color(TextColor::Named(NamedColor::Red))
                         .bold(true),
@@ -131,7 +132,7 @@ impl Plugin for CommandPlugin {
                 log.info(format_args!(
                     "Kick issued for {target} — not yet implemented"
                 ));
-                ctx.send_message_component(
+                ctx.chat().send_component(
                     &TextComponent::text(format!("Kick not yet implemented: {target}"))
                         .color(TextColor::Named(NamedColor::Yellow)),
                 );
@@ -142,7 +143,7 @@ impl Plugin for CommandPlugin {
             .command("list")
             .description("List connected players")
             .handler(|_args, ctx| {
-                ctx.send_message_component(
+                ctx.chat().send_component(
                     &TextComponent::text("Player list not yet implemented")
                         .color(TextColor::Named(NamedColor::Yellow)),
                 );
@@ -155,7 +156,7 @@ impl Plugin for CommandPlugin {
             .handler(|_args, ctx| {
                 let mut msg = TextComponent::text("Available commands:")
                     .color(TextColor::Named(NamedColor::Gold));
-                let mut cmds = ctx.registered_commands();
+                let mut cmds = ctx.player().registered_commands();
                 cmds.sort_by(|(a, _), (b, _)| a.cmp(b));
                 for (name, desc) in &cmds {
                     msg = msg
@@ -168,7 +169,7 @@ impl Plugin for CommandPlugin {
                                 .color(TextColor::Named(NamedColor::Gray)),
                         );
                 }
-                ctx.send_message_component(&msg);
+                ctx.chat().send_component(&msg);
             });
     }
 }

--- a/plugins/drops/src/lib.rs
+++ b/plugins/drops/src/lib.rs
@@ -31,7 +31,8 @@ impl Plugin for DropsPlugin {
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<BlockBrokenEvent>(Stage::Post, 0, |event, ctx| {
             if let Some(item_id) = block::block_state_to_item_id(event.block_state) {
-                ctx.spawn_dropped_item(event.x, event.y, event.z, item_id, 1);
+                ctx.entities()
+                    .spawn_dropped_item(event.x, event.y, event.z, item_id, 1);
             }
         });
     }

--- a/plugins/lifecycle/src/lib.rs
+++ b/plugins/lifecycle/src/lib.rs
@@ -23,13 +23,14 @@ impl Plugin for LifecyclePlugin {
 
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<PlayerJoinedEvent>(Stage::Post, 0, |event, ctx| {
-            ctx.broadcast(BroadcastMessage::PlayerJoined {
-                info: event.info.clone(),
-            });
+            ctx.entities()
+                .broadcast_raw(BroadcastMessage::PlayerJoined {
+                    info: event.info.clone(),
+                });
         });
 
         registrar.on::<PlayerLeftEvent>(Stage::Post, 0, |event, ctx| {
-            ctx.broadcast(BroadcastMessage::PlayerLeft {
+            ctx.entities().broadcast_raw(BroadcastMessage::PlayerLeft {
                 uuid: event.uuid,
                 entity_id: event.entity_id,
                 username: event.username.clone(),

--- a/plugins/movement/src/lib.rs
+++ b/plugins/movement/src/lib.rs
@@ -22,7 +22,7 @@ impl Plugin for MovementPlugin {
 
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<PlayerMovedEvent>(Stage::Post, 0, |event, ctx| {
-            ctx.broadcast(BroadcastMessage::EntityMoved {
+            ctx.entities().broadcast_raw(BroadcastMessage::EntityMoved {
                 entity_id: event.entity_id,
                 x: event.x,
                 y: event.y,

--- a/plugins/world/src/lib.rs
+++ b/plugins/world/src/lib.rs
@@ -26,7 +26,7 @@ impl Plugin for WorldPlugin {
             let new_cx = (event.x.floor() as i32) >> 4;
             let new_cz = (event.z.floor() as i32) >> 4;
             if new_cx != event.old_cx || new_cz != event.old_cz {
-                ctx.stream_chunks(new_cx, new_cz);
+                ctx.world_ctx().stream_chunks(new_cx, new_cz);
             }
         });
     }


### PR DESCRIPTION
## Summary

Phase 1 of the game loop refactoring plan. Replaces the flat 17-method Context trait with 5 domain-specific sub-context traits:

- **PlayerContext**: uuid, entity_id, username, yaw, pitch, teleport, set_gamemode, registered_commands
- **ChatContext**: send, send_component, action_bar, broadcast, broadcast_component
- **WorldContext**: world, send_block_ack, stream_chunks, persist_chunk
- **EntityContext**: spawn_dropped_item, broadcast_raw
- **ContainerContext**: open_chest (new)

Access via ctx.player(), ctx.chat(), ctx.world_ctx(), ctx.entities(), ctx.containers().

All 9 plugins mechanically migrated. New Response::OpenChest variant.

## Test plan

- [x] All tests pass (unit + e2e)
- [x] Clippy clean
- [x] Coverage 90.65%
- [x] All plugins compile and function identically
- [x] dyn Context works for command handlers
