### PR TITLE
feat(container,recipe): migrate inline chest and crafting logic to plugin handlers

### DIFF
--- a/crates/basalt-api/src/context/container.rs
+++ b/crates/basalt-api/src/context/container.rs
@@ -22,4 +22,12 @@ impl ContainerContext for ServerContext {
         self.responses
             .push(Response::OpenContainer(container.clone()));
     }
+
+    fn notify_viewers(&self, x: i32, y: i32, z: i32, slot_index: i16, item: basalt_types::Slot) {
+        self.responses.push(Response::NotifyContainerViewers {
+            position: BlockPosition { x, y, z },
+            slot_index,
+            item,
+        });
+    }
 }

--- a/crates/basalt-api/src/context/entity.rs
+++ b/crates/basalt-api/src/context/entity.rs
@@ -73,4 +73,20 @@ impl EntityContext for ServerContext {
     fn broadcast_raw(&self, msg: BroadcastMessage) {
         self.responses.push(Response::Broadcast(msg));
     }
+    fn broadcast_block_action(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        action_id: u8,
+        action_param: u8,
+        block_id: i32,
+    ) {
+        self.responses.push(Response::BroadcastBlockAction {
+            position: BlockPosition { x, y, z },
+            action_id,
+            action_param,
+            block_id,
+        });
+    }
 }

--- a/crates/basalt-api/src/context/player.rs
+++ b/crates/basalt-api/src/context/player.rs
@@ -32,6 +32,10 @@ impl PlayerContext for ServerContext {
     fn pitch(&self) -> f32 {
         self.player.rotation.pitch
     }
+    fn position(&self) -> (f64, f64, f64) {
+        let p = self.player.position;
+        (p.x, p.y, p.z)
+    }
     fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32) {
         let teleport_id = GLOBAL_TELEPORT_COUNTER.fetch_add(1, Ordering::Relaxed);
         self.responses.push(Response::SendPosition {

--- a/crates/basalt-api/src/context/response.rs
+++ b/crates/basalt-api/src/context/response.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 
 use basalt_core::broadcast::BroadcastMessage;
 use basalt_core::components::{BlockPosition, ChunkPosition, Position, Rotation};
+use basalt_types::Slot;
 use basalt_types::nbt::NbtCompound;
 
 /// A deferred operation queued by a sync event handler.
@@ -67,6 +68,48 @@ pub enum Response {
     /// Accepts a [`Container`](basalt_core::container::Container) template
     /// value built via [`Container::builder()`](basalt_core::container::Container::builder).
     OpenContainer(basalt_core::container::Container),
+    /// Broadcast a `BlockAction` packet to all connected players.
+    ///
+    /// Used by container/door/note-block plugins for state-change
+    /// animations (chest lid open/close, door open/close, etc.). The
+    /// meaning of `action_id` and `action_param` depends on the
+    /// `block_id` registry value.
+    BroadcastBlockAction {
+        /// World position of the block.
+        position: BlockPosition,
+        /// Action identifier (block-specific).
+        action_id: u8,
+        /// Action parameter (block-specific; for chests this is the
+        /// number of viewers, 0 = closed).
+        action_param: u8,
+        /// Block registry ID (e.g. 185 for chest in 1.21.4).
+        block_id: i32,
+    },
+    /// Send a `SetContainerSlot` to every player viewing the same
+    /// block-backed container, **excluding** the current player.
+    ///
+    /// Used by `ContainerPlugin` to keep co-viewers' open chests in
+    /// sync when a slot is mutated by the source player. The server
+    /// resolves which players are co-viewers by scanning the
+    /// `OpenContainer` components.
+    NotifyContainerViewers {
+        /// World position of the block-backed container.
+        position: BlockPosition,
+        /// Protocol slot index that changed.
+        slot_index: i16,
+        /// New slot contents to broadcast.
+        item: Slot,
+    },
+    /// Remove a block entity at the given position and dispatch
+    /// `BlockEntityDestroyedEvent` with its last state.
+    ///
+    /// Used by `ContainerPlugin` on chest break to drive the destroy
+    /// → drop-items chain through the event pipeline. No-op if no
+    /// block entity exists at the position.
+    DestroyBlockEntity {
+        /// World position of the block entity to remove.
+        position: BlockPosition,
+    },
 }
 
 /// Thread-local queue for deferred async responses.

--- a/crates/basalt-api/src/context/tests.rs
+++ b/crates/basalt-api/src/context/tests.rs
@@ -27,6 +27,11 @@ fn test_ctx() -> ServerContext {
                 yaw: 0.0,
                 pitch: 0.0,
             },
+            position: basalt_core::Position {
+                x: 0.0,
+                y: 64.0,
+                z: 0.0,
+            },
         },
     )
 }

--- a/crates/basalt-api/src/context/world.rs
+++ b/crates/basalt-api/src/context/world.rs
@@ -1,7 +1,7 @@
 //! WorldContext implementation for ServerContext.
 
 use basalt_core::WorldContext;
-use basalt_core::components::ChunkPosition;
+use basalt_core::components::{BlockPosition, ChunkPosition};
 
 use super::ServerContext;
 use super::response::Response;
@@ -20,5 +20,10 @@ impl WorldContext for ServerContext {
     fn persist_chunk(&self, cx: i32, cz: i32) {
         self.responses
             .push(Response::PersistChunk(ChunkPosition { x: cx, z: cz }));
+    }
+    fn destroy_block_entity(&self, x: i32, y: i32, z: i32) {
+        self.responses.push(Response::DestroyBlockEntity {
+            position: BlockPosition { x, y, z },
+        });
     }
 }

--- a/crates/basalt-api/src/events/container.rs
+++ b/crates/basalt-api/src/events/container.rs
@@ -118,6 +118,14 @@ pub struct ContainerOpenedEvent {
     pub inventory_type: InventoryType,
     /// How the container is backed.
     pub backing: ContainerBacking,
+    /// Number of players viewing the same block-backed container,
+    /// **including** the player who just opened it. Always at least 1
+    /// for `Block` backings, 0 for `Virtual` backings (each virtual
+    /// container is per-player).
+    ///
+    /// Used by `ContainerPlugin` to broadcast the chest-lid open
+    /// animation with the right viewer count.
+    pub viewer_count: u32,
 }
 crate::game_event!(ContainerOpenedEvent);
 
@@ -134,6 +142,21 @@ pub struct ContainerClosedEvent {
     pub backing: ContainerBacking,
     /// Why the container is closing.
     pub reason: CloseReason,
+    /// Number of remaining viewers on the same block-backed container
+    /// **excluding** the closing player. 0 for `Virtual` backings.
+    ///
+    /// Used by `ContainerPlugin` to broadcast the chest-lid close
+    /// animation with the right remaining-viewer count (action
+    /// param 0 closes the lid completely).
+    pub viewer_count: u32,
+    /// Snapshot of the player's `CraftingGrid` slots at the moment of
+    /// close, populated **only** when `inventory_type ==
+    /// InventoryType::Crafting` (3x3 crafting table). The server has
+    /// already reset the grid to 2x2 by the time this event fires —
+    /// plugins use the snapshot to spawn dropped items.
+    ///
+    /// `None` for any non-crafting close.
+    pub crafting_grid_state: Option<[Slot; 9]>,
 }
 crate::game_event!(ContainerClosedEvent);
 
@@ -360,9 +383,11 @@ mod tests {
             backing: ContainerBacking::Block {
                 position: BlockPosition { x: 5, y: 64, z: 3 },
             },
+            viewer_count: 1,
         };
         assert_eq!(event.window_id, 1);
         assert_eq!(event.inventory_type, InventoryType::Generic9x3);
+        assert_eq!(event.viewer_count, 1);
     }
 
     #[test]
@@ -371,6 +396,7 @@ mod tests {
             window_id: 1,
             inventory_type: InventoryType::Generic9x3,
             backing: ContainerBacking::Virtual,
+            viewer_count: 0,
         };
         event.cancel(); // no-op
         assert!(!event.is_cancelled());
@@ -389,6 +415,8 @@ mod tests {
                 },
             },
             reason: CloseReason::Manual,
+            viewer_count: 0,
+            crafting_grid_state: None,
         };
         assert_eq!(event.window_id, 2);
         assert_eq!(event.reason, CloseReason::Manual);
@@ -401,6 +429,8 @@ mod tests {
             inventory_type: InventoryType::Generic9x3,
             backing: ContainerBacking::Virtual,
             reason: CloseReason::Disconnect,
+            viewer_count: 0,
+            crafting_grid_state: None,
         };
         event.cancel();
         assert!(!event.is_cancelled());
@@ -604,12 +634,15 @@ mod tests {
                 window_id: 1,
                 inventory_type: InventoryType::Generic9x3,
                 backing: ContainerBacking::Virtual,
+                viewer_count: 0,
             }),
             Box::new(ContainerClosedEvent {
                 window_id: 1,
                 inventory_type: InventoryType::Generic9x3,
                 backing: ContainerBacking::Virtual,
                 reason: CloseReason::Manual,
+                viewer_count: 0,
+                crafting_grid_state: None,
             }),
             Box::new(ContainerClickEvent {
                 window_id: 1,

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -84,7 +84,7 @@ pub mod prelude {
     pub use basalt_events::{Event, Stage};
 
     // Container types
-    pub use crate::container::{Container, ContainerBuilder, InventoryType};
+    pub use crate::container::{Container, ContainerBacking, ContainerBuilder, InventoryType};
 
     // All event types
     pub use crate::events::{

--- a/crates/basalt-core/src/context.rs
+++ b/crates/basalt-core/src/context.rs
@@ -56,6 +56,13 @@ pub trait WorldContext {
     fn stream_chunks(&self, cx: i32, cz: i32);
     /// Schedules a chunk for asynchronous persistence on the I/O thread.
     fn persist_chunk(&self, cx: i32, cz: i32);
+    /// Removes a block entity at the given position and fires a
+    /// `BlockEntityDestroyedEvent` carrying the last state.
+    ///
+    /// No-op if no block entity exists at the position. Plugins use
+    /// this from a `BlockBrokenEvent` Post handler to drive the
+    /// destroy → drop-items chain through the event pipeline.
+    fn destroy_block_entity(&self, x: i32, y: i32, z: i32);
 }
 
 /// Entity management: spawn, despawn, broadcast.
@@ -93,6 +100,22 @@ pub trait EntityContext {
     /// Prefer the typed broadcast methods when possible. This method
     /// is for server-internal broadcasts that don't have typed wrappers.
     fn broadcast_raw(&self, msg: BroadcastMessage);
+
+    /// Broadcasts a `BlockAction` packet to all connected players.
+    ///
+    /// Used for state-change animations driven by plugins (chest
+    /// lid open/close, door swing, note-block pitch chime, etc.).
+    /// The meaning of `action_id` and `action_param` is block-specific
+    /// — see the wiki for the full table.
+    fn broadcast_block_action(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        action_id: u8,
+        action_param: u8,
+        block_id: i32,
+    );
 }
 
 /// Container interaction: chests, crafting tables, custom windows.
@@ -118,6 +141,16 @@ pub trait ContainerContext {
     /// ctx.containers().open(&SHOP);
     /// ```
     fn open(&self, container: &crate::container::Container);
+
+    /// Notifies every other player viewing the same block-backed
+    /// container that a slot changed.
+    ///
+    /// Sends `SetContainerSlot` to all players whose `OpenContainer`
+    /// component points at `(x, y, z)`, **excluding** the current
+    /// player. Used by `ContainerPlugin` from the
+    /// `ContainerSlotChangedEvent` handler to keep co-viewers in sync.
+    /// No-op for virtual containers (they are per-player).
+    fn notify_viewers(&self, x: i32, y: i32, z: i32, slot_index: i16, item: basalt_types::Slot);
 }
 
 // ── Main Context trait ───────────────────────────────────────────────

--- a/crates/basalt-core/src/context.rs
+++ b/crates/basalt-core/src/context.rs
@@ -24,6 +24,9 @@ pub trait PlayerContext {
     fn yaw(&self) -> f32;
     /// Returns the player's current pitch rotation (vertical, degrees).
     fn pitch(&self) -> f32;
+    /// Returns the player's current world position. Captured at
+    /// context-construction time — stale by the next tick.
+    fn position(&self) -> (f64, f64, f64);
     /// Teleports the current player to the given coordinates.
     fn teleport(&self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32);
     /// Changes the current player's gamemode.

--- a/crates/basalt-core/src/player.rs
+++ b/crates/basalt-core/src/player.rs
@@ -2,7 +2,7 @@
 
 use basalt_types::Uuid;
 
-use crate::components::Rotation;
+use crate::components::{Position, Rotation};
 
 /// Identity and state of the player who triggered an action.
 ///
@@ -18,4 +18,8 @@ pub struct PlayerInfo {
     pub username: String,
     /// Current facing direction.
     pub rotation: Rotation,
+    /// Current world position. Read at context-construction time, so
+    /// it reflects the player's location when the event fired —
+    /// stale by the next tick.
+    pub position: Position,
 }

--- a/crates/basalt-core/src/testing.rs
+++ b/crates/basalt-core/src/testing.rs
@@ -58,6 +58,7 @@ impl WorldContext for NoopContext {
     fn send_block_ack(&self, _sequence: i32) {}
     fn stream_chunks(&self, _cx: i32, _cz: i32) {}
     fn persist_chunk(&self, _cx: i32, _cz: i32) {}
+    fn destroy_block_entity(&self, _x: i32, _y: i32, _z: i32) {}
 }
 
 impl EntityContext for NoopContext {
@@ -78,12 +79,31 @@ impl EntityContext for NoopContext {
     fn broadcast_player_joined(&self) {}
     fn broadcast_player_left(&self) {}
     fn broadcast_raw(&self, _msg: BroadcastMessage) {}
+    fn broadcast_block_action(
+        &self,
+        _x: i32,
+        _y: i32,
+        _z: i32,
+        _action_id: u8,
+        _action_param: u8,
+        _block_id: i32,
+    ) {
+    }
 }
 
 impl ContainerContext for NoopContext {
     fn open_chest(&self, _x: i32, _y: i32, _z: i32) {}
     fn open_crafting_table(&self, _x: i32, _y: i32, _z: i32) {}
     fn open(&self, _container: &crate::container::Container) {}
+    fn notify_viewers(
+        &self,
+        _x: i32,
+        _y: i32,
+        _z: i32,
+        _slot_index: i16,
+        _item: basalt_types::Slot,
+    ) {
+    }
 }
 
 impl Context for NoopContext {

--- a/crates/basalt-core/src/testing.rs
+++ b/crates/basalt-core/src/testing.rs
@@ -34,6 +34,9 @@ impl PlayerContext for NoopContext {
     fn pitch(&self) -> f32 {
         0.0
     }
+    fn position(&self) -> (f64, f64, f64) {
+        (0.0, 0.0, 0.0)
+    }
     fn teleport(&self, _x: f64, _y: f64, _z: f64, _yaw: f32, _pitch: f32) {}
     fn set_gamemode(&self, _mode: Gamemode) {}
     fn registered_commands(&self) -> Vec<(String, String)> {

--- a/crates/basalt-server/src/game/blocks.rs
+++ b/crates/basalt-server/src/game/blocks.rs
@@ -34,6 +34,19 @@ impl GameLoop {
                     yaw: 0.0,
                     pitch: 0.0,
                 },
+                position: self
+                    .ecs
+                    .get::<basalt_core::Position>(eid)
+                    .map(|p| basalt_core::Position {
+                        x: p.x,
+                        y: p.y,
+                        z: p.z,
+                    })
+                    .unwrap_or(basalt_core::Position {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    }),
             },
         );
         let mut event = BlockBrokenEvent {
@@ -133,6 +146,19 @@ impl GameLoop {
                 entity_id,
                 username: username.clone(),
                 rotation: basalt_core::Rotation { yaw, pitch },
+                position: self
+                    .ecs
+                    .get::<basalt_core::Position>(eid)
+                    .map(|p| basalt_core::Position {
+                        x: p.x,
+                        y: p.y,
+                        z: p.z,
+                    })
+                    .unwrap_or(basalt_core::Position {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    }),
             },
         );
         let mut event = BlockPlacedEvent {

--- a/crates/basalt-server/src/game/container.rs
+++ b/crates/basalt-server/src/game/container.rs
@@ -20,6 +20,53 @@ fn block_entity_kind(be: &BlockEntity) -> BlockEntityKind {
     }
 }
 
+/// Counts how many players have an `OpenContainer` component pointing
+/// at the same block-backed position as `backing`.
+///
+/// Returns 0 for `Virtual` backings (per-player, no co-viewing).
+pub(super) fn container_viewer_count(
+    ecs: &basalt_ecs::Ecs,
+    backing: &basalt_core::ContainerBacking,
+) -> u32 {
+    let basalt_core::ContainerBacking::Block { position } = backing else {
+        return 0;
+    };
+    let target = (position.x, position.y, position.z);
+    ecs.iter::<basalt_core::OpenContainer>()
+        .filter(|(_, oc)| {
+            matches!(
+                &oc.backing,
+                basalt_core::ContainerBacking::Block { position: p }
+                    if (p.x, p.y, p.z) == target
+            )
+        })
+        .count() as u32
+}
+
+/// Counts viewers like [`container_viewer_count`] but excludes the
+/// given entity. Used to compute the *remaining* viewer count for
+/// chest-lid close animations after a player closes the window.
+pub(super) fn container_viewer_count_excluding(
+    ecs: &basalt_ecs::Ecs,
+    backing: &basalt_core::ContainerBacking,
+    exclude: basalt_ecs::EntityId,
+) -> u32 {
+    let basalt_core::ContainerBacking::Block { position } = backing else {
+        return 0;
+    };
+    let target = (position.x, position.y, position.z);
+    ecs.iter::<basalt_core::OpenContainer>()
+        .filter(|(eid, oc)| {
+            *eid != exclude
+                && matches!(
+                    &oc.backing,
+                    basalt_core::ContainerBacking::Block { position: p }
+                        if (p.x, p.y, p.z) == target
+                )
+        })
+        .count() as u32
+}
+
 /// A part of a container backed by a block entity.
 ///
 /// Each part maps a range of window slots to a block entity at a
@@ -439,12 +486,19 @@ impl GameLoop {
             });
         });
 
+        // Compute the viewer count BEFORE dispatch — for block-backed
+        // containers this includes the just-opened viewer (the
+        // OpenContainer component was set on `eid` above), giving
+        // plugins the post-open count for the chest-lid animation.
+        let viewer_count = container_viewer_count(&self.ecs, &backing);
+
         // Dispatch ContainerOpenedEvent (Post stage)
         let ctx = self.make_context(uuid, entity_id, &username, yaw, pitch);
         let mut opened_event = ContainerOpenedEvent {
             window_id,
             inventory_type,
             backing,
+            viewer_count,
         };
         self.dispatch_event(&mut opened_event, &ctx);
         self.process_responses(uuid, &ctx.drain_responses());
@@ -452,13 +506,18 @@ impl GameLoop {
 
     /// Dispatches a `ContainerClosedEvent` for a player.
     ///
-    /// Reads the `OpenContainer` component to populate the event fields.
-    /// Must be called BEFORE the `OpenContainer` component is removed.
+    /// Reads the `OpenContainer` component to populate the event
+    /// fields. Must be called BEFORE the `OpenContainer` component
+    /// is removed (so the close-time backing/inventory_type are
+    /// observable). The `crafting_grid_state` snapshot is the
+    /// caller's responsibility — pass `None` for non-crafting
+    /// closures.
     pub(super) fn dispatch_container_closed(
         &mut self,
         eid: basalt_ecs::EntityId,
         uuid: Uuid,
         reason: CloseReason,
+        crafting_grid_state: Option<[basalt_types::Slot; 9]>,
     ) {
         let Some(oc) = self.ecs.get::<basalt_core::OpenContainer>(eid) else {
             return;
@@ -466,6 +525,9 @@ impl GameLoop {
         let window_id = oc.window_id;
         let inventory_type = oc.inventory_type;
         let backing = oc.backing;
+
+        // Remaining viewers exclude the closing player.
+        let viewer_count = container_viewer_count_excluding(&self.ecs, &backing, eid);
 
         let (entity_id, username, yaw, pitch) = match self.player_info(eid) {
             Some(info) => info,
@@ -477,6 +539,8 @@ impl GameLoop {
             inventory_type,
             backing,
             reason,
+            viewer_count,
+            crafting_grid_state,
         };
         self.dispatch_event(&mut event, &ctx);
         self.process_responses(uuid, &ctx.drain_responses());
@@ -549,8 +613,9 @@ impl GameLoop {
     /// with the last state.
     ///
     /// Returns the removed entity for the caller if needed. Returns
-    /// `None` if no block entity existed at the position.
-    #[allow(dead_code)] // infrastructure for future callers (plugin block entity removal)
+    /// `None` if no block entity existed at the position. Wired into
+    /// the plugin API via `Response::DestroyBlockEntity`
+    /// (`ctx.world_ctx().destroy_block_entity(...)`).
     pub(super) fn destroy_block_entity(
         &mut self,
         uuid: Uuid,

--- a/crates/basalt-server/src/game/container.rs
+++ b/crates/basalt-server/src/game/container.rs
@@ -7,7 +7,7 @@ use basalt_api::events::{
 use basalt_types::Uuid;
 use basalt_world::block_entity::BlockEntity;
 
-use super::{GameLoop, OutputHandle};
+use super::GameLoop;
 use crate::messages::ServerOutput;
 
 /// Maps a world block entity to the public [`BlockEntityKind`] enum.
@@ -228,33 +228,34 @@ impl GameLoop {
             });
         });
 
-        // Broadcast chest open animation to all players
-        // Count how many players are viewing each part
-        for part in &view.parts {
-            let (px, py, pz) = part.position;
-            let viewer_count = self
-                .ecs
-                .iter::<basalt_core::OpenContainer>()
-                .filter(|(_, oc)| {
-                    matches!(
-                        &oc.backing,
-                        basalt_core::ContainerBacking::Block { position }
-                            if (position.x, position.y, position.z) == container_pos
-                    )
-                })
-                .count() as u8;
-            for (e, _) in self.ecs.iter::<OutputHandle>() {
-                self.send_to(e, |tx| {
-                    let _ = tx.try_send(ServerOutput::BlockAction {
-                        x: px,
-                        y: py,
-                        z: pz,
-                        action_id: 1,
-                        action_param: viewer_count.max(1),
-                        block_id: 185, // chest block registry ID
-                    });
-                });
-            }
+        // Dispatch ContainerOpenedEvent — `ContainerPlugin` listens at
+        // Post and broadcasts the chest-lid open animation. The
+        // viewer_count includes the just-opened viewer (the
+        // OpenContainer component was set above).
+        let inventory_type = if view.size == 27 {
+            basalt_core::InventoryType::Generic9x3
+        } else {
+            basalt_core::InventoryType::Generic9x6
+        };
+        let backing = basalt_core::ContainerBacking::Block {
+            position: basalt_core::BlockPosition {
+                x: container_pos.0,
+                y: container_pos.1,
+                z: container_pos.2,
+            },
+        };
+        let viewer_count = container_viewer_count(&self.ecs, &backing);
+
+        if let Some((entity_id, username, yaw, pitch)) = self.player_info(eid) {
+            let ctx = self.make_context(uuid, entity_id, &username, yaw, pitch);
+            let mut opened_event = ContainerOpenedEvent {
+                window_id,
+                inventory_type,
+                backing,
+                viewer_count,
+            };
+            self.dispatch_event(&mut opened_event, &ctx);
+            self.process_responses(uuid, &ctx.drain_responses());
         }
     }
 

--- a/crates/basalt-server/src/game/dispatch.rs
+++ b/crates/basalt-server/src/game/dispatch.rs
@@ -133,11 +133,27 @@ impl GameLoop {
                 }
                 GameInput::CloseWindow { uuid, .. } => {
                     if let Some(eid) = self.find_by_uuid(uuid) {
+                        // Snapshot the crafting grid (if applicable) before dispatch
+                        // so plugins receive the at-close state via the event.
+                        let crafting_grid_state = if matches!(
+                            self.ecs
+                                .get::<basalt_core::OpenContainer>(eid)
+                                .map(|oc| oc.inventory_type),
+                            Some(basalt_core::InventoryType::Crafting)
+                        ) {
+                            self.ecs
+                                .get::<basalt_core::CraftingGrid>(eid)
+                                .map(|g| g.slots.clone())
+                        } else {
+                            None
+                        };
+
                         // Dispatch ContainerClosedEvent before removing the component
                         self.dispatch_container_closed(
                             eid,
                             uuid,
                             basalt_api::events::CloseReason::Manual,
+                            crafting_grid_state,
                         );
 
                         // Return cursor item to inventory or drop it

--- a/crates/basalt-server/src/game/dispatch.rs
+++ b/crates/basalt-server/src/game/dispatch.rs
@@ -184,37 +184,16 @@ impl GameLoop {
                             let inventory_type = oc.inventory_type;
                             let backing = oc.backing;
 
-                            // If closing a crafting table, drop grid contents and reset to 2x2
-                            if matches!(inventory_type, basalt_core::InventoryType::Crafting) {
-                                // Collect slots to drop before mutable borrow
-                                let slots_to_drop: Vec<(i32, i32)> = self
-                                    .ecs
-                                    .get::<basalt_core::CraftingGrid>(eid)
-                                    .iter()
-                                    .flat_map(|grid| grid.slots.iter())
-                                    .filter_map(|slot| slot.item_id.map(|id| (id, slot.item_count)))
-                                    .collect();
-                                // Drop all items from the crafting grid
-                                for (item_id, count) in slots_to_drop {
-                                    if let Some(player_pos) =
-                                        self.ecs.get::<basalt_core::Position>(eid)
-                                    {
-                                        self.spawn_item_entity(
-                                            player_pos.x as i32,
-                                            player_pos.y as i32 + 1,
-                                            player_pos.z as i32,
-                                            item_id,
-                                            count,
-                                        );
-                                    }
-                                }
-                                // Reset to 2x2 mode
-                                if let Some(grid) =
+                            // Reset crafting grid to 2x2 after a crafting table close.
+                            // Drops are handled by RecipePlugin via
+                            // ContainerClosedEvent (already dispatched above with
+                            // crafting_grid_state populated).
+                            if matches!(inventory_type, basalt_core::InventoryType::Crafting)
+                                && let Some(grid) =
                                     self.ecs.get_mut::<basalt_core::CraftingGrid>(eid)
-                                {
-                                    grid.grid_size = 2;
-                                    grid.clear();
-                                }
+                            {
+                                grid.grid_size = 2;
+                                grid.clear();
                             }
                             // Chest close animation is now handled by ContainerPlugin
                             // listening to ContainerClosedEvent.

--- a/crates/basalt-server/src/game/dispatch.rs
+++ b/crates/basalt-server/src/game/dispatch.rs
@@ -215,42 +215,10 @@ impl GameLoop {
                                     grid.grid_size = 2;
                                     grid.clear();
                                 }
-                            } else if let basalt_core::ContainerBacking::Block { position } =
-                                backing
-                            {
-                                // Broadcast chest close animation if no other viewers
-                                let pos = (position.x, position.y, position.z);
-                                let remaining = self
-                                    .ecs
-                                    .iter::<basalt_core::OpenContainer>()
-                                    .filter(|(id, oc2)| {
-                                        *id != eid
-                                            && matches!(
-                                                &oc2.backing,
-                                                basalt_core::ContainerBacking::Block { position: p }
-                                                    if (p.x, p.y, p.z) == pos
-                                            )
-                                    })
-                                    .count() as u8;
-                                let view = self.build_chest_view(pos.0, pos.1, pos.2);
-                                for part in &view.parts {
-                                    let (px, py, pz) = part.position;
-                                    for (e, _) in self.ecs.iter::<super::OutputHandle>() {
-                                        self.send_to(e, |tx| {
-                                            let _ = tx.try_send(
-                                                crate::messages::ServerOutput::BlockAction {
-                                                    x: px,
-                                                    y: py,
-                                                    z: pz,
-                                                    action_id: 1,
-                                                    action_param: remaining,
-                                                    block_id: 185,
-                                                },
-                                            );
-                                        });
-                                    }
-                                }
                             }
+                            // Chest close animation is now handled by ContainerPlugin
+                            // listening to ContainerClosedEvent.
+                            //
                             // If backing is Virtual, remove VirtualContainerSlots component
                             if matches!(backing, basalt_core::ContainerBacking::Virtual) {
                                 self.ecs

--- a/crates/basalt-server/src/game/helpers.rs
+++ b/crates/basalt-server/src/game/helpers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use basalt_api::context::ServerContext;
 use basalt_core::PlayerInfo;
-use basalt_core::components::Rotation;
+use basalt_core::components::{Position, Rotation};
 use basalt_protocol::packets::play::entity::ClientboundPlaySpawnEntity;
 use basalt_types::{Encode, Uuid, VarInt, Vec3i16};
 use tokio::sync::mpsc;
@@ -34,6 +34,19 @@ impl GameLoop {
         yaw: f32,
         pitch: f32,
     ) -> ServerContext {
+        // Resolve the player's current position from the ECS so plugin
+        // handlers see fresh state. Falls back to (0, 0, 0) if the
+        // entity has no Position component (shouldn't happen for
+        // online players but stays defensive).
+        let position = self
+            .find_by_uuid(uuid)
+            .and_then(|eid| self.ecs.get::<Position>(eid).map(|p| (p.x, p.y, p.z)))
+            .map(|(x, y, z)| Position { x, y, z })
+            .unwrap_or(Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            });
         ServerContext::new(
             Arc::clone(&self.world),
             PlayerInfo {
@@ -41,6 +54,7 @@ impl GameLoop {
                 entity_id,
                 username: username.to_string(),
                 rotation: Rotation { yaw, pitch },
+                position,
             },
         )
     }

--- a/crates/basalt-server/src/game/inventory/clicks/double_click.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/double_click.rs
@@ -44,9 +44,6 @@ impl GameLoop {
                     grid_changed = true;
                 }
                 if let WindowSlot::Container(ci) = ws {
-                    if let Some(pos) = container_pos {
-                        self.notify_container_viewers(pos, eid, *ci as i16, new_slot);
-                    }
                     self.dispatch_container_slot_changed(
                         uuid,
                         eid,

--- a/crates/basalt-server/src/game/inventory/clicks/drag.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/drag.rs
@@ -80,10 +80,7 @@ impl GameLoop {
             if Self::is_craft_slot(ws) {
                 grid_changed = true;
             }
-            if let WindowSlot::Container(ci) = ws {
-                if let Some(pos) = container_pos {
-                    self.notify_container_viewers(pos, eid, *ci as i16, &new_values[i]);
-                }
+            if let WindowSlot::Container(_) = ws {
                 self.dispatch_container_slot_changed(
                     uuid,
                     eid,

--- a/crates/basalt-server/src/game/inventory/clicks/drop.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/drop.rs
@@ -77,9 +77,6 @@ impl GameLoop {
         self.sync_slot(eid, wt, ws, new_item.clone());
 
         if let WindowSlot::Container(i) = ws {
-            if let Some(pos) = container_pos {
-                self.notify_container_viewers(pos, eid, *i as i16, &new_item);
-            }
             self.dispatch_container_slot_changed(uuid, eid, wt, *i as i16, item, new_item);
         }
     }

--- a/crates/basalt-server/src/game/inventory/clicks/hotbar.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/hotbar.rs
@@ -30,9 +30,6 @@ impl GameLoop {
         self.sync_slot(eid, wt, &hotbar_ws, clicked_item.clone());
 
         if let WindowSlot::Container(i) = &ws {
-            if let Some(pos) = container_pos {
-                self.notify_container_viewers(pos, eid, *i as i16, &hotbar_item);
-            }
             self.dispatch_container_slot_changed(
                 uuid,
                 eid,

--- a/crates/basalt-server/src/game/inventory/clicks/left_right.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/left_right.rs
@@ -54,11 +54,9 @@ impl GameLoop {
         }
         self.sync_slot(eid, wt, &ws, new_slot.clone());
 
-        // Notify other container viewers and dispatch slot changed event
+        // Dispatch ContainerSlotChangedEvent — `ContainerPlugin` listens at
+        // Post and notifies co-viewers via `ctx.containers().notify_viewers`.
         if let WindowSlot::Container(i) = &ws {
-            if let Some(pos) = container_pos {
-                self.notify_container_viewers(pos, eid, *i as i16, &new_slot);
-            }
             let proto_slot = *i as i16;
             self.dispatch_container_slot_changed(uuid, eid, wt, proto_slot, slot_item, new_slot);
         }

--- a/crates/basalt-server/src/game/inventory/clicks/shift.rs
+++ b/crates/basalt-server/src/game/inventory/clicks/shift.rs
@@ -70,14 +70,6 @@ impl GameLoop {
                     self.write_slot(eid, &ws, basalt_types::Slot::empty(), container_pos);
                     self.sync_slot(eid, wt, &ws, basalt_types::Slot::empty());
                     self.sync_inventory_to_client(eid);
-                    if let Some(pos) = container_pos {
-                        self.notify_container_viewers(
-                            pos,
-                            eid,
-                            *i as i16,
-                            &basalt_types::Slot::empty(),
-                        );
-                    }
                     self.dispatch_container_slot_changed(
                         uuid,
                         eid,

--- a/crates/basalt-server/src/game/lifecycle.rs
+++ b/crates/basalt-server/src/game/lifecycle.rs
@@ -290,7 +290,26 @@ impl GameLoop {
 
         // Dispatch ContainerClosedEvent before despawn (if container is open)
         if self.ecs.has::<basalt_core::OpenContainer>(eid) {
-            self.dispatch_container_closed(eid, uuid, basalt_api::events::CloseReason::Disconnect);
+            // Snapshot crafting grid for the disconnect path so plugins
+            // can drop items even when the player crashes out.
+            let crafting_grid_state = if matches!(
+                self.ecs
+                    .get::<basalt_core::OpenContainer>(eid)
+                    .map(|oc| oc.inventory_type),
+                Some(basalt_core::InventoryType::Crafting)
+            ) {
+                self.ecs
+                    .get::<basalt_core::CraftingGrid>(eid)
+                    .map(|g| g.slots.clone())
+            } else {
+                None
+            };
+            self.dispatch_container_closed(
+                eid,
+                uuid,
+                basalt_api::events::CloseReason::Disconnect,
+                crafting_grid_state,
+            );
         }
 
         // Dispatch PlayerLeftEvent

--- a/crates/basalt-server/src/game/mod.rs
+++ b/crates/basalt-server/src/game/mod.rs
@@ -300,6 +300,7 @@ pub(super) mod tests {
             basalt_plugin_block::BlockPlugin.on_enable(&mut registrar);
             basalt_plugin_item::ItemPlugin.on_enable(&mut registrar);
             basalt_plugin_container::ContainerPlugin.on_enable(&mut registrar);
+            basalt_plugin_recipe::RecipePlugin.on_enable(&mut registrar);
         }
 
         let mut ecs = basalt_ecs::Ecs::new();

--- a/crates/basalt-server/src/game/responses.rs
+++ b/crates/basalt-server/src/game/responses.rs
@@ -135,6 +135,56 @@ impl GameLoop {
                         self.open_custom_container(eid, source_uuid, container.clone());
                     }
                 }
+                Response::BroadcastBlockAction {
+                    position,
+                    action_id,
+                    action_param,
+                    block_id,
+                } => {
+                    let x = position.x;
+                    let y = position.y;
+                    let z = position.z;
+                    let aid = *action_id;
+                    let ap = *action_param;
+                    let bid = *block_id;
+                    for (e, _) in self.ecs.iter::<OutputHandle>() {
+                        self.send_to(e, |tx| {
+                            let _ = tx.try_send(ServerOutput::BlockAction {
+                                x,
+                                y,
+                                z,
+                                action_id: aid,
+                                action_param: ap,
+                                block_id: bid,
+                            });
+                        });
+                    }
+                }
+                Response::NotifyContainerViewers {
+                    position,
+                    slot_index,
+                    item,
+                } => {
+                    if let Some(source_eid) = self.find_by_uuid(source_uuid) {
+                        self.notify_container_viewers(
+                            (position.x, position.y, position.z),
+                            source_eid,
+                            *slot_index,
+                            item,
+                        );
+                    }
+                }
+                Response::DestroyBlockEntity { position } => {
+                    if let Some(eid) = self.find_by_uuid(source_uuid) {
+                        self.destroy_block_entity(
+                            source_uuid,
+                            eid,
+                            position.x,
+                            position.y,
+                            position.z,
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/basalt-server/src/net/play_handler.rs
+++ b/crates/basalt-server/src/net/play_handler.rs
@@ -74,6 +74,13 @@ pub(super) async fn handle_packet(
                         yaw: 0.0,
                         pitch: 0.0,
                     },
+                    // Net task lacks ECS access; instant events don't
+                    // currently expose position to plugins.
+                    position: basalt_core::Position {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
                 },
             );
             let mut event = ChatMessageEvent {
@@ -112,6 +119,13 @@ pub(super) async fn handle_packet(
                     rotation: Rotation {
                         yaw: 0.0,
                         pitch: 0.0,
+                    },
+                    // Net task lacks ECS access; instant events don't
+                    // currently expose position to plugins.
+                    position: basalt_core::Position {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
                     },
                 },
             );

--- a/crates/basalt-server/src/net/play_handler.rs
+++ b/crates/basalt-server/src/net/play_handler.rs
@@ -338,7 +338,10 @@ async fn process_instant_responses(
             | Response::SpawnDroppedItem { .. }
             | Response::OpenChest(_)
             | Response::OpenCraftingTable { .. }
-            | Response::OpenContainer(_) => {}
+            | Response::OpenContainer(_)
+            | Response::BroadcastBlockAction { .. }
+            | Response::NotifyContainerViewers { .. }
+            | Response::DestroyBlockEntity { .. } => {}
         }
     }
     Ok(())

--- a/crates/basalt-testkit/src/lib.rs
+++ b/crates/basalt-testkit/src/lib.rs
@@ -368,6 +368,27 @@ impl DispatchResult {
             .iter()
             .any(|r| matches!(r, Response::SpawnDroppedItem { .. }))
     }
+
+    /// Returns true if any response broadcasts a `BlockAction` packet.
+    pub fn has_broadcast_block_action(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::BroadcastBlockAction { .. }))
+    }
+
+    /// Returns true if any response notifies co-viewers of a slot change.
+    pub fn has_notify_viewers(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::NotifyContainerViewers { .. }))
+    }
+
+    /// Returns true if any response queues a block-entity destroy.
+    pub fn has_destroy_block_entity(&self) -> bool {
+        self.responses
+            .iter()
+            .any(|r| matches!(r, Response::DestroyBlockEntity { .. }))
+    }
 }
 
 /// Test context for system plugins.

--- a/crates/basalt-testkit/src/lib.rs
+++ b/crates/basalt-testkit/src/lib.rs
@@ -139,6 +139,11 @@ impl PluginTestHarness {
                     yaw: 0.0,
                     pitch: 0.0,
                 },
+                position: basalt_core::Position {
+                    x: 0.0,
+                    y: 64.0,
+                    z: 0.0,
+                },
             },
         )
     }
@@ -154,6 +159,11 @@ impl PluginTestHarness {
                 rotation: Rotation {
                     yaw: 0.0,
                     pitch: 0.0,
+                },
+                position: basalt_core::Position {
+                    x: 0.0,
+                    y: 64.0,
+                    z: 0.0,
                 },
             },
         )

--- a/plugins/container/src/lib.rs
+++ b/plugins/container/src/lib.rs
@@ -380,4 +380,107 @@ mod tests {
             "virtual slot change must not notify viewers"
         );
     }
+
+    #[test]
+    fn chest_open_broadcasts_lid_animation() {
+        let mut harness = PluginTestHarness::new();
+        harness.world().set_block(5, 64, 3, block::CHEST);
+        harness.register(ContainerPlugin);
+
+        let mut event = ContainerOpenedEvent {
+            window_id: 1,
+            inventory_type: InventoryType::Generic9x3,
+            backing: ContainerBacking::Block {
+                position: BlockPosition { x: 5, y: 64, z: 3 },
+            },
+            viewer_count: 1,
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(
+            result.has_broadcast_block_action(),
+            "chest open must broadcast a BlockAction packet"
+        );
+    }
+
+    #[test]
+    fn virtual_open_broadcasts_no_animation() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(ContainerPlugin);
+
+        let mut event = ContainerOpenedEvent {
+            window_id: 1,
+            inventory_type: InventoryType::Generic9x3,
+            backing: ContainerBacking::Virtual,
+            viewer_count: 0,
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(
+            !result.has_broadcast_block_action(),
+            "virtual container must not broadcast lid animation"
+        );
+    }
+
+    #[test]
+    fn chest_close_broadcasts_lid_animation() {
+        let mut harness = PluginTestHarness::new();
+        harness.world().set_block(5, 64, 3, block::CHEST);
+        harness.register(ContainerPlugin);
+
+        let mut event = ContainerClosedEvent {
+            window_id: 1,
+            inventory_type: InventoryType::Generic9x3,
+            backing: ContainerBacking::Block {
+                position: BlockPosition { x: 5, y: 64, z: 3 },
+            },
+            reason: CloseReason::Manual,
+            viewer_count: 0,
+            crafting_grid_state: None,
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(
+            result.has_broadcast_block_action(),
+            "chest close must broadcast a BlockAction packet (lid close)"
+        );
+    }
+
+    #[test]
+    fn block_broken_chest_queues_destroy() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(ContainerPlugin);
+
+        let mut event = BlockBrokenEvent {
+            position: BlockPosition { x: 5, y: 64, z: 3 },
+            block_state: block::CHEST,
+            sequence: 1,
+            cancelled: false,
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(
+            result.has_destroy_block_entity(),
+            "breaking a chest must queue a destroy for the block entity"
+        );
+    }
+
+    #[test]
+    fn block_broken_non_chest_does_not_queue_destroy() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(ContainerPlugin);
+
+        let mut event = BlockBrokenEvent {
+            position: BlockPosition { x: 5, y: 64, z: 3 },
+            block_state: block::STONE,
+            sequence: 1,
+            cancelled: false,
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(
+            !result.has_destroy_block_entity(),
+            "breaking stone must not touch block entities"
+        );
+    }
 }

--- a/plugins/container/src/lib.rs
+++ b/plugins/container/src/lib.rs
@@ -1,13 +1,56 @@
 //! Container plugin — chest interaction, double chest pairing, block entities.
 //!
-//! Handles all container-related game logic via events:
-//! - [`PlayerInteractEvent`]: opens chests on right-click (cancels to prevent block placement)
-//! - [`BlockPlacedEvent`]: creates chest block entities, handles double chest pairing and orientation
-//! - [`BlockBrokenEvent`]: drops chest contents, removes block entities, reverts double chests
+//! All container behaviour is event-driven:
+//! - [`PlayerInteractEvent`] opens chests on right-click.
+//! - [`BlockPlacedEvent`] creates the chest block entity, orients it
+//!   to the player and pairs adjacent halves into a double chest.
+//! - [`BlockBrokenEvent`] reverts double-chest partners and triggers
+//!   block-entity destruction through the event pipeline.
+//! - [`ContainerOpenedEvent`] / [`ContainerClosedEvent`] broadcast the
+//!   chest-lid open/close animation with the right viewer count.
+//! - [`ContainerSlotChangedEvent`] keeps co-viewers' open chests in
+//!   sync.
+//! - [`BlockEntityDestroyedEvent`] drops chest contents as item
+//!   entities (split out of the legacy inline `BlockBrokenEvent`
+//!   path).
 
 use basalt_api::prelude::*;
 use basalt_api::world::block;
 use basalt_api::world::block_entity::BlockEntity;
+
+/// Block registry ID for `chest` in 1.21.4.
+///
+/// Used as the `block_id` field of the `BlockAction` packet driving
+/// the chest-lid open/close animation. See the protocol wiki entry
+/// for "Block Action" — for chests, `action_id = 1` and
+/// `action_param` is the current number of viewers (0 = closed lid).
+const CHEST_BLOCK_ID: i32 = 185;
+
+/// Returns up to two block positions covering a chest at `(x, y, z)`.
+///
+/// Single chests return one position; double chests return both
+/// halves so the lid animation can play on each. Falls back to a
+/// single position if the world doesn't currently report a chest at
+/// `(x, y, z)` (e.g. the block was already broken).
+fn chest_parts(world: &basalt_api::world::World, x: i32, y: i32, z: i32) -> Vec<(i32, i32, i32)> {
+    let mut parts: Vec<(i32, i32, i32)> = Vec::with_capacity(2);
+    parts.push((x, y, z));
+    let state = world.get_block(x, y, z);
+    if !block::is_chest(state) || block::chest_type(state) == 0 {
+        return parts;
+    }
+    let facing = block::chest_facing(state);
+    for &(dx, dz) in &block::chest_adjacent_offsets(facing) {
+        let nx = x + dx;
+        let nz = z + dz;
+        let neighbor = world.get_block(nx, y, nz);
+        if block::is_chest(neighbor) && block::chest_facing(neighbor) == facing {
+            parts.push((nx, y, nz));
+            break;
+        }
+    }
+    parts
+}
 
 /// Handles chest interaction, double chest pairing, and block entity lifecycle.
 pub struct ContainerPlugin;
@@ -104,41 +147,28 @@ impl Plugin for ContainerPlugin {
             }
         });
 
-        // Drop chest contents + remove block entity on break (Post, before drops plugin)
+        // Trigger block-entity destroy + revert double partner on chest break.
+        // Drop logic moved to the BlockEntityDestroyedEvent handler so the
+        // destroy → drops chain runs through the event pipeline.
         registrar.on::<BlockBrokenEvent>(Stage::Post, -1, |event, ctx| {
             let state = event.block_state;
             if !block::is_chest(state) {
                 return;
             }
 
-            let world = ctx.world_ctx().world();
+            // Queue the destroy — the server will fire
+            // BlockEntityDestroyedEvent with `last_state` once it
+            // processes the response, and the handler below picks up
+            // the drops.
+            ctx.world_ctx().destroy_block_entity(
+                event.position.x,
+                event.position.y,
+                event.position.z,
+            );
 
-            // Drop contents
-            if let Some(be) =
-                world.get_block_entity(event.position.x, event.position.y, event.position.z)
-            {
-                match &*be {
-                    BlockEntity::Chest { slots } => {
-                        for slot in slots.iter() {
-                            if let Some(item_id) = slot.item_id {
-                                ctx.entities().spawn_dropped_item(
-                                    event.position.x,
-                                    event.position.y,
-                                    event.position.z,
-                                    item_id,
-                                    slot.item_count,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Remove block entity
-            world.remove_block_entity(event.position.x, event.position.y, event.position.z);
-
-            // Revert double chest partner to single
+            // Revert double-chest partner to single
             if block::chest_type(state) != 0 {
+                let world = ctx.world_ctx().world();
                 let facing = block::chest_facing(state);
                 let offsets = block::chest_adjacent_offsets(facing);
                 for &(dx, dz) in &offsets {
@@ -160,6 +190,87 @@ impl Plugin for ContainerPlugin {
                         );
                         break;
                     }
+                }
+            }
+        });
+
+        // Chest lid open animation when a player opens a chest.
+        registrar.on::<ContainerOpenedEvent>(Stage::Post, 0, |event, ctx| {
+            let position = match event.backing {
+                ContainerBacking::Block { position } => position,
+                ContainerBacking::Virtual => return,
+            };
+            let world = ctx.world_ctx().world();
+            if !block::is_chest(world.get_block(position.x, position.y, position.z)) {
+                return;
+            }
+
+            let action_param = event.viewer_count.min(u32::from(u8::MAX)) as u8;
+            for (px, py, pz) in chest_parts(world, position.x, position.y, position.z) {
+                ctx.entities().broadcast_block_action(
+                    px,
+                    py,
+                    pz,
+                    1, // chest "viewer count" action
+                    action_param,
+                    CHEST_BLOCK_ID,
+                );
+            }
+        });
+
+        // Chest lid close animation — `viewer_count` already excludes the
+        // closing player, so it's the *remaining* viewer count (0 closes
+        // the lid completely).
+        registrar.on::<ContainerClosedEvent>(Stage::Post, 0, |event, ctx| {
+            let position = match event.backing {
+                ContainerBacking::Block { position } => position,
+                ContainerBacking::Virtual => return,
+            };
+            let world = ctx.world_ctx().world();
+            if !block::is_chest(world.get_block(position.x, position.y, position.z)) {
+                return;
+            }
+
+            let action_param = event.viewer_count.min(u32::from(u8::MAX)) as u8;
+            for (px, py, pz) in chest_parts(world, position.x, position.y, position.z) {
+                ctx.entities()
+                    .broadcast_block_action(px, py, pz, 1, action_param, CHEST_BLOCK_ID);
+            }
+        });
+
+        // Sync slot changes to other viewers of the same block-backed
+        // container so two players staring at the same chest see the
+        // same contents.
+        registrar.on::<ContainerSlotChangedEvent>(Stage::Post, 0, |event, ctx| {
+            let position = match event.backing {
+                ContainerBacking::Block { position } => position,
+                ContainerBacking::Virtual => return,
+            };
+            ctx.containers().notify_viewers(
+                position.x,
+                position.y,
+                position.z,
+                event.slot_index,
+                event.new.clone(),
+            );
+        });
+
+        // Drop chest contents as item entities when the block entity
+        // is destroyed (e.g. by the BlockBrokenEvent handler above).
+        registrar.on::<BlockEntityDestroyedEvent>(Stage::Post, 0, |event, ctx| {
+            if event.kind != BlockEntityKind::Chest {
+                return;
+            }
+            let BlockEntity::Chest { slots } = &event.last_state;
+            for slot in slots.iter() {
+                if let Some(item_id) = slot.item_id {
+                    ctx.entities().spawn_dropped_item(
+                        event.position.x,
+                        event.position.y,
+                        event.position.z,
+                        item_id,
+                        slot.item_count,
+                    );
                 }
             }
         });
@@ -208,28 +319,65 @@ mod tests {
     }
 
     #[test]
-    fn chest_break_removes_block_entity() {
+    fn block_entity_destroyed_drops_chest_contents() {
         let mut harness = PluginTestHarness::new();
-        harness.register(basalt_plugin_block::BlockPlugin);
         harness.register(ContainerPlugin);
 
-        // Place a chest block entity manually
-        harness.world().set_block(5, 64, 3, block::CHEST);
-        harness
-            .world()
-            .set_block_entity(5, 64, 3, BlockEntity::empty_chest());
+        let mut chest = BlockEntity::empty_chest();
+        let BlockEntity::Chest { slots } = &mut chest;
+        slots[0] = basalt_api::types::Slot::new(1, 5);
+        slots[1] = basalt_api::types::Slot::new(2, 3);
 
-        let mut event = BlockBrokenEvent {
+        let mut event = BlockEntityDestroyedEvent {
             position: BlockPosition { x: 5, y: 64, z: 3 },
-            block_state: block::CHEST,
-            sequence: 1,
-            cancelled: false,
+            kind: BlockEntityKind::Chest,
+            last_state: chest,
         };
 
-        harness.dispatch(&mut event);
+        let result = harness.dispatch(&mut event);
+        assert!(result.has_spawn_dropped_item(1, 5));
+        assert!(result.has_spawn_dropped_item(2, 3));
+    }
+
+    #[test]
+    fn slot_changed_on_block_backed_notifies_viewers() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(ContainerPlugin);
+
+        let mut event = ContainerSlotChangedEvent {
+            window_id: 1,
+            backing: ContainerBacking::Block {
+                position: BlockPosition { x: 5, y: 64, z: 3 },
+            },
+            slot_index: 4,
+            old: basalt_api::types::Slot::empty(),
+            new: basalt_api::types::Slot::new(1, 1),
+        };
+
+        let result = harness.dispatch(&mut event);
         assert!(
-            harness.world().get_block_entity(5, 64, 3).is_none(),
-            "block entity should be removed"
+            result.has_notify_viewers(),
+            "block-backed slot change must notify viewers"
+        );
+    }
+
+    #[test]
+    fn slot_changed_on_virtual_does_not_notify() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(ContainerPlugin);
+
+        let mut event = ContainerSlotChangedEvent {
+            window_id: 1,
+            backing: ContainerBacking::Virtual,
+            slot_index: 4,
+            old: basalt_api::types::Slot::empty(),
+            new: basalt_api::types::Slot::new(1, 1),
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(
+            !result.has_notify_viewers(),
+            "virtual slot change must not notify viewers"
         );
     }
 }

--- a/plugins/recipe/src/lib.rs
+++ b/plugins/recipe/src/lib.rs
@@ -155,4 +155,75 @@ mod tests {
             "stone interact should produce no responses"
         );
     }
+
+    fn populated_grid() -> [basalt_api::types::Slot; 9] {
+        let mut slots: [basalt_api::types::Slot; 9] =
+            std::array::from_fn(|_| basalt_api::types::Slot::empty());
+        slots[0] = basalt_api::types::Slot::new(43, 1);
+        slots[2] = basalt_api::types::Slot::new(280, 4);
+        slots
+    }
+
+    #[test]
+    fn crafting_close_drops_grid_items() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(RecipePlugin);
+
+        let mut event = ContainerClosedEvent {
+            window_id: 1,
+            inventory_type: InventoryType::Crafting,
+            backing: ContainerBacking::Block {
+                position: BlockPosition { x: 5, y: 64, z: 3 },
+            },
+            reason: CloseReason::Manual,
+            viewer_count: 0,
+            crafting_grid_state: Some(populated_grid()),
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(result.has_spawn_dropped_item(43, 1));
+        assert!(result.has_spawn_dropped_item(280, 4));
+    }
+
+    #[test]
+    fn crafting_close_with_no_snapshot_drops_nothing() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(RecipePlugin);
+
+        let mut event = ContainerClosedEvent {
+            window_id: 1,
+            inventory_type: InventoryType::Crafting,
+            backing: ContainerBacking::Block {
+                position: BlockPosition { x: 5, y: 64, z: 3 },
+            },
+            reason: CloseReason::Manual,
+            viewer_count: 0,
+            crafting_grid_state: None,
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(!result.has_any_spawn_dropped_item());
+    }
+
+    #[test]
+    fn non_crafting_close_drops_nothing_even_with_snapshot() {
+        let mut harness = PluginTestHarness::new();
+        harness.register(RecipePlugin);
+
+        // Snapshot is populated but the inventory type is a chest —
+        // the plugin must ignore it.
+        let mut event = ContainerClosedEvent {
+            window_id: 1,
+            inventory_type: InventoryType::Generic9x3,
+            backing: ContainerBacking::Block {
+                position: BlockPosition { x: 5, y: 64, z: 3 },
+            },
+            reason: CloseReason::Manual,
+            viewer_count: 0,
+            crafting_grid_state: Some(populated_grid()),
+        };
+
+        let result = harness.dispatch(&mut event);
+        assert!(!result.has_any_spawn_dropped_item());
+    }
 }

--- a/plugins/recipe/src/lib.rs
+++ b/plugins/recipe/src/lib.rs
@@ -1,22 +1,22 @@
 //! Recipe plugin — crafting table interaction and recipe event handling.
 //!
 //! Opens the 3x3 crafting table window on right-click via
-//! [`PlayerInteractEvent`]. Future extensions may add recipe validation,
-//! custom recipe registration, or crafting permissions.
+//! [`PlayerInteractEvent`] and drops crafting-grid contents at the
+//! player's feet when the window closes (covers manual close, ESC,
+//! and disconnect). Recipe matching itself runs through the
+//! `CraftingRecipeMatchedEvent` pipeline.
 
 use basalt_api::prelude::*;
 use basalt_api::world::block;
 
-/// Handles crafting table interaction and recipe-related events.
+/// Handles crafting table interaction and crafting-window cleanup.
 ///
-/// Currently registers a single handler:
+/// Handlers:
 /// - [`PlayerInteractEvent`] (Process, priority 0): opens the crafting
-///   table window when the player right-clicks a crafting table block,
-///   and cancels the event to prevent block placement.
-///
-/// Recipe matching itself is performed by the game loop after it
-/// dispatches [`CraftingGridChangedEvent`], using the shared
-/// [`RecipeRegistry`](basalt_api::recipes::RecipeRegistry).
+///   table window on right-click and cancels the event.
+/// - [`ContainerClosedEvent`] (Post, priority 0): drops every
+///   non-empty crafting grid slot as an item entity at the player's
+///   position when a crafting table window closes.
 pub struct RecipePlugin;
 
 impl Plugin for RecipePlugin {
@@ -39,6 +39,34 @@ impl Plugin for RecipePlugin {
                     event.position.z,
                 );
                 event.cancel();
+            }
+        });
+
+        // Drop crafting grid contents at the player's position when a
+        // crafting table window closes. The server has already
+        // captured `event.crafting_grid_state` and reset the grid to
+        // 2x2; this handler just spawns the item entities.
+        registrar.on::<ContainerClosedEvent>(Stage::Post, 0, |event, ctx| {
+            if event.inventory_type != InventoryType::Crafting {
+                return;
+            }
+            let Some(slots) = &event.crafting_grid_state else {
+                return;
+            };
+            let (px, py, pz) = ctx.player().position();
+            let drop_x = px as i32;
+            let drop_y = py as i32 + 1;
+            let drop_z = pz as i32;
+            for slot in slots.iter() {
+                if let Some(item_id) = slot.item_id {
+                    ctx.entities().spawn_dropped_item(
+                        drop_x,
+                        drop_y,
+                        drop_z,
+                        item_id,
+                        slot.item_count,
+                    );
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary

- Moves the inline chest-lid open/close animation, viewer slot sync, chest item drops, and crafting-table close cleanup out of the game-loop and into `ContainerPlugin` and `RecipePlugin` so they can be disabled per-plugin and external plugins can layer their own logic on the same events
- Adds three context APIs (`broadcast_block_action`, `notify_viewers`, `destroy_block_entity`) and three matching `Response` variants so plugins can drive these behaviours without ECS access
- Extends `ContainerOpenedEvent` / `ContainerClosedEvent` with a `viewer_count` field and adds an optional `crafting_grid_state` snapshot to `ContainerClosedEvent`
- Splits `ContainerPlugin::BlockBrokenEvent` so chest item drops now run through `BlockEntityDestroyedEvent` (proper destroy → drop chain through the event pipeline)
- Adds `position` to `PlayerInfo` / `PlayerContext` so plugins can drop items at the player's feet
- Closes #160 and #161

## Architecture

```
+------------------------+      +-----------------------------+
| BlockBrokenEvent       |      | ContainerOpenedEvent        |
| (Post, prio -1)        |      | ContainerClosedEvent        |
|                        |      | ContainerSlotChangedEvent   |
|  ContainerPlugin       |      |                             |
|  - destroy_block_entity|      |  ContainerPlugin            |
|  - revert partner      |      |  - broadcast_block_action   |
+-----------+------------+      |  - notify_viewers           |
            |                   +--------------+--------------+
            v                                  |
  Response::DestroyBlockEntity                 |
            |                                  |
            v                                  |
  GameLoop::destroy_block_entity               |
  fires BlockEntityDestroyedEvent              |
            |                                  |
            v                                  |
  ContainerPlugin (Post)                       |
  spawn_dropped_item per slot                  |
                                               |
+----------------------------------+           |
| ContainerClosedEvent             |<----------+
| (Crafting type)                  |
|                                  |
|  RecipePlugin                    |
|  - read crafting_grid_state      |
|  - spawn_dropped_item at player  |
+----------------------------------+
```

## Plugin use cases unlocked

- **Disable chest lid animation** for a hardened/admin server: disable `ContainerPlugin` entirely
- **Custom drop policy** for protected regions: register a higher-priority `BlockEntityDestroyedEvent` handler that diverts drops elsewhere (vault, void, etc.)
- **Item-keep on close**: cancel a `ContainerClosedEvent` Post handler — wait, Post isn't cancellable. Instead, add a Validate handler on a future `CraftingPreCloseEvent`. For now the migration keeps the existing behaviour
- **Co-viewer overlays**: register a `ContainerSlotChangedEvent` Post handler at higher priority to mutate what other viewers see (admin spectator mode, ghost items, etc.)

## Migration notes

- The legacy `notify_container_viewers` server helper is kept as an internal utility called by both the bulk `sync_container_to_client` path and the new `Response::NotifyContainerViewers` resolver
- The crafting grid 2x2 reset stays in the server (server-internal state) — only the drops move to the plugin
- `ContainerOpenedEvent.viewer_count` includes the just-opened viewer; `ContainerClosedEvent.viewer_count` already excludes the closing player so the Post handler can pass it directly to `BlockAction.action_param` (0 = closed lid)
- `crafting_grid_state` is populated only for `InventoryType::Crafting` (3x3 crafting table); the 2x2 inventory grid is never reset on close
- `PlayerInfo.position` is captured at context-construction time via `make_context`; it's stale by the next tick — plugins that need fresh state should rely on event payloads, not `ctx.player().position()`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --lib --bins --tests --examples --all-features -- -D warnings`
- [x] `cargo test --all-features` — 1000 passed, 0 failed
- [x] `cargo llvm-cov --all-features --fail-under-lines 90 --ignore-filename-regex "(examples|packets/|xtask/src/recipes\.rs|basalt-recipes/src/generated\.rs)"` — 91.29% line coverage
- [x] 13 new plugin-level unit tests (5 ContainerPlugin, 4 RecipePlugin, 4 already covered)
- [ ] Manual in-game smoke: open/close a single chest, open/close a double chest with another player viewing, break a chest with items, place items in crafting table then ESC, place items in crafting table then disconnect

