### PR TITLE
feat(testkit): add DispatchResult and hide Response from plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Plugin crates under `plugins/`:
   - `Component` marker trait, `EntityId` type alias, `Phase` enum
   - `SystemContext` trait + `SystemContextExt` extension for typed entity access in system plugins
   - `SystemDescriptor`, `SystemBuilder` for system registration
+  - `PlayerInfo` struct (uuid, entity_id, username, rotation) in `player` module
   - `NoopContext` in `testing` module for unit tests that need a `&dyn Context`
   - Shared broadcast types (`BroadcastMessage`, `PlayerSnapshot`, `ProfileProperty`)
 - `basalt-command` provides typed argument API (`Arg`, `Validation`, `CommandArg`, `CommandArgs`, parsing with variant support) and the `Command` trait. Depends on `basalt-core`, NOT on `basalt-api` (no circular dependency).
@@ -197,6 +198,7 @@ crates/basalt-server/
 - **I/O thread** (dedicated OS thread): receives chunk persist requests via channel, writes BSR region files without blocking the game loop. On shutdown, flushes all dirty chunks from World before exiting.
 - Two event buses: **instant bus** (chat, commands — dispatched in net tasks) and **game bus** (blocks, movement, lifecycle — dispatched in game loop).
 - Handlers are sync. They interact with the server through `ServerContext` methods which queue deferred responses.
+- **Panic handling**: infrastructure panics (game loop, I/O thread) crash the server via `process::exit(1)` — detected through `JoinHandle::join()`. Plugin handler panics are caught via `catch_unwind` at the dispatch level: when `crash_on_plugin_panic = false`, the handler is logged and skipped without killing the game loop. Net task panics are monitored via `JoinHandle` and logged without crashing the server.
 - 10 built-in plugins under `plugins/`, each implementing `Plugin`:
 
 | Plugin | Events | Stages |
@@ -633,7 +635,7 @@ Benchmarks (`criterion`) from day one: encode/decode throughput, allocations per
 
 Two test utilities are available:
 
-**`PluginTestHarness`** (`basalt-testkit`) — for event-based plugins:
+**`PluginTestHarness`** (`basalt-testkit`) — for event-based plugins. Returns `DispatchResult` with high-level assertion methods — plugins never import `Response` directly:
 ```rust
 use basalt_testkit::PluginTestHarness;
 
@@ -641,9 +643,13 @@ let mut harness = PluginTestHarness::new();
 harness.register(MyPlugin);
 
 let mut event = BlockBrokenEvent { position: BlockPosition { x: 5, y: 64, z: 3 }, ... };
-let responses = harness.dispatch(&mut event);
-assert!(matches!(responses[0], Response::SendBlockAck { .. }));
+let result = harness.dispatch(&mut event);
+assert_eq!(result.len(), 2);
+assert!(result.has_block_ack_seq(42));
+assert!(result.has_block_change_broadcast());
 ```
+
+`DispatchResult` methods: `len()`, `is_empty()`, `has_block_ack()`, `has_block_ack_seq(n)`, `has_system_chat()`, `has_teleport()`, `has_game_state_change()`, `has_chat_broadcast()`, `has_block_change_broadcast()`, `has_entity_moved_broadcast()`, `has_player_joined_broadcast()`, `has_player_left_broadcast()`, `has_stream_chunks(x, z)`, `has_spawn_dropped_item(item_id, count)`, `has_any_spawn_dropped_item()`.
 
 **`SystemTestContext`** (`basalt-testkit`) — for system plugins:
 ```rust

--- a/crates/basalt-testkit/src/lib.rs
+++ b/crates/basalt-testkit/src/lib.rs
@@ -11,13 +11,14 @@
 //! harness.register(MyPlugin);
 //!
 //! // Dispatch an event
-//! let mut event = BlockBrokenEvent { x: 5, y: 64, z: 3, ... };
-//! let responses = harness.dispatch(&mut event);
-//! assert_eq!(responses.len(), 2);
+//! let mut event = BlockBrokenEvent { position: BlockPosition { x: 5, y: 64, z: 3 }, ... };
+//! let result = harness.dispatch(&mut event);
+//! assert_eq!(result.len(), 2);
+//! assert!(result.has_block_ack());
 //!
 //! // Execute a command
-//! let responses = harness.dispatch_command("tp 10 64 -5");
-//! assert!(matches!(responses[0], Response::SendPosition { .. }));
+//! let result = harness.dispatch_command("tp 10 64 -5");
+//! assert!(result.has_teleport());
 //! ```
 
 use std::sync::Arc;
@@ -153,8 +154,8 @@ impl PluginTestHarness {
         )
     }
 
-    /// Dispatches an event and returns the queued responses.
-    pub fn dispatch(&self, event: &mut dyn Event) -> Vec<Response> {
+    /// Dispatches an event and returns a [`DispatchResult`] for assertions.
+    pub fn dispatch(&self, event: &mut dyn Event) -> DispatchResult {
         let ctx = self.context();
         self.dispatch_routed(event, &ctx);
         let responses = ctx.drain_responses();
@@ -163,13 +164,15 @@ impl PluginTestHarness {
                 self.world.persist_chunk(chunk.x, chunk.z);
             }
         }
-        responses
+        DispatchResult { responses }
     }
 
-    /// Dispatches an event with a specific context and returns responses.
-    pub fn dispatch_with(&self, event: &mut dyn Event, ctx: &ServerContext) -> Vec<Response> {
+    /// Dispatches an event with a specific context and returns a [`DispatchResult`].
+    pub fn dispatch_with(&self, event: &mut dyn Event, ctx: &ServerContext) -> DispatchResult {
         self.dispatch_routed(event, ctx);
-        ctx.drain_responses()
+        DispatchResult {
+            responses: ctx.drain_responses(),
+        }
     }
 
     /// Executes a command by name and returns the responses.
@@ -182,7 +185,8 @@ impl PluginTestHarness {
     /// ```ignore
     /// let responses = harness.dispatch_command("tp 10 64 -5");
     /// ```
-    pub fn dispatch_command(&self, command: &str) -> Vec<Response> {
+    /// Executes a command by name and returns a [`DispatchResult`].
+    pub fn dispatch_command(&self, command: &str) -> DispatchResult {
         let ctx = self.context();
         ctx.set_command_list(
             self.commands
@@ -201,7 +205,9 @@ impl PluginTestHarness {
         {
             (entry.handler)(&parsed, &ctx);
         }
-        ctx.drain_responses()
+        DispatchResult {
+            responses: ctx.drain_responses(),
+        }
     }
 
     /// Returns a reference to the collected command entries.
@@ -221,6 +227,141 @@ impl PluginTestHarness {
 impl Default for PluginTestHarness {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Result of dispatching an event through the test harness.
+///
+/// Wraps the internal response queue and provides high-level assertion
+/// methods. Plugin tests use this instead of inspecting `Response`
+/// variants directly.
+pub struct DispatchResult {
+    responses: Vec<Response>,
+}
+
+impl DispatchResult {
+    /// Returns the number of queued responses.
+    pub fn len(&self) -> usize {
+        self.responses.len()
+    }
+
+    /// Returns true if no responses were queued.
+    pub fn is_empty(&self) -> bool {
+        self.responses.is_empty()
+    }
+
+    /// Returns true if any response is a block acknowledgement.
+    pub fn has_block_ack(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::SendBlockAck { .. }))
+    }
+
+    /// Returns true if any response is a block ack with the given sequence.
+    pub fn has_block_ack_seq(&self, seq: i32) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::SendBlockAck { sequence } if *sequence == seq))
+    }
+
+    /// Returns true if any response is a system chat message.
+    pub fn has_system_chat(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::SendSystemChat { .. }))
+    }
+
+    /// Returns true if any response is a teleport.
+    pub fn has_teleport(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::SendPosition { .. }))
+    }
+
+    /// Returns true if any response is a game state change.
+    pub fn has_game_state_change(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::SendGameStateChange { .. }))
+    }
+
+    /// Returns true if any response is a chat broadcast.
+    pub fn has_chat_broadcast(&self) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::Broadcast(basalt_core::BroadcastMessage::Chat { .. })
+            )
+        })
+    }
+
+    /// Returns true if any response is a block change broadcast.
+    pub fn has_block_change_broadcast(&self) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::Broadcast(basalt_core::BroadcastMessage::BlockChanged { .. })
+            )
+        })
+    }
+
+    /// Returns true if any response is an entity moved broadcast.
+    pub fn has_entity_moved_broadcast(&self) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::Broadcast(basalt_core::BroadcastMessage::EntityMoved { .. })
+            )
+        })
+    }
+
+    /// Returns true if any response is a player joined broadcast.
+    pub fn has_player_joined_broadcast(&self) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::Broadcast(basalt_core::BroadcastMessage::PlayerJoined { .. })
+            )
+        })
+    }
+
+    /// Returns true if any response is a player left broadcast.
+    pub fn has_player_left_broadcast(&self) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::Broadcast(basalt_core::BroadcastMessage::PlayerLeft { .. })
+            )
+        })
+    }
+
+    /// Returns true if any response streams chunks to the given position.
+    pub fn has_stream_chunks(&self, x: i32, z: i32) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::StreamChunks(basalt_core::ChunkPosition { x: cx, z: cz })
+                if *cx == x && *cz == z
+            )
+        })
+    }
+
+    /// Returns true if any response spawns a dropped item with the given ID and count.
+    pub fn has_spawn_dropped_item(&self, item_id: i32, count: i32) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::SpawnDroppedItem { item_id: id, count: c, .. }
+                if *id == item_id && *c == count
+            )
+        })
+    }
+
+    /// Returns true if any response spawns any dropped item.
+    pub fn has_any_spawn_dropped_item(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::SpawnDroppedItem { .. }))
     }
 }
 

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -83,21 +83,15 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
+        let result = harness.dispatch(&mut event);
 
         assert_eq!(
             harness.world().get_block(5, 64, 3),
             basalt_api::world::block::AIR
         );
-        assert_eq!(responses.len(), 2);
-        assert!(matches!(
-            responses[0],
-            Response::SendBlockAck { sequence: 42 }
-        ));
-        assert!(matches!(
-            responses[1],
-            Response::Broadcast(BroadcastMessage::BlockChanged { .. })
-        ));
+        assert_eq!(result.len(), 2);
+        assert!(result.has_block_ack_seq(42));
+        assert!(result.has_block_change_broadcast());
     }
 
     #[test]
@@ -120,13 +114,13 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
+        let result = harness.dispatch(&mut event);
 
         assert_eq!(
             harness.world().get_block(8, 64, 8),
             basalt_api::world::block::STONE
         );
-        assert!(responses.is_empty());
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -141,21 +135,15 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
+        let result = harness.dispatch(&mut event);
 
         assert_eq!(
             harness.world().get_block(5, 64, 3),
             basalt_api::world::block::STONE
         );
-        assert_eq!(responses.len(), 2);
-        assert!(matches!(
-            responses[0],
-            Response::SendBlockAck { sequence: 10 }
-        ));
-        assert!(matches!(
-            responses[1],
-            Response::Broadcast(BroadcastMessage::BlockChanged { .. })
-        ));
+        assert_eq!(result.len(), 2);
+        assert!(result.has_block_ack_seq(10));
+        assert!(result.has_block_change_broadcast());
     }
 
     #[test]
@@ -174,11 +162,11 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
+        let result = harness.dispatch(&mut event);
         assert_eq!(
             harness.world().get_block(5, 200, 3),
             basalt_api::world::block::AIR
         );
-        assert!(responses.is_empty());
+        assert!(result.is_empty());
     }
 }

--- a/plugins/chat/src/lib.rs
+++ b/plugins/chat/src/lib.rs
@@ -39,7 +39,6 @@ pub fn build_chat_component(username: &str, message: &str) -> TextComponent {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::Response;
     use basalt_testkit::PluginTestHarness;
 
     use super::*;
@@ -54,12 +53,9 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::Broadcast(BroadcastMessage::Chat { .. })
-        ));
+        let result = harness.dispatch(&mut event);
+        assert_eq!(result.len(), 1);
+        assert!(result.has_chat_broadcast());
     }
 
     #[test]
@@ -75,8 +71,8 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
-        assert!(responses.is_empty());
+        let result = harness.dispatch(&mut event);
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -89,7 +85,7 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
-        assert_eq!(responses.len(), 1);
+        let result = harness.dispatch(&mut event);
+        assert_eq!(result.len(), 1);
     }
 }

--- a/plugins/command/src/lib.rs
+++ b/plugins/command/src/lib.rs
@@ -183,8 +183,7 @@ impl Default for CommandPlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::Response;
-    use basalt_testkit::PluginTestHarness;
+    use basalt_testkit::{DispatchResult, PluginTestHarness};
 
     use super::*;
 
@@ -194,89 +193,83 @@ mod tests {
         h
     }
 
-    fn dispatch_command(cmd: &str) -> Vec<Response> {
+    fn dispatch_command(cmd: &str) -> DispatchResult {
         harness().dispatch_command(cmd)
     }
 
     #[test]
     fn tp_coords() {
-        let responses = dispatch_command("tp 10 64 -5");
-        assert_eq!(responses.len(), 2);
-        assert!(matches!(responses[0], Response::SendPosition { .. }));
+        let result = dispatch_command("tp 10 64 -5");
+        assert_eq!(result.len(), 2);
+        assert!(result.has_teleport());
     }
 
     #[test]
     fn tp_player() {
-        let responses = dispatch_command("tp Steve");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+        let result = dispatch_command("tp Steve");
+        assert_eq!(result.len(), 1);
+        assert!(result.has_system_chat());
     }
 
     #[test]
     fn gamemode_creative() {
-        let responses = dispatch_command("gamemode creative");
-        assert_eq!(responses.len(), 2);
-        assert!(matches!(responses[0], Response::SendGameStateChange { .. }));
+        let result = dispatch_command("gamemode creative");
+        assert_eq!(result.len(), 2);
+        assert!(result.has_game_state_change());
     }
 
     #[test]
     fn say_message() {
-        let responses = dispatch_command("say hello world");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::Broadcast(BroadcastMessage::Chat { .. })
-        ));
+        let result = dispatch_command("say hello world");
+        assert_eq!(result.len(), 1);
+        assert!(result.has_chat_broadcast());
     }
 
     #[test]
     fn help_command() {
-        let responses = dispatch_command("help");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+        let result = dispatch_command("help");
+        assert_eq!(result.len(), 1);
+        assert!(result.has_system_chat());
     }
 
     #[test]
     fn stop_command() {
-        let responses = dispatch_command("stop");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::Broadcast(BroadcastMessage::Chat { .. })
-        ));
+        let result = dispatch_command("stop");
+        assert_eq!(result.len(), 1);
+        assert!(result.has_chat_broadcast());
     }
 
     #[test]
     fn kick_command() {
-        let responses = dispatch_command("kick Steve");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+        let result = dispatch_command("kick Steve");
+        assert_eq!(result.len(), 1);
+        assert!(result.has_system_chat());
     }
 
     #[test]
     fn list_command() {
-        let responses = dispatch_command("list");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+        let result = dispatch_command("list");
+        assert_eq!(result.len(), 1);
+        assert!(result.has_system_chat());
     }
 
     #[test]
     fn tp_invalid_coords() {
-        let responses = dispatch_command("tp abc def ghi");
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(responses[0], Response::SendSystemChat { .. }));
+        let result = dispatch_command("tp abc def ghi");
+        assert_eq!(result.len(), 1);
+        assert!(result.has_system_chat());
     }
 
     #[test]
     fn gamemode_survival() {
-        let responses = dispatch_command("gamemode survival");
-        assert_eq!(responses.len(), 2);
-        assert!(matches!(responses[0], Response::SendGameStateChange { .. }));
+        let result = dispatch_command("gamemode survival");
+        assert_eq!(result.len(), 2);
+        assert!(result.has_game_state_change());
     }
 
     #[test]
     fn unknown_command_returns_empty() {
-        let responses = dispatch_command("foobar");
-        assert!(responses.is_empty());
+        let result = dispatch_command("foobar");
+        assert!(result.is_empty());
     }
 }

--- a/plugins/item/src/lib.rs
+++ b/plugins/item/src/lib.rs
@@ -66,20 +66,10 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
+        let result = harness.dispatch(&mut event);
 
-        let has_spawn = responses.iter().any(|r| {
-            matches!(
-                r,
-                Response::SpawnDroppedItem {
-                    item_id: 1,
-                    count: 1,
-                    ..
-                }
-            )
-        });
         assert!(
-            has_spawn,
+            result.has_spawn_dropped_item(1, 1),
             "breaking stone should produce a SpawnDroppedItem response"
         );
     }
@@ -97,11 +87,11 @@ mod tests {
             cancelled: false,
         };
 
-        let responses = harness.dispatch(&mut event);
+        let result = harness.dispatch(&mut event);
 
-        let has_spawn = responses
-            .iter()
-            .any(|r| matches!(r, Response::SpawnDroppedItem { .. }));
-        assert!(!has_spawn, "breaking air should not produce a drop");
+        assert!(
+            !result.has_any_spawn_dropped_item(),
+            "breaking air should not produce a drop"
+        );
     }
 }

--- a/plugins/lifecycle/src/lib.rs
+++ b/plugins/lifecycle/src/lib.rs
@@ -34,7 +34,6 @@ impl Plugin for LifecyclePlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::Response;
     use basalt_testkit::PluginTestHarness;
 
     use super::*;
@@ -46,12 +45,9 @@ mod tests {
 
         let mut event = PlayerJoinedEvent;
 
-        let responses = harness.dispatch(&mut event);
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::Broadcast(BroadcastMessage::PlayerJoined { .. })
-        ));
+        let result = harness.dispatch(&mut event);
+        assert_eq!(result.len(), 1);
+        assert!(result.has_player_joined_broadcast());
     }
 
     #[test]
@@ -61,11 +57,8 @@ mod tests {
 
         let mut event = PlayerLeftEvent;
 
-        let responses = harness.dispatch(&mut event);
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::Broadcast(BroadcastMessage::PlayerLeft { .. })
-        ));
+        let result = harness.dispatch(&mut event);
+        assert_eq!(result.len(), 1);
+        assert!(result.has_player_left_broadcast());
     }
 }

--- a/plugins/movement/src/lib.rs
+++ b/plugins/movement/src/lib.rs
@@ -37,7 +37,6 @@ impl Plugin for MovementPlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::Response;
     use basalt_api::components::{ChunkPosition, Position, Rotation};
     use basalt_testkit::PluginTestHarness;
 
@@ -62,11 +61,8 @@ mod tests {
             old_chunk: ChunkPosition { x: 0, z: 0 },
         };
 
-        let responses = harness.dispatch(&mut event);
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::Broadcast(BroadcastMessage::EntityMoved { .. })
-        ));
+        let result = harness.dispatch(&mut event);
+        assert_eq!(result.len(), 1);
+        assert!(result.has_entity_moved_broadcast());
     }
 }

--- a/plugins/world/src/lib.rs
+++ b/plugins/world/src/lib.rs
@@ -34,7 +34,6 @@ impl Plugin for WorldPlugin {
 
 #[cfg(test)]
 mod tests {
-    use basalt_api::Response;
     use basalt_api::components::{ChunkPosition, Position, Rotation};
     use basalt_testkit::PluginTestHarness;
 
@@ -59,12 +58,9 @@ mod tests {
             old_chunk: ChunkPosition { x: 0, z: 0 },
         };
 
-        let responses = harness.dispatch(&mut event);
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::StreamChunks(ChunkPosition { x: 1, z: 0 })
-        ));
+        let result = harness.dispatch(&mut event);
+        assert_eq!(result.len(), 1);
+        assert!(result.has_stream_chunks(1, 0));
     }
 
     #[test]
@@ -87,12 +83,9 @@ mod tests {
             old_chunk: ChunkPosition { x: 0, z: 0 },
         };
 
-        let responses = harness.dispatch(&mut event);
-        assert_eq!(responses.len(), 1);
-        assert!(matches!(
-            responses[0],
-            Response::StreamChunks(ChunkPosition { x: -1, z: -1 })
-        ));
+        let result = harness.dispatch(&mut event);
+        assert_eq!(result.len(), 1);
+        assert!(result.has_stream_chunks(-1, -1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **DispatchResult** wrapper in basalt-testkit: `dispatch()` and `dispatch_command()` return `DispatchResult` instead of `Vec<Response>`. Provides 15 high-level assertion methods (`has_block_ack()`, `has_teleport()`, `has_chat_broadcast()`, `has_stream_chunks(x, z)`, etc.)
- **All 7 plugin test modules migrated**: replaced `matches!(responses[i], Response::Variant { .. })` with `result.has_*()` methods. Removed `Response` and `BroadcastMessage` imports from plugin tests
- **CLAUDE.md updated**: DispatchResult docs, panic handling, PlayerInfo

Plugins never import or reference `Response` directly — it is now a pure implementation detail.

## Test plan

- [ ] cargo fmt --all --check
- [ ] cargo clippy --lib --tests --all-features -- -D warnings
- [ ] cargo test
- [ ] cargo llvm-cov --all-features --ignore-filename-regex "(packets/|examples/)" --fail-under-lines 90
