### PR TITLE
feat(server): ContainerPlugin, PlayerInteractEvent, rename DropsPlugin → ItemPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "basalt-plugin-drops"
+name = "basalt-plugin-container"
+version = "0.1.0"
+dependencies = [
+ "basalt-api",
+ "basalt-plugin-block",
+ "basalt-testkit",
+ "basalt-types",
+ "basalt-world",
+]
+
+[[package]]
+name = "basalt-plugin-item"
 version = "0.1.0"
 dependencies = [
  "basalt-api",
@@ -278,7 +289,8 @@ dependencies = [
  "basalt-plugin-block",
  "basalt-plugin-chat",
  "basalt-plugin-command",
- "basalt-plugin-drops",
+ "basalt-plugin-container",
+ "basalt-plugin-item",
  "basalt-plugin-lifecycle",
  "basalt-plugin-movement",
  "basalt-plugin-physics",

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -310,10 +310,16 @@ const physics = [
   'physics',
 ];
 
-const drops = [
-  // Drops plugin: item entity spawning on block break.
-  // Example: "feat(drops): spawn item entity on block break"
-  'drops',
+const item = [
+  // Item plugin: dropped item lifecycle (spawn, pickup, despawn).
+  // Example: "feat(item): add item merging for nearby stacks"
+  'item',
+];
+
+const container = [
+  // Container plugin: chest interaction, double chests, block entities.
+  // Example: "feat(container): add ender chest support"
+  'container',
 ];
 
 const keywords = [
@@ -376,7 +382,7 @@ const keywords = [
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...api, ...core, ...command, ...storage, ...ecs, ...physics, ...drops, ...keywords]],
+    'scope-enum': [2, 'always', [...types, ...derive, ...protocol, ...net, ...server, ...world, ...events, ...api, ...core, ...command, ...storage, ...ecs, ...physics, ...item, ...container, ...keywords]],
     'scope-empty': [2, 'never'],
   },
 };

--- a/crates/basalt-api/src/events.rs
+++ b/crates/basalt-api/src/events.rs
@@ -267,6 +267,32 @@ pub struct PlayerLeftEvent {
 }
 game_event!(PlayerLeftEvent);
 
+/// A player right-clicked on a block (use item on block).
+///
+/// Fired before any container interaction or block placement.
+/// If cancelled by a handler (e.g., ContainerPlugin opens a chest),
+/// the game loop skips block placement entirely.
+#[derive(Debug, Clone)]
+pub struct PlayerInteractEvent {
+    /// Block X coordinate that was right-clicked.
+    pub x: i32,
+    /// Block Y coordinate that was right-clicked.
+    pub y: i32,
+    /// Block Z coordinate that was right-clicked.
+    pub z: i32,
+    /// UUID of the interacting player.
+    pub player_uuid: Uuid,
+    /// Block state at the clicked position.
+    pub block_state: u16,
+    /// Face direction clicked (0-5).
+    pub direction: i32,
+    /// Sequence number for acknowledgement.
+    pub sequence: i32,
+    /// Whether this event has been cancelled.
+    pub cancelled: bool,
+}
+game_cancellable_event!(PlayerInteractEvent);
+
 #[cfg(test)]
 mod tests {
     use basalt_events::Event;

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -36,8 +36,8 @@ pub mod prelude {
 
     pub use crate::context::{Response, ServerContext};
     pub use crate::events::{
-        BlockBrokenEvent, BlockPlacedEvent, ChatMessageEvent, CommandEvent, PlayerJoinedEvent,
-        PlayerLeftEvent, PlayerMovedEvent,
+        BlockBrokenEvent, BlockPlacedEvent, ChatMessageEvent, CommandEvent, PlayerInteractEvent,
+        PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent,
     };
     pub use crate::plugin::{Plugin, PluginMetadata, PluginRegistrar};
     pub use basalt_events::{Event, Stage};

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -22,7 +22,8 @@ basalt-plugin-command = { path = "../../plugins/command" }
 basalt-plugin-block = { path = "../../plugins/block" }
 basalt-plugin-world = { path = "../../plugins/world" }
 basalt-plugin-storage = { path = "../../plugins/storage" }
-basalt-plugin-drops = { path = "../../plugins/drops" }
+basalt-plugin-item = { path = "../../plugins/item" }
+basalt-plugin-container = { path = "../../plugins/container" }
 basalt-plugin-physics = { path = "../../plugins/physics" }
 basalt-plugin-lifecycle = { path = "../../plugins/lifecycle" }
 basalt-plugin-movement = { path = "../../plugins/movement" }

--- a/crates/basalt-server/src/config.rs
+++ b/crates/basalt-server/src/config.rs
@@ -193,6 +193,8 @@ pub struct PluginsSection {
     pub physics: bool,
     /// Item drops on block break.
     pub drops: bool,
+    /// Container interaction (chests).
+    pub container: bool,
 }
 
 impl Default for ServerSection {
@@ -239,6 +241,7 @@ impl Default for PluginsSection {
             movement: true,
             physics: true,
             drops: true,
+            container: true,
         }
     }
 }
@@ -364,7 +367,10 @@ impl ServerConfig {
             plugins.push(Box::new(basalt_plugin_storage::StoragePlugin));
         }
         if self.plugins.drops && self.plugins.block {
-            plugins.push(Box::new(basalt_plugin_drops::DropsPlugin));
+            plugins.push(Box::new(basalt_plugin_item::ItemPlugin));
+        }
+        if self.plugins.container && self.plugins.block {
+            plugins.push(Box::new(basalt_plugin_container::ContainerPlugin));
         }
         if self.plugins.physics {
             plugins.push(Box::new(basalt_plugin_physics::PhysicsPlugin));
@@ -455,8 +461,8 @@ storage = "none"
     fn create_plugins_all_enabled() {
         let config = ServerConfig::default();
         let plugins = config.create_plugins();
-        // 9 built-in plugins
-        assert_eq!(plugins.len(), 9);
+        // 10 built-in plugins
+        assert_eq!(plugins.len(), 10);
     }
 
     #[test]
@@ -464,8 +470,8 @@ storage = "none"
         let mut config = ServerConfig::default();
         config.world.storage = StorageMode::ReadOnly;
         let plugins = config.create_plugins();
-        // 8 plugins: no StoragePlugin (drops + physics still enabled)
-        assert_eq!(plugins.len(), 8);
+        // 9 plugins: no StoragePlugin (drops + container + physics still enabled)
+        assert_eq!(plugins.len(), 9);
         assert!(plugins.iter().all(|p| p.metadata().name != "storage"));
     }
 

--- a/crates/basalt-server/src/game/blocks.rs
+++ b/crates/basalt-server/src/game/blocks.rs
@@ -3,12 +3,12 @@
 use std::sync::Arc;
 
 use basalt_api::context::ServerContext;
-use basalt_api::events::{BlockBrokenEvent, BlockPlacedEvent};
+use basalt_api::events::{BlockBrokenEvent, BlockPlacedEvent, PlayerInteractEvent};
 use basalt_events::Event;
 use basalt_types::Uuid;
 
 use super::{GameLoop, OutputHandle, Sneaking};
-use crate::messages::{BroadcastEvent, ServerOutput, SharedBroadcast};
+use crate::messages::ServerOutput;
 
 impl GameLoop {
     /// Handles a block dig (break).
@@ -49,58 +49,6 @@ impl GameLoop {
         }
 
         self.process_responses(uuid, &ctx.drain_responses());
-
-        // Collect items to drop from block entity before removing it
-        let items_to_drop: Vec<(i32, i32)> = self
-            .world
-            .get_block_entity(x, y, z)
-            .map(|be| match &*be {
-                basalt_world::block_entity::BlockEntity::Chest { slots } => slots
-                    .iter()
-                    .filter_map(|s| s.item_id.map(|id| (id, s.item_count)))
-                    .collect(),
-            })
-            .unwrap_or_default();
-
-        self.world.remove_block_entity(x, y, z);
-
-        // Spawn dropped items for chest contents
-        for (item_id, count) in items_to_drop {
-            self.spawn_item_entity(x, y, z, item_id, count);
-        }
-
-        // If this was part of a double chest, revert the other half to single
-        if basalt_world::block::is_chest(original_state)
-            && basalt_world::block::chest_type(original_state) != 0
-        {
-            let facing = basalt_world::block::chest_facing(original_state);
-            let offsets = basalt_world::block::chest_adjacent_offsets(facing);
-            for (dx, dz) in offsets {
-                let nx = x + dx;
-                let nz = z + dz;
-                let neighbor = self.world.get_block(nx, y, nz);
-                if basalt_world::block::is_chest(neighbor)
-                    && basalt_world::block::chest_facing(neighbor) == facing
-                    && basalt_world::block::chest_type(neighbor) != 0
-                {
-                    let single = basalt_world::block::chest_state(facing, 0);
-                    self.world.set_block(nx, y, nz, single);
-                    self.chunk_cache.invalidate(nx >> 4, nz >> 4);
-                    let bc = Arc::new(SharedBroadcast::new(BroadcastEvent::BlockChanged {
-                        x: nx,
-                        y,
-                        z: nz,
-                        state: i32::from(single),
-                    }));
-                    for (e, _) in self.ecs.iter::<OutputHandle>() {
-                        self.send_to(e, |tx| {
-                            let _ = tx.try_send(ServerOutput::Broadcast(Arc::clone(&bc)));
-                        });
-                    }
-                    break;
-                }
-            }
-        }
     }
 
     /// Handles a block place.
@@ -117,13 +65,36 @@ impl GameLoop {
             return;
         };
 
-        // Check if the clicked block is an interactable container
-        // Sneaking players skip interaction and place blocks instead
+        // Dispatch PlayerInteractEvent for the clicked block.
+        // Plugins (e.g., ContainerPlugin) can cancel to prevent placement.
         let is_sneaking = self.ecs.has::<Sneaking>(eid);
         let clicked_state = self.world.get_block(x, y, z);
-        if !is_sneaking && basalt_world::block::is_chest(clicked_state) {
-            self.open_chest(eid, x, y, z);
-            return;
+        if !is_sneaking {
+            let entity_id = eid as i32;
+            let username = self
+                .ecs
+                .get::<basalt_ecs::PlayerRef>(eid)
+                .map_or_else(String::new, |pr| pr.username.clone());
+            let (yaw, pitch) = self
+                .ecs
+                .get::<basalt_ecs::Rotation>(eid)
+                .map_or((0.0, 0.0), |r| (r.yaw, r.pitch));
+            let ctx = self.make_context(uuid, entity_id, &username, yaw, pitch);
+            let mut interact = PlayerInteractEvent {
+                x,
+                y,
+                z,
+                player_uuid: uuid,
+                block_state: clicked_state,
+                direction,
+                sequence,
+                cancelled: false,
+            };
+            self.bus.dispatch(&mut interact, &ctx);
+            self.process_responses(uuid, &ctx.drain_responses());
+            if interact.is_cancelled() {
+                return;
+            }
         }
 
         let (dx, dy, dz) = face_offset(direction);
@@ -136,25 +107,28 @@ impl GameLoop {
             let Some(item_id) = inv.held_item().item_id else {
                 return;
             };
-            let Some(mut block_state) = basalt_world::block::item_to_default_block_state(item_id)
+            let Some(block_state) = basalt_world::block::item_to_default_block_state(item_id)
             else {
                 return;
             };
-            // Orient directional blocks based on player yaw
-            if basalt_world::block::is_chest(block_state) {
-                let yaw = self
-                    .ecs
-                    .get::<basalt_ecs::Rotation>(eid)
-                    .map_or(0.0, |r| r.yaw);
-                block_state = basalt_world::block::chest_state_for_yaw(yaw);
-            }
             let Some(pr) = self.ecs.get::<basalt_ecs::PlayerRef>(eid) else {
                 return;
             };
             (eid as i32, pr.username.clone(), block_state)
         };
 
-        let ctx = ServerContext::new(Arc::clone(&self.world), uuid, entity_id, username, 0.0, 0.0);
+        let (yaw, pitch) = self
+            .ecs
+            .get::<basalt_ecs::Rotation>(eid)
+            .map_or((0.0, 0.0), |r| (r.yaw, r.pitch));
+        let ctx = ServerContext::new(
+            Arc::clone(&self.world),
+            uuid,
+            entity_id,
+            username,
+            yaw,
+            pitch,
+        );
         let mut event = BlockPlacedEvent {
             x: px,
             y: py,
@@ -179,111 +153,8 @@ impl GameLoop {
         }
 
         self.process_responses(uuid, &ctx.drain_responses());
-
-        // Create block entity for interactive blocks (chests)
-        if basalt_world::block::is_chest(block_state) {
-            self.world.set_block_entity(
-                px,
-                py,
-                pz,
-                basalt_world::block_entity::BlockEntity::empty_chest(),
-            );
-
-            // Double chest pairing logic:
-            // - Not sneaking: scan adjacent blocks for a single chest to pair with
-            // - Sneaking + clicked a chest: pair only with the clicked chest
-            // - Sneaking + clicked non-chest: no pairing (single chest)
-            let facing = basalt_world::block::chest_facing(block_state);
-            let mut paired = false;
-
-            // Build candidate list: either all adjacent or just the clicked chest
-            let candidates: Vec<(i32, i32)> = if !is_sneaking {
-                basalt_world::block::chest_adjacent_offsets(facing)
-                    .iter()
-                    .map(|&(ddx, ddz)| (px + ddx, pz + ddz))
-                    .collect()
-            } else if basalt_world::block::is_chest(clicked_state) {
-                // Sneaking on a chest: pair only if new chest is lateral (left/right)
-                let valid_offsets = basalt_world::block::chest_adjacent_offsets(facing);
-                let actual_offset = (px - x, pz - z);
-                if valid_offsets.contains(&actual_offset) {
-                    vec![(x, z)]
-                } else {
-                    vec![] // front/back placement: no pairing
-                }
-            } else {
-                vec![] // sneaking on non-chest: no pairing
-            };
-
-            for &(nx, nz) in &candidates {
-                let neighbor = self.world.get_block(nx, py, nz);
-                if basalt_world::block::is_single_chest(neighbor)
-                    && basalt_world::block::chest_facing(neighbor) == facing
-                {
-                    // Compute offset from new chest to neighbor
-                    let ddx = nx - px;
-                    let ddz = nz - pz;
-                    let (new_type, existing_type) =
-                        basalt_world::block::chest_double_types(facing, ddx, ddz);
-                    let new_state = basalt_world::block::chest_state(facing, new_type);
-                    self.world.set_block(px, py, pz, new_state);
-                    let neighbor_state = basalt_world::block::chest_state(facing, existing_type);
-                    self.world.set_block(nx, py, nz, neighbor_state);
-                    self.chunk_cache.invalidate(px >> 4, pz >> 4);
-                    self.chunk_cache.invalidate(nx >> 4, nz >> 4);
-                    for (e, _) in self.ecs.iter::<OutputHandle>() {
-                        self.send_to(e, |tx| {
-                            let _ = tx.try_send(ServerOutput::BlockChanged {
-                                x: px,
-                                y: py,
-                                z: pz,
-                                state: i32::from(new_state),
-                            });
-                            let _ = tx.try_send(ServerOutput::BlockEntityData {
-                                x: px,
-                                y: py,
-                                z: pz,
-                                action: 2,
-                            });
-                            let _ = tx.try_send(ServerOutput::BlockChanged {
-                                x: nx,
-                                y: py,
-                                z: nz,
-                                state: i32::from(neighbor_state),
-                            });
-                            let _ = tx.try_send(ServerOutput::BlockEntityData {
-                                x: nx,
-                                y: py,
-                                z: nz,
-                                action: 2,
-                            });
-                        });
-                    }
-                    paired = true;
-                    break;
-                }
-            }
-
-            if !paired {
-                // Single chest — broadcast normally
-                for (e, _) in self.ecs.iter::<OutputHandle>() {
-                    self.send_to(e, |tx| {
-                        let _ = tx.try_send(ServerOutput::BlockChanged {
-                            x: px,
-                            y: py,
-                            z: pz,
-                            state: i32::from(block_state),
-                        });
-                        let _ = tx.try_send(ServerOutput::BlockEntityData {
-                            x: px,
-                            y: py,
-                            z: pz,
-                            action: 2,
-                        });
-                    });
-                }
-            }
-        }
+        // Block entity creation, chest orientation, and double chest
+        // pairing are handled by ContainerPlugin via BlockPlacedEvent Post.
     }
 }
 

--- a/crates/basalt-server/src/game/mod.rs
+++ b/crates/basalt-server/src/game/mod.rs
@@ -236,7 +236,8 @@ pub(super) mod tests {
                 Arc::clone(&world),
             );
             basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
-            basalt_plugin_drops::DropsPlugin.on_enable(&mut registrar);
+            basalt_plugin_item::ItemPlugin.on_enable(&mut registrar);
+            basalt_plugin_container::ContainerPlugin.on_enable(&mut registrar);
         }
 
         let mut ecs = basalt_ecs::Ecs::new();

--- a/plugins/container/Cargo.toml
+++ b/plugins/container/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "basalt-plugin-container"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+basalt-api = { workspace = true }
+basalt-world = { workspace = true }
+
+[dev-dependencies]
+basalt-testkit = { workspace = true }
+basalt-types = { workspace = true }
+basalt-world = { workspace = true }
+basalt-plugin-block = { path = "../block" }

--- a/plugins/container/src/lib.rs
+++ b/plugins/container/src/lib.rs
@@ -1,0 +1,230 @@
+//! Container plugin — chest interaction, double chest pairing, block entities.
+//!
+//! Handles all container-related game logic via events:
+//! - [`PlayerInteractEvent`]: opens chests on right-click (cancels to prevent block placement)
+//! - [`BlockPlacedEvent`]: creates chest block entities, handles double chest pairing and orientation
+//! - [`BlockBrokenEvent`]: drops chest contents, removes block entities, reverts double chests
+
+use basalt_api::prelude::*;
+use basalt_world::block;
+use basalt_world::block_entity::BlockEntity;
+
+/// Handles chest interaction, double chest pairing, and block entity lifecycle.
+pub struct ContainerPlugin;
+
+impl Plugin for ContainerPlugin {
+    fn metadata(&self) -> PluginMetadata {
+        PluginMetadata {
+            name: "container",
+            version: "0.1.0",
+            author: Some("Basalt"),
+            dependencies: &["block"],
+        }
+    }
+
+    fn on_enable(&self, registrar: &mut PluginRegistrar) {
+        // Open chest on right-click (Process stage, cancels event)
+        registrar.on::<PlayerInteractEvent>(Stage::Process, 0, |event, ctx| {
+            if block::is_chest(event.block_state) {
+                ctx.containers().open_chest(event.x, event.y, event.z);
+                event.cancel();
+            }
+        });
+
+        // Create block entity + handle double chest on placement (Post stage)
+        registrar.on::<BlockPlacedEvent>(Stage::Post, 5, |event, ctx| {
+            let state = event.block_state;
+            if !block::is_chest(state) {
+                return;
+            }
+
+            let world = ctx.world_ctx().world();
+
+            // Create block entity
+            world.set_block_entity(event.x, event.y, event.z, BlockEntity::empty_chest());
+
+            // Orient chest based on player yaw
+            let yaw = ctx.player().yaw();
+            let oriented = block::chest_state_for_yaw(yaw);
+            world.set_block(event.x, event.y, event.z, oriented);
+            ctx.entities()
+                .broadcast_raw(BroadcastMessage::BlockChanged {
+                    x: event.x,
+                    y: event.y,
+                    z: event.z,
+                    block_state: i32::from(oriented),
+                });
+
+            // Double chest pairing — scan adjacent for single chest with same facing
+            let facing = block::chest_facing(oriented);
+            let offsets = block::chest_adjacent_offsets(facing);
+            for &(dx, dz) in &offsets {
+                let nx = event.x + dx;
+                let nz = event.z + dz;
+                let neighbor = world.get_block(nx, event.y, nz);
+                if block::is_single_chest(neighbor) && block::chest_facing(neighbor) == facing {
+                    let ddx = nx - event.x;
+                    let ddz = nz - event.z;
+                    let (new_type, existing_type) = block::chest_double_types(facing, ddx, ddz);
+                    let new_state = block::chest_state(facing, new_type);
+                    let neighbor_state = block::chest_state(facing, existing_type);
+                    world.set_block(event.x, event.y, event.z, new_state);
+                    world.set_block(nx, event.y, nz, neighbor_state);
+                    world.mark_chunk_dirty(event.x >> 4, event.z >> 4);
+                    world.mark_chunk_dirty(nx >> 4, nz >> 4);
+                    ctx.entities()
+                        .broadcast_raw(BroadcastMessage::BlockChanged {
+                            x: event.x,
+                            y: event.y,
+                            z: event.z,
+                            block_state: i32::from(new_state),
+                        });
+                    ctx.entities()
+                        .broadcast_raw(BroadcastMessage::BlockChanged {
+                            x: nx,
+                            y: event.y,
+                            z: nz,
+                            block_state: i32::from(neighbor_state),
+                        });
+                    break;
+                }
+            }
+        });
+
+        // Drop chest contents + remove block entity on break (Post, before drops plugin)
+        registrar.on::<BlockBrokenEvent>(Stage::Post, -1, |event, ctx| {
+            let state = event.block_state;
+            if !block::is_chest(state) {
+                return;
+            }
+
+            let world = ctx.world_ctx().world();
+
+            // Drop contents
+            if let Some(be) = world.get_block_entity(event.x, event.y, event.z) {
+                match &*be {
+                    BlockEntity::Chest { slots } => {
+                        for slot in slots.iter() {
+                            if let Some(item_id) = slot.item_id {
+                                ctx.entities().spawn_dropped_item(
+                                    event.x,
+                                    event.y,
+                                    event.z,
+                                    item_id,
+                                    slot.item_count,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Remove block entity
+            world.remove_block_entity(event.x, event.y, event.z);
+
+            // Revert double chest partner to single
+            if block::chest_type(state) != 0 {
+                let facing = block::chest_facing(state);
+                let offsets = block::chest_adjacent_offsets(facing);
+                for &(dx, dz) in &offsets {
+                    let nx = event.x + dx;
+                    let nz = event.z + dz;
+                    let neighbor = world.get_block(nx, event.y, nz);
+                    if block::is_chest(neighbor)
+                        && block::chest_facing(neighbor) == facing
+                        && block::chest_type(neighbor) != 0
+                    {
+                        let single = block::chest_state(facing, 0);
+                        world.set_block(nx, event.y, nz, single);
+                        world.mark_chunk_dirty(nx >> 4, nz >> 4);
+                        ctx.entities()
+                            .broadcast_raw(BroadcastMessage::BlockChanged {
+                                x: nx,
+                                y: event.y,
+                                z: nz,
+                                block_state: i32::from(single),
+                            });
+                        break;
+                    }
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use basalt_testkit::PluginTestHarness;
+    use basalt_types::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn interact_on_chest_cancels_event() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(ContainerPlugin);
+
+        let mut event = PlayerInteractEvent {
+            x: 5,
+            y: 64,
+            z: 3,
+            player_uuid: Uuid::default(),
+            block_state: block::CHEST,
+            direction: 1,
+            sequence: 1,
+            cancelled: false,
+        };
+
+        harness.dispatch(&mut event);
+        assert!(event.is_cancelled(), "interact on chest should cancel");
+    }
+
+    #[test]
+    fn interact_on_non_chest_does_not_cancel() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(ContainerPlugin);
+
+        let mut event = PlayerInteractEvent {
+            x: 5,
+            y: 64,
+            z: 3,
+            player_uuid: Uuid::default(),
+            block_state: block::STONE,
+            direction: 1,
+            sequence: 1,
+            cancelled: false,
+        };
+
+        harness.dispatch(&mut event);
+        assert!(!event.is_cancelled(), "interact on stone should not cancel");
+    }
+
+    #[test]
+    fn chest_break_removes_block_entity() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(basalt_plugin_block::BlockPlugin);
+        harness.register(ContainerPlugin);
+
+        // Place a chest block entity manually
+        harness.world().set_block(5, 64, 3, block::CHEST);
+        harness
+            .world()
+            .set_block_entity(5, 64, 3, BlockEntity::empty_chest());
+
+        let mut event = BlockBrokenEvent {
+            x: 5,
+            y: 64,
+            z: 3,
+            block_state: block::CHEST,
+            sequence: 1,
+            player_uuid: Uuid::default(),
+            cancelled: false,
+        };
+
+        harness.dispatch(&mut event);
+        assert!(
+            harness.world().get_block_entity(5, 64, 3).is_none(),
+            "block entity should be removed"
+        );
+    }
+}

--- a/plugins/item/Cargo.toml
+++ b/plugins/item/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "basalt-plugin-drops"
+name = "basalt-plugin-item"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true

--- a/plugins/item/src/lib.rs
+++ b/plugins/item/src/lib.rs
@@ -1,4 +1,4 @@
-//! Drops plugin — spawns item entities when blocks are broken.
+//! Item plugin — manages dropped item lifecycle.
 //!
 //! Listens to [`BlockBrokenEvent`] in the Post stage (after the block
 //! has been set to AIR by the block plugin) and spawns a dropped item
@@ -16,12 +16,12 @@ use basalt_world::block;
 /// Reads `BlockBrokenEvent.block_state` to determine the item to drop
 /// via [`block::block_state_to_item_id`]. Non-droppable blocks (air,
 /// technical blocks) produce no drop.
-pub struct DropsPlugin;
+pub struct ItemPlugin;
 
-impl Plugin for DropsPlugin {
+impl Plugin for ItemPlugin {
     fn metadata(&self) -> PluginMetadata {
         PluginMetadata {
-            name: "drops",
+            name: "item",
             version: "0.1.0",
             author: Some("Basalt"),
             dependencies: &["block"],
@@ -49,7 +49,7 @@ mod tests {
     fn breaking_stone_produces_drop_response() {
         let mut harness = PluginTestHarness::new();
         harness.register(basalt_plugin_block::BlockPlugin);
-        harness.register(DropsPlugin);
+        harness.register(ItemPlugin);
 
         // Place a stone block first
         harness.world().set_block(5, 64, 3, block::STONE);
@@ -86,7 +86,7 @@ mod tests {
     fn breaking_air_produces_no_drop() {
         let mut harness = PluginTestHarness::new();
         harness.register(basalt_plugin_block::BlockPlugin);
-        harness.register(DropsPlugin);
+        harness.register(ItemPlugin);
 
         let mut event = BlockBrokenEvent {
             x: 5,


### PR DESCRIPTION
## Summary

Phase 3 of the game loop refactoring plan.

- **ContainerPlugin** (new): handles chest interaction via events instead of inline game loop logic
- **PlayerInteractEvent** (new event): dispatched on right-click before placement, cancellable
- **Game loop cleanup**: blocks.rs stripped of all chest-specific logic
- **DropsPlugin → ItemPlugin**: renamed crate + struct for broader domain

## Test plan

- [x] All tests pass
- [x] Clippy clean
- [x] Coverage 90.76%
