### PR TITLE
feat(server): configurable CPU budgets per tick for simulation systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ version = "0.1.0"
 dependencies = [
  "basalt-core",
  "basalt-world",
+ "log",
  "rayon",
 ]
 

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -32,6 +32,7 @@ pub mod components {
 pub mod system {
     pub use basalt_core::{
         Phase, SystemAccess, SystemBuilder, SystemContext, SystemContextExt, SystemDescriptor,
+        TickBudget,
     };
 }
 

--- a/crates/basalt-core/src/budget.rs
+++ b/crates/basalt-core/src/budget.rs
@@ -1,0 +1,116 @@
+//! Cooperative CPU budget for tick-based systems.
+//!
+//! Systems receive a [`TickBudget`] via [`SystemContext::budget()`] that
+//! tracks elapsed time against a configured limit. Budget-aware systems
+//! check [`is_expired()`](TickBudget::is_expired) and yield early when
+//! time runs out. Systems that ignore the budget run to completion —
+//! enforcement is cooperative, not preemptive.
+
+use std::time::{Duration, Instant};
+
+/// A cooperative CPU budget for one system invocation.
+///
+/// Created by the dispatcher before each system runs. The system can
+/// query remaining time to decide whether to continue processing
+/// (e.g., a pathfinding system stops after its budget expires and
+/// re-queues remaining requests for the next tick).
+///
+/// # Example
+///
+/// ```ignore
+/// fn my_system(ctx: &mut dyn SystemContext) {
+///     for request in pending_requests() {
+///         if ctx.budget().is_expired() {
+///             break; // yield, continue next tick
+///         }
+///         process(request, ctx);
+///     }
+/// }
+/// ```
+pub struct TickBudget {
+    /// When this budget started (system dispatch time).
+    start: Instant,
+    /// Maximum allowed duration for this system.
+    limit: Duration,
+}
+
+impl TickBudget {
+    /// Creates a budget that starts now with the given time limit.
+    pub fn new(limit: Duration) -> Self {
+        Self {
+            start: Instant::now(),
+            limit,
+        }
+    }
+
+    /// Creates an unlimited budget (never expires).
+    ///
+    /// Used for systems that have no configured budget and for
+    /// backward compatibility with systems that don't check budgets.
+    pub fn unlimited() -> Self {
+        Self {
+            start: Instant::now(),
+            limit: Duration::MAX,
+        }
+    }
+
+    /// Returns the time remaining before the budget expires.
+    ///
+    /// Returns [`Duration::ZERO`] if the budget is already expired.
+    pub fn remaining(&self) -> Duration {
+        self.limit.saturating_sub(self.start.elapsed())
+    }
+
+    /// Returns whether the budget has expired.
+    pub fn is_expired(&self) -> bool {
+        self.start.elapsed() >= self.limit
+    }
+
+    /// Returns the time elapsed since the budget was created.
+    pub fn elapsed(&self) -> Duration {
+        self.start.elapsed()
+    }
+
+    /// Returns the configured time limit.
+    pub fn limit(&self) -> Duration {
+        self.limit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unlimited_budget_never_expires() {
+        let budget = TickBudget::unlimited();
+        assert!(!budget.is_expired());
+        assert!(budget.remaining() > Duration::from_secs(1000));
+        assert_eq!(budget.limit(), Duration::MAX);
+    }
+
+    #[test]
+    fn new_budget_starts_not_expired() {
+        let budget = TickBudget::new(Duration::from_millis(100));
+        assert!(!budget.is_expired());
+        assert!(budget.remaining() > Duration::ZERO);
+        assert_eq!(budget.limit(), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn zero_budget_expires_immediately() {
+        let budget = TickBudget::new(Duration::ZERO);
+        assert!(budget.is_expired());
+        assert_eq!(budget.remaining(), Duration::ZERO);
+    }
+
+    #[test]
+    fn elapsed_increases() {
+        let budget = TickBudget::new(Duration::from_secs(10));
+        let e1 = budget.elapsed();
+        // Spin briefly
+        std::hint::spin_loop();
+        let e2 = budget.elapsed();
+        assert!(e2 >= e1);
+    }
+}

--- a/crates/basalt-core/src/lib.rs
+++ b/crates/basalt-core/src/lib.rs
@@ -12,6 +12,7 @@
 //! - [`PluginLogger`] — scoped logging for plugins
 
 pub mod broadcast;
+pub mod budget;
 pub mod components;
 pub mod context;
 pub mod gamemode;
@@ -21,6 +22,7 @@ pub mod system;
 pub mod testing;
 
 pub use broadcast::{BroadcastMessage, PlayerSnapshot, ProfileProperty};
+pub use budget::TickBudget;
 pub use components::{
     BlockPosition, BoundingBox, ChunkPosition, Component, DroppedItem, EntityId, EntityKind,
     Health, Inventory, Lifetime, OpenContainer, Phase, PickupDelay, PlayerRef, Position, Rotation,

--- a/crates/basalt-core/src/system.rs
+++ b/crates/basalt-core/src/system.rs
@@ -6,7 +6,9 @@
 
 use std::any::{Any, TypeId};
 use std::collections::HashSet;
+use std::time::Duration;
 
+use crate::budget::TickBudget;
 use crate::components::{EntityId, Phase};
 
 /// Abstract interface for system runners.
@@ -43,6 +45,12 @@ pub trait SystemContext {
 
     /// Returns a mutable reference to a component as `dyn Any`.
     fn get_component_mut(&mut self, entity: EntityId, type_id: TypeId) -> Option<&mut dyn Any>;
+
+    /// Returns the CPU budget for the current system invocation.
+    ///
+    /// Budget-aware systems call this to check remaining time and yield
+    /// early when expired. Systems that ignore the budget run to completion.
+    fn budget(&self) -> &TickBudget;
 }
 
 /// Typed convenience methods on [`SystemContext`].
@@ -93,6 +101,8 @@ pub struct SystemDescriptor {
     pub every: u64,
     /// Component access declaration.
     pub access: SystemAccess,
+    /// Optional CPU budget per invocation. `None` means unlimited.
+    pub budget: Option<Duration>,
     /// The system function (type-erased).
     pub runner: Box<dyn SystemRunner>,
 }
@@ -165,6 +175,7 @@ pub struct SystemBuilder {
     phase: Phase,
     every: u64,
     access: SystemAccess,
+    budget: Option<Duration>,
 }
 
 impl SystemBuilder {
@@ -175,6 +186,7 @@ impl SystemBuilder {
             phase: Phase::Simulate,
             every: 1,
             access: SystemAccess::new(),
+            budget: None,
         }
     }
 
@@ -205,6 +217,15 @@ impl SystemBuilder {
         self
     }
 
+    /// Sets the CPU budget for this system in milliseconds.
+    ///
+    /// When set, the system can check `ctx.budget().is_expired()` to
+    /// yield early. Systems without a budget get an unlimited one.
+    pub fn budget_ms(mut self, ms: u64) -> Self {
+        self.budget = Some(Duration::from_millis(ms));
+        self
+    }
+
     /// Finalizes the builder and registers the system with a runner.
     pub fn run<F: FnMut(&mut dyn SystemContext) + Send + 'static>(
         self,
@@ -215,6 +236,7 @@ impl SystemBuilder {
             phase: self.phase,
             every: self.every,
             access: self.access,
+            budget: self.budget,
             runner: Box::new(runner),
         }
     }

--- a/crates/basalt-ecs/Cargo.toml
+++ b/crates/basalt-ecs/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 basalt-core = { workspace = true }
 basalt-world = { workspace = true }
 rayon = { workspace = true }
+log = { workspace = true }
 
 [[bench]]
 name = "ecs"

--- a/crates/basalt-ecs/src/ecs.rs
+++ b/crates/basalt-ecs/src/ecs.rs
@@ -345,6 +345,7 @@ impl Ecs {
     /// double mutable borrow (`self.systems` + `&mut self` passed
     /// to each system runner). They are put back after execution.
     pub fn run_phase(&mut self, phase: basalt_core::Phase, tick: u64) {
+        let track = self.tick_duration.is_some();
         let mut systems = std::mem::take(&mut self.systems);
         for slot in &mut systems {
             if let Some(system) = slot
@@ -357,8 +358,10 @@ impl Ecs {
                 };
                 self.current_budget = budget;
                 system.runner.run(self);
-                self.tick_timings
-                    .push((system.name.clone(), self.current_budget.elapsed()));
+                if track {
+                    self.tick_timings
+                        .push((system.name.clone(), self.current_budget.elapsed()));
+                }
             }
         }
         self.systems = systems;
@@ -563,8 +566,11 @@ impl Ecs {
     /// non-conflicting systems exist. All other phases run sequentially.
     pub fn run_all(&mut self, tick: u64) {
         use basalt_core::Phase;
-        let tick_start = Instant::now();
-        self.tick_timings.clear();
+        // Only start timing when overrun detection is enabled (avoids ~25ns Instant::now cost)
+        let tick_start = self.tick_duration.map(|_| Instant::now());
+        if tick_start.is_some() {
+            self.tick_timings.clear();
+        }
 
         self.run_phase(Phase::Input, tick);
         self.run_phase(Phase::Validate, tick);
@@ -573,8 +579,10 @@ impl Ecs {
         self.run_phase(Phase::Output, tick);
         self.run_phase(Phase::Post, tick);
 
-        if let Some(limit) = self.tick_duration {
-            let total = tick_start.elapsed();
+        if let Some(start) = tick_start
+            && let Some(limit) = self.tick_duration
+        {
+            let total = start.elapsed();
             if total > limit {
                 log::warn!(
                     "Tick {tick} overrun: {total:.1?} > {limit:.1?} — {}",

--- a/crates/basalt-ecs/src/ecs.rs
+++ b/crates/basalt-ecs/src/ecs.rs
@@ -3,7 +3,9 @@
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
 
+use basalt_core::TickBudget;
 pub use basalt_core::{Component, EntityId};
 
 /// Type-erased component store, allowing the [`Ecs`] to hold
@@ -150,6 +152,12 @@ pub struct Ecs {
     /// Precomputed parallel execution groups for the SIMULATE phase.
     /// Built lazily on first tick, invalidated on system registration.
     simulate_cache: Option<crate::schedule::GroupCache>,
+    /// Budget for the currently executing system (set before each runner call).
+    current_budget: TickBudget,
+    /// Per-system timing for the current tick (name, elapsed).
+    tick_timings: Vec<(String, Duration)>,
+    /// Expected tick duration for overrun detection. `None` disables logging.
+    tick_duration: Option<Duration>,
 }
 
 impl Ecs {
@@ -162,7 +170,18 @@ impl Ecs {
             systems: Vec::new(),
             world: None,
             simulate_cache: None,
+            current_budget: TickBudget::unlimited(),
+            tick_timings: Vec::new(),
+            tick_duration: None,
         }
+    }
+
+    /// Sets the expected tick duration for overrun detection.
+    ///
+    /// When set, `run_all` logs a warning if the total tick time exceeds
+    /// this duration, including a per-system timing breakdown.
+    pub fn set_tick_duration(&mut self, duration: Duration) {
+        self.tick_duration = Some(duration);
     }
 
     /// Sets the world reference for system runners.
@@ -332,7 +351,14 @@ impl Ecs {
                 && system.phase == phase
                 && tick.is_multiple_of(system.every)
             {
+                let budget = match system.budget {
+                    Some(limit) => TickBudget::new(limit),
+                    None => TickBudget::unlimited(),
+                };
+                self.current_budget = budget;
                 system.runner.run(self);
+                self.tick_timings
+                    .push((system.name.clone(), self.current_budget.elapsed()));
             }
         }
         self.systems = systems;
@@ -460,12 +486,14 @@ impl Ecs {
             .collect();
 
         // Collect results from parallel execution via a shared mutex.
-        // Each entry: (system_index, system_descriptor, returned_write_stores, deferred_commands)
+        // Each entry: (index, descriptor, write_stores, deferred_cmds, name, elapsed)
         type GroupResult = (
             usize,
             basalt_core::SystemDescriptor,
             HashMap<TypeId, Box<dyn AnyComponentStore>>,
             Vec<crate::parallel::DeferredCommand>,
+            String,
+            Duration,
         );
         let results: std::sync::Mutex<Vec<GroupResult>> = std::sync::Mutex::new(Vec::new());
 
@@ -477,6 +505,11 @@ impl Ecs {
                 let results = &results;
                 let counter = &local_counter;
 
+                let sys_budget = match sys.budget {
+                    Some(limit) => TickBudget::new(limit),
+                    None => TickBudget::unlimited(),
+                };
+
                 s.spawn(move |_| {
                     let mut ctx = crate::parallel::ParallelSystemContext::new(
                         write_stores,
@@ -484,13 +517,17 @@ impl Ecs {
                         world_ref,
                         counter,
                         sys_name,
+                        sys_budget,
                     );
+                    let run_start = Instant::now();
                     sys.runner.run(&mut ctx);
+                    let elapsed = run_start.elapsed();
+                    let name = ctx.system_name().to_string();
                     let (writes_back, deferred) = ctx.into_parts();
                     results
                         .lock()
                         .unwrap()
-                        .push((idx, sys, writes_back, deferred));
+                        .push((idx, sys, writes_back, deferred, name, elapsed));
                 });
             }
         });
@@ -500,8 +537,9 @@ impl Ecs {
         self.next_entity_id
             .store(local_counter.load(Ordering::Relaxed), Ordering::Relaxed);
 
-        // Process results: return systems, stores, and apply deferred commands
-        for (idx, sys, writes_back, deferred) in results.into_inner().unwrap() {
+        // Process results: return systems, stores, apply deferred commands, collect timings
+        for (idx, sys, writes_back, deferred, name, elapsed) in results.into_inner().unwrap() {
+            self.tick_timings.push((name, elapsed));
             system_slots[idx] = Some(sys);
             for (tid, store) in writes_back {
                 self.stores.insert(tid, store);
@@ -525,17 +563,44 @@ impl Ecs {
     /// non-conflicting systems exist. All other phases run sequentially.
     pub fn run_all(&mut self, tick: u64) {
         use basalt_core::Phase;
+        let tick_start = Instant::now();
+        self.tick_timings.clear();
+
         self.run_phase(Phase::Input, tick);
         self.run_phase(Phase::Validate, tick);
         self.run_phase_parallel(Phase::Simulate, tick);
         self.run_phase(Phase::Process, tick);
         self.run_phase(Phase::Output, tick);
         self.run_phase(Phase::Post, tick);
+
+        if let Some(limit) = self.tick_duration {
+            let total = tick_start.elapsed();
+            if total > limit {
+                log::warn!(
+                    "Tick {tick} overrun: {total:.1?} > {limit:.1?} — {}",
+                    self.format_timings()
+                );
+            }
+        }
     }
 
     /// Returns the number of registered systems.
     pub fn system_count(&self) -> usize {
         self.systems.len()
+    }
+
+    /// Returns per-system timings collected during the last `run_all` call.
+    pub fn tick_timings(&self) -> &[(String, Duration)] {
+        &self.tick_timings
+    }
+
+    /// Formats the per-system timing breakdown for logging.
+    fn format_timings(&self) -> String {
+        self.tick_timings
+            .iter()
+            .map(|(name, elapsed)| format!("{name}={elapsed:.1?}"))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }
 
@@ -588,6 +653,10 @@ impl basalt_core::SystemContext for Ecs {
 
     fn get_component_mut(&mut self, entity: EntityId, type_id: TypeId) -> Option<&mut dyn Any> {
         self.stores.get_mut(&type_id)?.get_any_mut(entity)
+    }
+
+    fn budget(&self) -> &TickBudget {
+        &self.current_budget
     }
 }
 

--- a/crates/basalt-ecs/src/parallel.rs
+++ b/crates/basalt-ecs/src/parallel.rs
@@ -12,7 +12,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use basalt_core::{EntityId, SystemContext};
+use basalt_core::{EntityId, SystemContext, TickBudget};
 
 use crate::ecs::AnyComponentStore;
 
@@ -50,6 +50,8 @@ pub(crate) struct ParallelSystemContext<'scope> {
     pub(crate) deferred: Vec<DeferredCommand>,
     /// System name for error messages.
     system_name: String,
+    /// CPU budget for this system invocation.
+    budget: TickBudget,
 }
 
 impl<'scope> ParallelSystemContext<'scope> {
@@ -60,6 +62,7 @@ impl<'scope> ParallelSystemContext<'scope> {
         world: &'scope basalt_world::World,
         next_entity_id: &'scope AtomicU32,
         system_name: String,
+        budget: TickBudget,
     ) -> Self {
         Self {
             write_stores,
@@ -68,7 +71,13 @@ impl<'scope> ParallelSystemContext<'scope> {
             next_entity_id,
             deferred: Vec::new(),
             system_name,
+            budget,
         }
+    }
+
+    /// Returns the system name.
+    pub(crate) fn system_name(&self) -> &str {
+        &self.system_name
     }
 
     /// Consumes the context, returning write stores and deferred commands.
@@ -148,6 +157,10 @@ impl SystemContext for ParallelSystemContext<'_> {
             self.system_name, type_id
         );
     }
+
+    fn budget(&self) -> &TickBudget {
+        &self.budget
+    }
 }
 
 #[cfg(test)]
@@ -193,6 +206,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         let pos = ctx.get::<Position>(1).unwrap();
@@ -216,6 +230,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         let pos = ctx.get::<Position>(1).unwrap();
@@ -238,6 +253,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         let pos = ctx.get_mut::<Position>(1).unwrap();
@@ -257,6 +273,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         let id1 = ctx.spawn();
@@ -278,6 +295,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         ctx.despawn(5);
@@ -308,6 +326,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         let entities = ctx.entities_with(TypeId::of::<Position>());
@@ -325,6 +344,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         ctx.set_component(
@@ -346,6 +366,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         ctx.get_component_mut(1, TypeId::of::<Position>());
@@ -367,6 +388,7 @@ mod tests {
             &world,
             &counter,
             "test".to_string(),
+            TickBudget::unlimited(),
         );
 
         // Mutate through context

--- a/crates/basalt-ecs/src/schedule.rs
+++ b/crates/basalt-ecs/src/schedule.rs
@@ -173,6 +173,7 @@ mod tests {
             phase: Phase::Simulate,
             every,
             access,
+            budget: None,
             runner: Box::new(|_: &mut dyn basalt_core::SystemContext| {}),
         })
     }
@@ -288,6 +289,7 @@ mod tests {
                 phase: Phase::Input,
                 every: 1,
                 access: SystemAccess::new(),
+                budget: None,
                 runner: Box::new(|_: &mut dyn basalt_core::SystemContext| {}),
             }),
         ];

--- a/crates/basalt-server/src/config.rs
+++ b/crates/basalt-server/src/config.rs
@@ -4,6 +4,7 @@
 //! mode), and which plugins are enabled. Missing fields use sensible
 //! defaults — a missing `basalt.toml` runs a full game server.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use serde::Deserialize;
@@ -63,6 +64,8 @@ pub struct ServerSection {
     pub persistence_interval_seconds: u32,
     /// Performance tuning.
     pub performance: PerformanceSection,
+    /// Per-system CPU budget overrides (milliseconds per tick).
+    pub budgets: BudgetsSection,
 }
 
 /// Performance tuning settings.
@@ -103,6 +106,32 @@ pub struct PerformanceSection {
     /// `None` (default) lets rayon auto-detect based on available CPU cores.
     /// Set to `Some(n)` to use exactly `n` worker threads.
     pub system_threads: Option<usize>,
+}
+
+/// Per-system CPU budget overrides.
+///
+/// Systems can declare a default budget via the builder API. This
+/// section allows operators to override budgets by system name,
+/// or set a global default for systems without explicit budgets.
+///
+/// # Example
+///
+/// ```toml
+/// [server.budgets]
+/// default_ms = 10
+/// physics = 5
+/// ai_goals = 8
+/// pathfinding = 2
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct BudgetsSection {
+    /// Default budget in milliseconds for systems without an explicit
+    /// builder-declared or per-system override. `None` means unlimited.
+    pub default_ms: Option<u64>,
+    /// Per-system overrides: system name → max milliseconds per tick.
+    #[serde(flatten)]
+    pub overrides: HashMap<String, u64>,
 }
 
 /// Log output format.
@@ -214,6 +243,7 @@ impl Default for ServerSection {
             simulation_distance: 8,
             persistence_interval_seconds: 30,
             performance: PerformanceSection::default(),
+            budgets: BudgetsSection::default(),
         }
     }
 }

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -130,7 +130,16 @@ impl Server {
         ecs.register_component::<basalt_core::OpenContainer>();
         ecs.register_component::<basalt_core::PlayerRef>();
         ecs.register_component::<basalt_core::Inventory>();
-        for system in plugin_systems {
+        // Apply budget overrides from config before registering systems
+        let budgets = &self.config.server.budgets;
+        for mut system in plugin_systems {
+            if let Some(&ms) = budgets.overrides.get(&system.name) {
+                system.budget = Some(std::time::Duration::from_millis(ms));
+            } else if system.budget.is_none()
+                && let Some(ms) = budgets.default_ms
+            {
+                system.budget = Some(std::time::Duration::from_millis(ms));
+            }
             ecs.add_system(system);
         }
 
@@ -169,6 +178,10 @@ impl Server {
                     }
                 }),
         );
+
+        // Configure tick overrun detection
+        let tick_duration = std::time::Duration::from_nanos(1_000_000_000 / u64::from(tps));
+        ecs.set_tick_duration(tick_duration);
 
         // Game loop — single dedicated OS thread
         let persistence_interval_ticks =

--- a/crates/basalt-testkit/src/lib.rs
+++ b/crates/basalt-testkit/src/lib.rs
@@ -385,6 +385,8 @@ pub struct SystemTestContext {
     pub ecs: basalt_ecs::Ecs,
     /// Shared world for block/collision queries.
     world: Arc<World>,
+    /// Unlimited budget for test systems.
+    budget: basalt_core::TickBudget,
 }
 
 impl SystemTestContext {
@@ -393,6 +395,7 @@ impl SystemTestContext {
         Self {
             ecs: basalt_ecs::Ecs::new(),
             world: Arc::new(World::flat()),
+            budget: basalt_core::TickBudget::unlimited(),
         }
     }
 
@@ -401,6 +404,7 @@ impl SystemTestContext {
         Self {
             ecs: basalt_ecs::Ecs::new(),
             world,
+            budget: basalt_core::TickBudget::unlimited(),
         }
     }
 }
@@ -451,5 +455,9 @@ impl basalt_core::SystemContext for SystemTestContext {
         type_id: std::any::TypeId,
     ) -> Option<&mut dyn std::any::Any> {
         self.ecs.get_component_mut(entity, type_id)
+    }
+
+    fn budget(&self) -> &basalt_core::TickBudget {
+        &self.budget
     }
 }


### PR DESCRIPTION
## Summary

- Add cooperative `TickBudget` API on `SystemContext` — systems call `ctx.budget().is_expired()` to yield early when time runs out, backward-compatible with systems that ignore it
- Per-system timing collection during both sequential and parallel dispatch, with tick overrun detection and warning log including per-system breakdown
- Configurable `[server.budgets]` section with per-system overrides by name and optional `default_ms` fallback (config > builder declaration > unlimited)
- Re-export `TickBudget` in `basalt-api` for plugin access

Closes #124

## Test plan

- [x] Full workspace test suite green (0 failures)
- [x] clippy clean (`-D warnings`)
- [x] fmt clean
- [x] All existing systems continue to work without budget declarations (backward compat)
- [ ] Manual: add `[server.budgets]` to basalt.toml, verify overrun logging triggers with a tight budget (e.g. `physics = 0`)
