### PR TITLE
feat(api): crafting events MVP — match cycle and craft execution

### DIFF
--- a/crates/basalt-api/src/events/crafting.rs
+++ b/crates/basalt-api/src/events/crafting.rs
@@ -1,10 +1,16 @@
-//! Crafting events: grid changes and output clicks.
+//! Crafting events: grid changes, recipe matching, and craft execution.
+
+use basalt_types::Slot;
 
 /// The contents of a crafting grid have changed.
 ///
-/// Fired when a player places or removes an item in any crafting slot.
-/// The recipe matching system listens for this event to compute the
-/// crafting output. The crafting player is available via `ctx.player()`.
+/// Fired at the **Post** stage on the **game** bus whenever a player
+/// places, removes, or rearranges an item in any crafting slot. This
+/// is a pure notification — the result of the new grid is computed
+/// separately and surfaced through [`CraftingRecipeMatchedEvent`] /
+/// [`CraftingRecipeClearedEvent`].
+///
+/// The crafting player is available via `ctx.player()`.
 #[derive(Debug, Clone)]
 pub struct CraftingGridChangedEvent {
     /// Item IDs in the 9 grid slots (`None` for empty slots).
@@ -15,57 +21,193 @@ pub struct CraftingGridChangedEvent {
 }
 crate::game_event!(CraftingGridChangedEvent);
 
-/// A player clicked the crafting output slot to collect the result.
+/// A recipe was matched against the current crafting grid contents.
 ///
-/// Cancellable — a Validate handler can prevent the craft (e.g.,
-/// permissions, anti-cheat). The crafting player is available via
-/// `ctx.player()`.
+/// Fired at **Process + Post** stages on the **game** bus after the
+/// server has resolved a matching recipe for the grid. Plugins can
+/// **mutate `result`** at the Process stage (priority-ordered) to:
+/// - augment the result (bonus count, custom NBT, applied enchantments)
+/// - **deny the craft** by setting `result` to [`Slot::empty()`] —
+///   the player will see no result appear in slot 0
+///
+/// After dispatch the server reads back `event.result` and writes it
+/// to the player's `CraftingGrid.output`, then syncs slot 0 to the
+/// client. Post listeners observe the final (post-mutation) result.
 #[derive(Debug, Clone)]
-pub struct CraftingOutputClickedEvent {
-    /// Item ID of the crafting result.
-    pub result_id: i32,
-    /// Stack count of the crafting result.
-    pub result_count: i32,
-    /// Whether the player shift-clicked (craft all).
-    pub shift_click: bool,
+pub struct CraftingRecipeMatchedEvent {
+    /// Item IDs in the 9 grid slots that produced the match
+    /// (`None` for empty slots).
+    pub grid: [Option<i32>; 9],
+    /// Grid dimension: 2 for inventory crafting, 3 for crafting table.
+    pub grid_size: u8,
+    /// The crafting result. **Mutable at Process** — plugins layer
+    /// modifications by handler priority. Setting this to
+    /// [`Slot::empty()`] hides the result from the player.
+    pub result: Slot,
+}
+crate::game_event!(CraftingRecipeMatchedEvent);
+
+/// The current crafting grid no longer matches any recipe.
+///
+/// Fired at the **Post** stage on the **game** bus only on the
+/// transition `matched → unmatched` (i.e. the previous tick had a
+/// non-empty result, this tick has none). Useful for plugins that
+/// want to react when a result disappears (UI hints, achievements
+/// for "almost crafted X").
+#[derive(Debug, Clone)]
+pub struct CraftingRecipeClearedEvent {
+    /// Grid dimension: 2 for inventory crafting, 3 for crafting table.
+    pub grid_size: u8,
+}
+crate::game_event!(CraftingRecipeClearedEvent);
+
+/// A player is about to take a crafting result (cancellable).
+///
+/// Fired at the **Validate** stage on the **game** bus when a player
+/// clicks the crafting output slot — both for normal clicks and the
+/// initial click of a shift-click batch. Cancelling the event aborts
+/// the craft entirely (no consumption, no result transfer).
+///
+/// For shift-click batches, [`CraftingShiftClickBatchEvent`] fires
+/// immediately after this event (if not cancelled here) to allow
+/// plugins to cap the batch size.
+///
+/// The crafting player is available via `ctx.player()`.
+#[derive(Debug, Clone)]
+pub struct CraftingPreCraftEvent {
+    /// The result the player is about to receive.
+    pub result: Slot,
+    /// Whether the player shift-clicked (batch craft).
+    pub is_shift_click: bool,
     /// Whether this event has been cancelled by a Validate handler.
     pub cancelled: bool,
 }
-crate::game_cancellable_event!(CraftingOutputClickedEvent);
+crate::game_cancellable_event!(CraftingPreCraftEvent);
+
+/// A successful craft has been performed.
+///
+/// Fired at the **Post** stage on the **game** bus exactly **once
+/// per crafted unit**. For a normal click, fires once. For a
+/// shift-click batch, fires N times (one per loop iteration). The
+/// canonical hook for stats / achievements / logging.
+#[derive(Debug, Clone)]
+pub struct CraftingCraftedEvent {
+    /// Snapshot of the grid contents **before** ingredient
+    /// consumption for this craft. Index 0..9 corresponds to grid
+    /// slot indices.
+    pub consumed: [Slot; 9],
+    /// The result that was delivered to the player.
+    pub produced: Slot,
+}
+crate::game_event!(CraftingCraftedEvent);
+
+/// A shift-click batch craft is about to begin (cancellable).
+///
+/// Fired at the **Validate** stage on the **game** bus immediately
+/// after [`CraftingPreCraftEvent`] when the player shift-clicks the
+/// crafting output. Plugins can cancel the entire batch, or **lower
+/// `max_count`** to cap the number of iterations (e.g. anti-grief
+/// limit "max 16 crafted per shift-click"). Increasing `max_count`
+/// has no effect — the natural inventory-space cap still applies.
+#[derive(Debug, Clone)]
+pub struct CraftingShiftClickBatchEvent {
+    /// The result the player will receive on each iteration.
+    pub result: Slot,
+    /// Maximum number of crafts to perform. **Mutable at Validate**
+    /// — plugins lower this to cap the batch. Initial value is
+    /// `u32::MAX` (the loop is naturally capped by available
+    /// inventory space).
+    pub max_count: u32,
+    /// Whether this event has been cancelled by a Validate handler.
+    pub cancelled: bool,
+}
+crate::game_cancellable_event!(CraftingShiftClickBatchEvent);
 
 #[cfg(test)]
 mod tests {
-    use basalt_events::Event;
+    use basalt_events::{BusKind, Event, EventRouting};
 
     use super::*;
+
+    fn empty_grid() -> [Option<i32>; 9] {
+        [None; 9]
+    }
+
+    fn empty_slots() -> [Slot; 9] {
+        std::array::from_fn(|_| Slot::empty())
+    }
 
     #[test]
     fn grid_changed_not_cancellable() {
         let mut event = CraftingGridChangedEvent {
-            grid: [None; 9],
+            grid: empty_grid(),
             grid_size: 3,
         };
-        event.cancel(); // no-op
+        event.cancel();
         assert!(!event.is_cancelled());
+        assert_eq!(CraftingGridChangedEvent::BUS, BusKind::Game);
     }
 
     #[test]
-    fn output_clicked_cancellation() {
-        let mut event = CraftingOutputClickedEvent {
-            result_id: 1,
-            result_count: 1,
-            shift_click: false,
+    fn recipe_matched_carries_mutable_result() {
+        let mut event = CraftingRecipeMatchedEvent {
+            grid: empty_grid(),
+            grid_size: 3,
+            result: Slot::new(1, 4),
+        };
+        event.result = Slot::empty();
+        assert!(event.result.item_id.is_none());
+        // not cancellable
+        event.cancel();
+        assert!(!event.is_cancelled());
+        assert_eq!(CraftingRecipeMatchedEvent::BUS, BusKind::Game);
+    }
+
+    #[test]
+    fn recipe_cleared_not_cancellable() {
+        let mut event = CraftingRecipeClearedEvent { grid_size: 2 };
+        event.cancel();
+        assert!(!event.is_cancelled());
+        assert_eq!(CraftingRecipeClearedEvent::BUS, BusKind::Game);
+    }
+
+    #[test]
+    fn pre_craft_cancellation() {
+        let mut event = CraftingPreCraftEvent {
+            result: Slot::new(280, 4),
+            is_shift_click: false,
             cancelled: false,
         };
         assert!(!event.is_cancelled());
         event.cancel();
         assert!(event.is_cancelled());
+        assert_eq!(CraftingPreCraftEvent::BUS, BusKind::Game);
     }
 
     #[test]
-    fn event_routing() {
-        use basalt_events::{BusKind, EventRouting};
-        assert_eq!(CraftingGridChangedEvent::BUS, BusKind::Game);
-        assert_eq!(CraftingOutputClickedEvent::BUS, BusKind::Game);
+    fn crafted_carries_consumed_and_produced() {
+        let mut consumed = empty_slots();
+        consumed[0] = Slot::new(17, 1);
+        let event = CraftingCraftedEvent {
+            consumed,
+            produced: Slot::new(280, 4),
+        };
+        assert_eq!(event.consumed[0].item_id, Some(17));
+        assert_eq!(event.produced.item_count, 4);
+        assert_eq!(CraftingCraftedEvent::BUS, BusKind::Game);
+    }
+
+    #[test]
+    fn shift_click_batch_cap_and_cancel() {
+        let mut event = CraftingShiftClickBatchEvent {
+            result: Slot::new(280, 4),
+            max_count: u32::MAX,
+            cancelled: false,
+        };
+        event.max_count = 2;
+        assert_eq!(event.max_count, 2);
+        event.cancel();
+        assert!(event.is_cancelled());
+        assert_eq!(CraftingShiftClickBatchEvent::BUS, BusKind::Game);
     }
 }

--- a/crates/basalt-api/src/events/mod.rs
+++ b/crates/basalt-api/src/events/mod.rs
@@ -19,7 +19,10 @@ mod player;
 pub use block::{BlockBrokenEvent, BlockPlacedEvent, PlayerInteractEvent};
 pub use chat::{ChatMessageEvent, CommandEvent};
 pub use container::*;
-pub use crafting::{CraftingGridChangedEvent, CraftingOutputClickedEvent};
+pub use crafting::{
+    CraftingCraftedEvent, CraftingGridChangedEvent, CraftingPreCraftEvent,
+    CraftingRecipeClearedEvent, CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
+};
 pub use player::{PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent};
 
 /// Implements [`Event`](basalt_events::Event) and

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -92,7 +92,9 @@ pub mod prelude {
         BlockEntityModifiedEvent, BlockPlacedEvent, ChatMessageEvent, CloseReason, CommandEvent,
         ContainerClickEvent, ContainerClickType, ContainerClosedEvent, ContainerDragEvent,
         ContainerOpenRequestEvent, ContainerOpenedEvent, ContainerSlotChangedEvent,
-        CraftingGridChangedEvent, CraftingOutputClickedEvent, DragType, PlayerInteractEvent,
-        PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent, WindowSlotKind,
+        CraftingCraftedEvent, CraftingGridChangedEvent, CraftingPreCraftEvent,
+        CraftingRecipeClearedEvent, CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
+        DragType, PlayerInteractEvent, PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent,
+        WindowSlotKind,
     };
 }

--- a/crates/basalt-server/src/game/crafting.rs
+++ b/crates/basalt-server/src/game/crafting.rs
@@ -4,7 +4,10 @@
 //! and crafting window management. All crafting-specific methods live here
 //! to keep `inventory.rs` and `container.rs` focused on their domains.
 
-use basalt_api::events::{CraftingGridChangedEvent, CraftingPreCraftEvent};
+use basalt_api::events::{
+    CraftingGridChangedEvent, CraftingPreCraftEvent, CraftingRecipeClearedEvent,
+    CraftingRecipeMatchedEvent,
+};
 use basalt_types::Slot;
 use basalt_types::Uuid;
 
@@ -139,41 +142,83 @@ impl GameLoop {
         event.cancelled
     }
 
-    /// Matches crafting grid contents against the recipe registry and
-    /// updates the output slot.
+    /// Resolves the crafting result for the current grid contents.
     ///
-    /// Reads the `CraftingGrid` component, calls `match_grid()` on the
-    /// recipe registry, sets `CraftingGrid.output`, and sends a
-    /// `SetContainerSlot` to the client so the output slot is visible.
-    /// Always sends the packet because crafting output is server-authoritative:
-    /// after the player takes the output, the client clears slot 0 locally,
-    /// so the server must re-send even if the same recipe matches again.
-    pub(super) fn update_crafting_output(&mut self, eid: basalt_ecs::EntityId) {
-        let (grid_items, grid_size) = {
+    /// Calls `RecipeRegistry::match_grid` and dispatches the
+    /// appropriate event:
+    /// - `CraftingRecipeMatchedEvent` (Process+Post, mutable `result`)
+    ///   when a recipe matches. Plugins layer modifications by handler
+    ///   priority — setting `result` to `Slot::empty()` denies the
+    ///   craft.
+    /// - `CraftingRecipeClearedEvent` (Post) only on the transition
+    ///   `matched → unmatched` (i.e. when `grid.output` was non-empty
+    ///   before this call and no recipe now matches).
+    ///
+    /// Returns the final (post-mutation) result slot. Does **not**
+    /// write to `grid.output` and does **not** send any packet — see
+    /// [`sync_crafting_output_slot`](Self::sync_crafting_output_slot)
+    /// and [`run_crafting_match_cycle`](Self::run_crafting_match_cycle).
+    pub(super) fn compute_crafting_match(&mut self, uuid: Uuid, eid: basalt_ecs::EntityId) -> Slot {
+        let (grid_ids, grid_size, previous_output) = {
             let Some(grid) = self.ecs.get::<basalt_core::CraftingGrid>(eid) else {
-                return;
+                return Slot::empty();
             };
-            let items: Vec<Option<i32>> = grid.slots.iter().map(|s| s.item_id).collect();
-            (items, grid.grid_size)
+            let mut g = [None; 9];
+            for (i, slot) in grid.slots.iter().enumerate().take(9) {
+                g[i] = slot.item_id;
+            }
+            (g, grid.grid_size, grid.output.clone())
         };
 
-        let result = self.recipes.match_grid(&grid_items, grid_size);
-        let output_slot = match result {
-            Some((id, count)) => basalt_types::Slot::new(id, count),
-            None => basalt_types::Slot::empty(),
+        let raw_match = self
+            .recipes
+            .match_grid(&grid_ids, grid_size)
+            .map(|(id, count)| Slot::new(id, count));
+
+        let (entity_id, username, yaw, pitch) = match self.player_info(eid) {
+            Some(info) => info,
+            None => return raw_match.unwrap_or_else(Slot::empty),
         };
 
+        let ctx = self.make_context(uuid, entity_id, &username, yaw, pitch);
+
+        match raw_match {
+            Some(initial) => {
+                let mut event = CraftingRecipeMatchedEvent {
+                    grid: grid_ids,
+                    grid_size,
+                    result: initial,
+                };
+                self.dispatch_event(&mut event, &ctx);
+                self.process_responses(uuid, &ctx.drain_responses());
+                event.result
+            }
+            None => {
+                if !previous_output.is_empty() {
+                    let mut event = CraftingRecipeClearedEvent { grid_size };
+                    self.dispatch_event(&mut event, &ctx);
+                    self.process_responses(uuid, &ctx.drain_responses());
+                }
+                Slot::empty()
+            }
+        }
+    }
+
+    /// Writes the resolved result to `CraftingGrid.output` and pushes
+    /// a `SetContainerSlot` for slot 0 to the client.
+    ///
+    /// Always sends because crafting output is server-authoritative:
+    /// the client clears slot 0 locally when the player takes the
+    /// output, so the server must re-send even when the same recipe
+    /// still matches.
+    pub(super) fn sync_crafting_output_slot(&mut self, eid: basalt_ecs::EntityId, output: Slot) {
         if let Some(grid) = self.ecs.get_mut::<basalt_core::CraftingGrid>(eid) {
-            grid.output = output_slot.clone();
+            grid.output = output.clone();
         }
 
-        // Always send to client — crafting output is server-authoritative.
-        // The client clears slot 0 when taking the output, so even if the
-        // same recipe matches again, the server must re-send the result.
-        //
-        // Window ID 0 = player inventory window (used when no container is
-        // open for the 2x2 grid). The client accepts slot 0 updates for
-        // the crafting output because it is always server-pushed.
+        // Window ID 0 = player inventory window (used for the 2x2 grid
+        // when no container is open). The client accepts slot 0
+        // updates because crafting output is always server-pushed.
         let window_id = self
             .ecs
             .get::<basalt_core::OpenContainer>(eid)
@@ -184,9 +229,19 @@ impl GameLoop {
             let _ = tx.try_send(ServerOutput::SetContainerSlot {
                 window_id,
                 slot: 0,
-                item: output_slot,
+                item: output,
             });
         });
+    }
+
+    /// Runs the full crafting match cycle: resolve match (firing
+    /// matched/cleared events) and sync slot 0 to the client.
+    ///
+    /// This is the steady-state entry point invoked after every
+    /// crafting-grid mutation in the inventory click handler.
+    pub(super) fn run_crafting_match_cycle(&mut self, uuid: Uuid, eid: basalt_ecs::EntityId) {
+        let output = self.compute_crafting_match(uuid, eid);
+        self.sync_crafting_output_slot(eid, output);
     }
 
     /// Consumes one ingredient from each occupied grid slot after
@@ -293,9 +348,15 @@ impl GameLoop {
     /// Handles shift-click crafting: repeatedly consumes ingredients
     /// and inserts results into the player's inventory until either
     /// no recipe matches or the inventory is full.
-    pub(super) fn handle_shift_click_craft(&mut self, eid: basalt_ecs::EntityId) {
+    ///
+    /// Between iterations, calls
+    /// [`compute_crafting_match`](Self::compute_crafting_match) to
+    /// resolve the next result through the event pipeline so plugins
+    /// can mutate the per-iteration result.
+    pub(super) fn handle_shift_click_craft(&mut self, uuid: Uuid, eid: basalt_ecs::EntityId) {
         loop {
-            // Check the current output
+            // Read the current output (set by the prior iteration's
+            // `compute_crafting_match` or by the initial click).
             let (result_id, result_count) = {
                 let Some(grid) = self.ecs.get::<basalt_core::CraftingGrid>(eid) else {
                     break;
@@ -317,30 +378,19 @@ impl GameLoop {
                 break;
             }
 
-            // Consume ingredients
+            // Consume ingredients (clears grid.output as a side effect)
             self.consume_crafting_ingredients(eid);
 
-            // Re-match the grid to check if we can craft again
-            let next_result = {
-                let Some(grid) = self.ecs.get::<basalt_core::CraftingGrid>(eid) else {
-                    break;
-                };
-                let items: Vec<Option<i32>> = grid.slots.iter().map(|s| s.item_id).collect();
-                self.recipes.match_grid(&items, grid.grid_size)
-            };
-
-            match next_result {
-                Some((id, count)) => {
-                    if let Some(grid) = self.ecs.get_mut::<basalt_core::CraftingGrid>(eid) {
-                        grid.output = basalt_types::Slot::new(id, count);
-                    }
-                }
-                None => {
-                    if let Some(grid) = self.ecs.get_mut::<basalt_core::CraftingGrid>(eid) {
-                        grid.output = basalt_types::Slot::empty();
-                    }
-                    break;
-                }
+            // Resolve next iteration through the event pipeline so
+            // plugins observe each match. `compute_crafting_match`
+            // suppresses `CraftingRecipeClearedEvent` here because the
+            // previous output was already cleared by `consume`.
+            let next = self.compute_crafting_match(uuid, eid);
+            if let Some(grid) = self.ecs.get_mut::<basalt_core::CraftingGrid>(eid) {
+                grid.output = next.clone();
+            }
+            if next.is_empty() {
+                break;
             }
         }
     }

--- a/crates/basalt-server/src/game/crafting.rs
+++ b/crates/basalt-server/src/game/crafting.rs
@@ -5,8 +5,8 @@
 //! to keep `inventory.rs` and `container.rs` focused on their domains.
 
 use basalt_api::events::{
-    CraftingGridChangedEvent, CraftingPreCraftEvent, CraftingRecipeClearedEvent,
-    CraftingRecipeMatchedEvent,
+    CraftingCraftedEvent, CraftingGridChangedEvent, CraftingPreCraftEvent,
+    CraftingRecipeClearedEvent, CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
 };
 use basalt_types::Slot;
 use basalt_types::Uuid;
@@ -140,6 +140,61 @@ impl GameLoop {
         self.dispatch_event(&mut event, &ctx);
         self.process_responses(uuid, &ctx.drain_responses());
         event.cancelled
+    }
+
+    /// Dispatches a `CraftingShiftClickBatchEvent` and returns the
+    /// resolved `(cancelled, max_count)` pair.
+    ///
+    /// Fired at Validate just before a shift-click crafting batch
+    /// begins. Plugins can cancel the entire batch or lower
+    /// `max_count` to cap iterations. The initial `max_count` is
+    /// `u32::MAX` — the natural inventory-space cap still applies on
+    /// top of any plugin-imposed limit.
+    pub(super) fn dispatch_crafting_shift_click_batch(
+        &mut self,
+        uuid: Uuid,
+        eid: basalt_ecs::EntityId,
+        result: Slot,
+    ) -> (bool, u32) {
+        let (entity_id, username, yaw, pitch) = match self.player_info(eid) {
+            Some(info) => info,
+            None => return (true, 0),
+        };
+
+        let ctx = self.make_context(uuid, entity_id, &username, yaw, pitch);
+        let mut event = CraftingShiftClickBatchEvent {
+            result,
+            max_count: u32::MAX,
+            cancelled: false,
+        };
+        self.dispatch_event(&mut event, &ctx);
+        self.process_responses(uuid, &ctx.drain_responses());
+        (event.cancelled, event.max_count)
+    }
+
+    /// Dispatches a `CraftingCraftedEvent` (Post) for one successful
+    /// craft.
+    ///
+    /// Fires once per crafted unit — for shift-click batches, the
+    /// caller must invoke this per loop iteration. `consumed` is the
+    /// snapshot of the grid slots **before** ingredient consumption
+    /// for this craft.
+    pub(super) fn dispatch_crafting_crafted(
+        &mut self,
+        uuid: Uuid,
+        eid: basalt_ecs::EntityId,
+        consumed: [Slot; 9],
+        produced: Slot,
+    ) {
+        let (entity_id, username, yaw, pitch) = match self.player_info(eid) {
+            Some(info) => info,
+            None => return,
+        };
+
+        let ctx = self.make_context(uuid, entity_id, &username, yaw, pitch);
+        let mut event = CraftingCraftedEvent { consumed, produced };
+        self.dispatch_event(&mut event, &ctx);
+        self.process_responses(uuid, &ctx.drain_responses());
     }
 
     /// Resolves the crafting result for the current grid contents.
@@ -347,14 +402,38 @@ impl GameLoop {
 
     /// Handles shift-click crafting: repeatedly consumes ingredients
     /// and inserts results into the player's inventory until either
-    /// no recipe matches or the inventory is full.
+    /// no recipe matches, the inventory is full, or a plugin-imposed
+    /// `max_count` is reached.
     ///
-    /// Between iterations, calls
+    /// Dispatches `CraftingShiftClickBatchEvent` once before the loop
+    /// (cancellable, `max_count` mutable), then `CraftingCraftedEvent`
+    /// once per successful iteration. Between iterations, calls
     /// [`compute_crafting_match`](Self::compute_crafting_match) to
-    /// resolve the next result through the event pipeline so plugins
-    /// can mutate the per-iteration result.
+    /// resolve the next result through the event pipeline.
     pub(super) fn handle_shift_click_craft(&mut self, uuid: Uuid, eid: basalt_ecs::EntityId) {
+        // Capture the initial result so plugins know what's about to
+        // be batched. Empty output means there's nothing to craft.
+        let initial = {
+            let Some(grid) = self.ecs.get::<basalt_core::CraftingGrid>(eid) else {
+                return;
+            };
+            if grid.output.is_empty() {
+                return;
+            }
+            grid.output.clone()
+        };
+
+        let (cancelled, max_count) = self.dispatch_crafting_shift_click_batch(uuid, eid, initial);
+        if cancelled {
+            return;
+        }
+
+        let mut crafted: u32 = 0;
         loop {
+            if crafted >= max_count {
+                break;
+            }
+
             // Read the current output (set by the prior iteration's
             // `compute_crafting_match` or by the initial click).
             let (result_id, result_count) = {
@@ -378,8 +457,22 @@ impl GameLoop {
                 break;
             }
 
+            // Snapshot the grid BEFORE consume so the CraftedEvent
+            // carries the pre-consumption state.
+            let consumed = {
+                let Some(grid) = self.ecs.get::<basalt_core::CraftingGrid>(eid) else {
+                    break;
+                };
+                grid.slots.clone()
+            };
+            let produced = Slot::new(result_id, result_count);
+
             // Consume ingredients (clears grid.output as a side effect)
             self.consume_crafting_ingredients(eid);
+
+            // Notify plugins of the successful craft.
+            self.dispatch_crafting_crafted(uuid, eid, consumed, produced);
+            crafted = crafted.saturating_add(1);
 
             // Resolve next iteration through the event pipeline so
             // plugins observe each match. `compute_crafting_match`

--- a/crates/basalt-server/src/game/crafting.rs
+++ b/crates/basalt-server/src/game/crafting.rs
@@ -4,7 +4,8 @@
 //! and crafting window management. All crafting-specific methods live here
 //! to keep `inventory.rs` and `container.rs` focused on their domains.
 
-use basalt_api::events::{CraftingGridChangedEvent, CraftingOutputClickedEvent};
+use basalt_api::events::{CraftingGridChangedEvent, CraftingPreCraftEvent};
+use basalt_types::Slot;
 use basalt_types::Uuid;
 
 use super::GameLoop;
@@ -100,25 +101,26 @@ impl GameLoop {
         self.process_responses(uuid, &ctx.drain_responses());
     }
 
-    /// Dispatches a `CraftingOutputClickedEvent` for the given player.
+    /// Dispatches a `CraftingPreCraftEvent` for the given player.
     ///
-    /// Fires when the player clicks the output slot of a crafting
-    /// grid that has a valid recipe result. Returns `true` if the
-    /// event was cancelled by a Validate handler.
-    pub(super) fn dispatch_crafting_output_clicked(
+    /// Fires at Validate when the player clicks the output slot of a
+    /// crafting grid that has a valid recipe result. Returns `true`
+    /// if the event was cancelled by a Validate handler — the caller
+    /// must abort the craft (no consume, no transfer).
+    pub(super) fn dispatch_crafting_pre_craft(
         &mut self,
         uuid: Uuid,
         eid: basalt_ecs::EntityId,
-        shift_click: bool,
+        is_shift_click: bool,
     ) -> bool {
-        let (result_id, result_count) = {
+        let result: Slot = {
             let Some(grid) = self.ecs.get::<basalt_core::CraftingGrid>(eid) else {
                 return true;
             };
-            let Some(id) = grid.output.item_id else {
+            if grid.output.item_id.is_none() {
                 return true;
-            };
-            (id, grid.output.item_count)
+            }
+            grid.output.clone()
         };
 
         let (entity_id, username, yaw, pitch) = match self.player_info(eid) {
@@ -127,10 +129,9 @@ impl GameLoop {
         };
 
         let ctx = self.make_context(uuid, entity_id, &username, yaw, pitch);
-        let mut event = CraftingOutputClickedEvent {
-            result_id,
-            result_count,
-            shift_click,
+        let mut event = CraftingPreCraftEvent {
+            result,
+            is_shift_click,
             cancelled: false,
         };
         self.dispatch_event(&mut event, &ctx);

--- a/crates/basalt-server/src/game/crafting.rs
+++ b/crates/basalt-server/src/game/crafting.rs
@@ -1523,4 +1523,199 @@ mod tests {
         assert_eq!(grid.slots[1].item_id, Some(43));
         assert_eq!(grid.slots[1].item_count, 2);
     }
+
+    // ── Event-pipeline tests ──────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use basalt_api::context::ServerContext;
+    use basalt_api::events::{
+        CraftingCraftedEvent, CraftingPreCraftEvent, CraftingRecipeClearedEvent,
+        CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
+    };
+    use basalt_events::{Event, Stage};
+
+    /// Sets up a player with an open crafting table and pre-fills the
+    /// 2x2 of oak planks (id 43) needed for a crafting-table recipe
+    /// (item id 314). Drains all initial output messages.
+    fn setup_planks_grid(
+        amount: i32,
+    ) -> (
+        crate::game::GameLoop,
+        tokio::sync::mpsc::UnboundedSender<GameInput>,
+        Uuid,
+        basalt_ecs::EntityId,
+        tokio::sync::mpsc::Receiver<ServerOutput>,
+    ) {
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        let eid = game_loop.find_by_uuid(uuid).unwrap();
+        game_loop
+            .world
+            .set_block(5, 64, 3, basalt_world::block::CRAFTING_TABLE);
+        game_loop.open_crafting_table(eid, 5, 64, 3);
+        while rx.try_recv().is_ok() {}
+
+        if let Some(grid) = game_loop.ecs.get_mut::<basalt_core::CraftingGrid>(eid) {
+            grid.slots[0] = basalt_types::Slot::new(43, amount);
+            grid.slots[1] = basalt_types::Slot::new(43, amount);
+            grid.slots[3] = basalt_types::Slot::new(43, amount);
+            grid.slots[4] = basalt_types::Slot::new(43, amount);
+            grid.output = basalt_types::Slot::new(314, 1);
+        }
+
+        (game_loop, game_tx, uuid, eid, rx)
+    }
+
+    #[test]
+    fn pre_craft_cancellation_blocks_consume() {
+        let (mut game_loop, game_tx, uuid, eid, _rx) = setup_planks_grid(1);
+
+        // Validate handler that always cancels the craft.
+        game_loop.bus.on::<CraftingPreCraftEvent, ServerContext>(
+            Stage::Validate,
+            0,
+            |event, _ctx| {
+                event.cancel();
+            },
+        );
+
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 0,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(1);
+
+        let grid = game_loop.ecs.get::<basalt_core::CraftingGrid>(eid).unwrap();
+        assert_eq!(grid.slots[0].item_count, 1, "ingredients not consumed");
+        let inv = game_loop.ecs.get::<basalt_core::Inventory>(eid).unwrap();
+        assert!(inv.cursor.is_empty(), "cursor still empty");
+    }
+
+    #[test]
+    fn matched_event_can_clear_result() {
+        let (mut game_loop, game_tx, uuid, eid, _rx) = setup_planks_grid(1);
+
+        // Process handler that denies the recipe by zeroing the result.
+        game_loop
+            .bus
+            .on::<CraftingRecipeMatchedEvent, ServerContext>(Stage::Process, 100, |event, _ctx| {
+                event.result = basalt_types::Slot::empty();
+            });
+
+        // Trigger a match cycle by clicking on (and re-placing) a grid slot.
+        // We pick up slot 0 then put it back; the resulting grid is identical
+        // but a recompute fires through the event pipeline.
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 1,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(1);
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 1,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(2);
+
+        let grid = game_loop.ecs.get::<basalt_core::CraftingGrid>(eid).unwrap();
+        assert!(
+            grid.output.is_empty(),
+            "plugin denied recipe; output must be empty"
+        );
+    }
+
+    #[test]
+    fn shift_click_batch_cap_limits_iterations() {
+        // 4 stacks of 4 planks → 4 craft iterations possible naturally,
+        // but the plugin caps at 1.
+        let (mut game_loop, game_tx, uuid, eid, _rx) = setup_planks_grid(4);
+
+        let crafted = Arc::new(AtomicU32::new(0));
+        let crafted_clone = Arc::clone(&crafted);
+        game_loop
+            .bus
+            .on::<CraftingShiftClickBatchEvent, ServerContext>(
+                Stage::Validate,
+                0,
+                |event, _ctx| {
+                    event.max_count = 1;
+                },
+            );
+        game_loop.bus.on::<CraftingCraftedEvent, ServerContext>(
+            Stage::Post,
+            0,
+            move |_event, _ctx| {
+                crafted_clone.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        // Shift-click on the output slot (mode = 1)
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 0,
+            button: 0,
+            mode: 1,
+            changed_slots: vec![],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(1);
+
+        assert_eq!(crafted.load(Ordering::SeqCst), 1, "cap honoured");
+        let grid = game_loop.ecs.get::<basalt_core::CraftingGrid>(eid).unwrap();
+        assert_eq!(
+            grid.slots[0].item_count, 3,
+            "only one plank consumed per slot"
+        );
+    }
+
+    #[test]
+    fn cleared_event_fires_on_match_to_no_match_transition() {
+        let (mut game_loop, game_tx, uuid, eid, _rx) = setup_planks_grid(1);
+
+        let cleared = Arc::new(AtomicU32::new(0));
+        let cleared_clone = Arc::clone(&cleared);
+        game_loop
+            .bus
+            .on::<CraftingRecipeClearedEvent, ServerContext>(
+                Stage::Post,
+                0,
+                move |_event, _ctx| {
+                    cleared_clone.fetch_add(1, Ordering::SeqCst);
+                },
+            );
+
+        // Pick up one plank — grid breaks the 2x2 pattern, output clears.
+        let _ = game_tx.send(GameInput::WindowClick {
+            uuid,
+            slot: 1,
+            button: 0,
+            mode: 0,
+            changed_slots: vec![],
+            cursor_item: basalt_types::Slot::empty(),
+        });
+        game_loop.tick(1);
+
+        let grid = game_loop.ecs.get::<basalt_core::CraftingGrid>(eid).unwrap();
+        assert!(
+            grid.output.is_empty(),
+            "broken pattern clears the output slot"
+        );
+        assert_eq!(cleared.load(Ordering::SeqCst), 1, "single transition fired");
+    }
 }

--- a/crates/basalt-server/src/game/inventory/clicks/left_right.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/left_right.rs
@@ -107,6 +107,15 @@ impl GameLoop {
             return false;
         }
 
+        // Snapshot grid contents BEFORE consume so the CraftedEvent
+        // carries the pre-consumption state.
+        let consumed = self
+            .ecs
+            .get::<basalt_core::CraftingGrid>(eid)
+            .map(|g| g.slots.clone())
+            .unwrap_or_else(|| std::array::from_fn(|_| basalt_types::Slot::empty()));
+        let produced = output.clone();
+
         if let Some(inv) = self.ecs.get_mut::<basalt_core::Inventory>(eid) {
             if inv.cursor.is_empty() {
                 inv.cursor = output;
@@ -117,6 +126,9 @@ impl GameLoop {
 
         self.consume_crafting_ingredients(eid);
         self.sync_crafting_grid_to_client(eid);
+
+        // Notify plugins of the successful craft.
+        self.dispatch_crafting_crafted(uuid, eid, consumed, produced);
 
         // Re-match recipe after consuming — return true so caller
         // dispatches grid changed + updates output

--- a/crates/basalt-server/src/game/inventory/clicks/left_right.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/left_right.rs
@@ -69,7 +69,7 @@ impl GameLoop {
     /// Takes the crafting output and consumes ingredients.
     ///
     /// Validates that the cursor is empty or compatible with the output,
-    /// dispatches `CraftingOutputClickedEvent` (allowing cancellation),
+    /// dispatches `CraftingPreCraftEvent` (allowing cancellation),
     /// then moves the output to the cursor and decrements each grid
     /// ingredient by one.
     ///
@@ -102,7 +102,7 @@ impl GameLoop {
             return false;
         }
 
-        let cancelled = self.dispatch_crafting_output_clicked(uuid, eid, false);
+        let cancelled = self.dispatch_crafting_pre_craft(uuid, eid, false);
         if cancelled {
             return false;
         }

--- a/crates/basalt-server/src/game/inventory/clicks/shift.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/shift.rs
@@ -27,7 +27,7 @@ impl GameLoop {
                 if !has_output {
                     return false;
                 }
-                let cancelled = self.dispatch_crafting_output_clicked(uuid, eid, true);
+                let cancelled = self.dispatch_crafting_pre_craft(uuid, eid, true);
                 if !cancelled {
                     self.handle_shift_click_craft(eid);
                     self.sync_crafting_grid_to_client(eid);

--- a/crates/basalt-server/src/game/inventory/clicks/shift.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/shift.rs
@@ -29,7 +29,7 @@ impl GameLoop {
                 }
                 let cancelled = self.dispatch_crafting_pre_craft(uuid, eid, true);
                 if !cancelled {
-                    self.handle_shift_click_craft(eid);
+                    self.handle_shift_click_craft(uuid, eid);
                     self.sync_crafting_grid_to_client(eid);
                     self.sync_inventory_to_client(eid);
                 }

--- a/crates/basalt-server/src/game/inventory/mod.rs
+++ b/crates/basalt-server/src/game/inventory/mod.rs
@@ -177,7 +177,7 @@ impl GameLoop {
 
         if craft_grid_changed {
             self.dispatch_crafting_grid_changed(uuid, eid);
-            self.update_crafting_output(eid);
+            self.run_crafting_match_cycle(uuid, eid);
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds 4 new fine-grained crafting events (`CraftingRecipeMatchedEvent`, `CraftingRecipeClearedEvent`, `CraftingCraftedEvent`, `CraftingShiftClickBatchEvent`) and renames `CraftingOutputClickedEvent` → `CraftingPreCraftEvent` to give plugins composable hooks for the crafting flow (augment / deny / cap / observe)
- Refactors the inline crafting logic in `basalt-server` into three composable helpers (`compute_crafting_match`, `sync_crafting_output_slot`, `run_crafting_match_cycle`) so the match step runs through the event pipeline both for steady-state grid edits and inside the shift-click loop
- Wires `CraftingShiftClickBatchEvent` (Validate, mutable `max_count`) before the shift-click batch and `CraftingCraftedEvent` (Post) per crafted unit — both for normal clicks and shift-click iterations
- Closes #163

Implements categories **B (match cycle, 3 events)** and **C (craft execution, 3 events)** of the validated 13-event proposal. Categories A (registry lifecycle) and D (recipe book) are deferred to follow-up issues — see #163.

## Plugin use cases unlocked

- **Conditionally allow a recipe** ("only VIP can craft a diamond block"): set `event.result = Slot::empty()` in a `CraftingRecipeMatchedEvent` Process handler — the player never sees the result appear
- **Augment a result** (bonus count, custom NBT, Fortune-style double drop): mutate `event.result` at Process priority 100+
- **Cap shift-click batches** (anti-grief): lower `event.max_count` in a `CraftingShiftClickBatchEvent` Validate handler
- **Cancel a craft mid-flow** (anti-cheat): cancel `CraftingPreCraftEvent` at Validate
- **Track crafted items** (stats, achievements): listen to `CraftingCraftedEvent` at Post — fires once per crafted unit, including each iteration of a shift-click batch

## Architecture

The match cycle now follows the event-first paradigm consistent with the container events from #162:

1. Click writes to `CraftingGrid` slots
2. `dispatch_crafting_grid_changed` fires `CraftingGridChangedEvent` (Post-only notification)
3. `run_crafting_match_cycle` calls `RecipeRegistry::match_grid`, then dispatches either `CraftingRecipeMatchedEvent` (Process: plugins mutate `result`) or `CraftingRecipeClearedEvent` (Post, only on matched → unmatched transition)
4. The (possibly plugin-mutated) result is written to `grid.output` and synced to the client

The shift-click loop reuses `compute_crafting_match` between iterations so plugins observe each per-craft match through the same pipeline. Per-iteration events fire in this order: `CraftingPreCraftEvent` (once before the batch) → `CraftingShiftClickBatchEvent` (once before the loop) → loop N times: `CraftingCraftedEvent` (Post, with pre-consume snapshot) + `CraftingRecipeMatchedEvent` (next iteration's match resolution).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --lib --bins --tests --examples --all-features -- -D warnings`
- [x] `cargo test --all-features` — 990 passed, 0 failed
- [x] `cargo llvm-cov --all-features --fail-under-lines 90 --ignore-filename-regex "(examples|packets/|xtask/src/recipes\.rs|basalt-recipes/src/generated\.rs)"` — 91.14% line coverage
- [x] Unit tests for each new event (construction, cancellation behaviour, BUS routing) in `basalt-api`
- [x] Server-side integration tests covering the full event pipeline:
  - `pre_craft_cancellation_blocks_consume`
  - `matched_event_can_clear_result`
  - `shift_click_batch_cap_limits_iterations`
  - `cleared_event_fires_on_match_to_no_match_transition`
- [ ] Manual in-game smoke: craft a stick (normal), shift-click craft (batch), break a 2x2 pattern (cleared event)
