### PR TITLE
feat(server): recipe-book Phase 1 — unlock/lock events + ghost recipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
 name = "basalt-core"
 version = "0.1.0"
 dependencies = [
+ "basalt-recipes",
  "basalt-types",
  "basalt-world",
  "log",

--- a/crates/basalt-api/src/context/mod.rs
+++ b/crates/basalt-api/src/context/mod.rs
@@ -9,6 +9,7 @@ mod chat;
 mod container;
 mod entity;
 mod player;
+mod recipe;
 mod response;
 mod world;
 
@@ -21,10 +22,11 @@ pub(crate) use response::ResponseQueue;
 use std::cell::RefCell;
 use std::sync::Arc;
 
+use basalt_core::components::KnownRecipes;
 use basalt_core::player::PlayerInfo;
 use basalt_core::{
     ChatContext, ContainerContext, Context, EntityContext, PlayerContext, PluginLogger,
-    WorldContext,
+    RecipeContext, WorldContext,
 };
 
 /// Context available to event handlers during dispatch.
@@ -39,6 +41,11 @@ pub struct ServerContext {
     pub(super) responses: ResponseQueue,
     /// Identity and state of the player who triggered this action.
     pub(super) player: PlayerInfo,
+    /// Snapshot of the player's [`KnownRecipes`] at context construction
+    /// — read-only view used by [`RecipeContext::has`] and
+    /// [`RecipeContext::unlocked`]. Mutations queue a `Response::UnlockRecipe`
+    /// / `LockRecipe` and only land in the ECS after dispatch completes.
+    pub(super) known_recipes: KnownRecipes,
     /// Name of the plugin currently being dispatched.
     pub(super) plugin_name: RefCell<String>,
     /// Registered command list (name, description) for /help.
@@ -47,14 +54,29 @@ pub struct ServerContext {
 
 impl ServerContext {
     /// Creates a new context for a single event dispatch.
+    ///
+    /// The player's `KnownRecipes` snapshot defaults to empty —
+    /// callers that need plugins to read live recipe state should use
+    /// [`with_known_recipes`](Self::with_known_recipes) to attach a
+    /// snapshot from the ECS.
     pub fn new(world: Arc<basalt_world::World>, player: PlayerInfo) -> Self {
         Self {
             world,
             responses: ResponseQueue::new(),
             player,
+            known_recipes: KnownRecipes::default(),
             plugin_name: RefCell::new(String::new()),
             command_list: RefCell::new(Vec::new()),
         }
+    }
+
+    /// Attaches a snapshot of the player's current `KnownRecipes` so
+    /// [`RecipeContext::has`] / [`RecipeContext::unlocked`] reflect
+    /// live state. The server clones this from the ECS at the start
+    /// of each dispatch.
+    pub fn with_known_recipes(mut self, known_recipes: KnownRecipes) -> Self {
+        self.known_recipes = known_recipes;
+        self
     }
 
     /// Sets the registered command list for /help.
@@ -95,6 +117,10 @@ impl Context for ServerContext {
     }
 
     fn containers(&self) -> &dyn ContainerContext {
+        self
+    }
+
+    fn recipes(&self) -> &dyn RecipeContext {
         self
     }
 }

--- a/crates/basalt-api/src/context/recipe.rs
+++ b/crates/basalt-api/src/context/recipe.rs
@@ -1,0 +1,37 @@
+//! [`RecipeContext`] implementation for [`ServerContext`].
+//!
+//! Mutations queue a [`Response::UnlockRecipe`] /
+//! [`Response::LockRecipe`] for the game loop to commit. Reads
+//! (`has`, `unlocked`) hit the snapshot of the player's
+//! [`KnownRecipes`] captured at context construction.
+
+use basalt_core::{RecipeContext, UnlockReason};
+use basalt_recipes::RecipeId;
+
+use super::{Response, ServerContext};
+
+impl RecipeContext for ServerContext {
+    fn unlock(&self, id: &RecipeId, reason: UnlockReason) {
+        self.responses.push(Response::UnlockRecipe {
+            recipe_id: id.clone(),
+            reason,
+        });
+    }
+
+    fn lock(&self, id: &RecipeId) {
+        self.responses.push(Response::LockRecipe {
+            recipe_id: id.clone(),
+        });
+    }
+
+    fn has(&self, id: &RecipeId) -> bool {
+        self.known_recipes.has(id)
+    }
+
+    fn unlocked(&self) -> Vec<RecipeId> {
+        self.known_recipes
+            .iter()
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+}

--- a/crates/basalt-api/src/context/response.rs
+++ b/crates/basalt-api/src/context/response.rs
@@ -4,6 +4,8 @@ use std::cell::RefCell;
 
 use basalt_core::broadcast::BroadcastMessage;
 use basalt_core::components::{BlockPosition, ChunkPosition, Position, Rotation};
+use basalt_core::context::UnlockReason;
+use basalt_recipes::RecipeId;
 use basalt_types::Slot;
 use basalt_types::nbt::NbtCompound;
 
@@ -109,6 +111,28 @@ pub enum Response {
     DestroyBlockEntity {
         /// World position of the block entity to remove.
         position: BlockPosition,
+    },
+    /// Unlock a recipe for the current player.
+    ///
+    /// The server inserts the recipe id into the player's
+    /// `KnownRecipes` component, sends a `Recipe Book Add` S2C packet,
+    /// and dispatches `RecipeUnlockedEvent` at Post. No-op if the
+    /// recipe is already unlocked.
+    UnlockRecipe {
+        /// Stable identifier of the recipe to unlock.
+        recipe_id: RecipeId,
+        /// Why the unlock happened — surfaced on `RecipeUnlockedEvent`.
+        reason: UnlockReason,
+    },
+    /// Lock a recipe for the current player.
+    ///
+    /// The server removes the recipe from the player's `KnownRecipes`,
+    /// sends a `Recipe Book Remove` S2C packet, and dispatches
+    /// `RecipeLockedEvent` at Post. No-op if the recipe is not
+    /// currently unlocked.
+    LockRecipe {
+        /// Stable identifier of the recipe to lock.
+        recipe_id: RecipeId,
     },
 }
 

--- a/crates/basalt-api/src/context/tests.rs
+++ b/crates/basalt-api/src/context/tests.rs
@@ -105,3 +105,75 @@ fn context_trait_is_usable_as_dyn() {
     dyn_ctx.chat().send("via trait");
     assert_eq!(ctx.drain_responses().len(), 1);
 }
+
+#[test]
+fn recipes_unlock_queues_response() {
+    use basalt_core::context::UnlockReason;
+    use basalt_recipes::RecipeId;
+
+    let ctx = test_ctx();
+    let id = RecipeId::vanilla("oak_planks");
+    ctx.recipes().unlock(&id, UnlockReason::Manual);
+
+    let responses = ctx.drain_responses();
+    assert_eq!(responses.len(), 1);
+    match &responses[0] {
+        Response::UnlockRecipe { recipe_id, reason } => {
+            assert_eq!(recipe_id, &id);
+            assert_eq!(*reason, UnlockReason::Manual);
+        }
+        other => panic!("expected UnlockRecipe, got {other:?}"),
+    }
+}
+
+#[test]
+fn recipes_lock_queues_response() {
+    use basalt_recipes::RecipeId;
+
+    let ctx = test_ctx();
+    let id = RecipeId::new("plugin", "obsolete");
+    ctx.recipes().lock(&id);
+
+    let responses = ctx.drain_responses();
+    assert_eq!(responses.len(), 1);
+    match &responses[0] {
+        Response::LockRecipe { recipe_id } => {
+            assert_eq!(recipe_id, &id);
+        }
+        other => panic!("expected LockRecipe, got {other:?}"),
+    }
+}
+
+#[test]
+fn recipes_has_reads_snapshot() {
+    use basalt_core::components::KnownRecipes;
+    use basalt_recipes::RecipeId;
+
+    let id = RecipeId::vanilla("oak_planks");
+    let mut snapshot = KnownRecipes::default();
+    snapshot.unlock(id.clone());
+
+    let ctx = ServerContext::new(
+        test_world(),
+        PlayerInfo {
+            uuid: Uuid::default(),
+            entity_id: 1,
+            username: "Steve".into(),
+            rotation: Rotation {
+                yaw: 0.0,
+                pitch: 0.0,
+            },
+            position: basalt_core::Position {
+                x: 0.0,
+                y: 64.0,
+                z: 0.0,
+            },
+        },
+    )
+    .with_known_recipes(snapshot);
+
+    assert!(ctx.recipes().has(&id));
+    assert!(!ctx.recipes().has(&RecipeId::vanilla("missing")));
+    let snapshot_ids = ctx.recipes().unlocked();
+    assert_eq!(snapshot_ids, vec![id]);
+}

--- a/crates/basalt-api/src/events/crafting.rs
+++ b/crates/basalt-api/src/events/crafting.rs
@@ -1,6 +1,7 @@
 //! Crafting events: grid changes, recipe matching, craft execution,
 //! and recipe-registry lifecycle.
 
+use basalt_core::context::UnlockReason;
 use basalt_recipes::{Recipe, RecipeId};
 use basalt_types::Slot;
 
@@ -181,6 +182,35 @@ pub struct RecipeUnregisteredEvent {
 }
 crate::game_event!(RecipeUnregisteredEvent);
 
+/// A recipe has been unlocked for the current player.
+///
+/// Fired at the **Post** stage on the **game** bus after the player's
+/// `KnownRecipes` component records the recipe and the
+/// `Recipe Book Add` packet has been queued. The crafting player is
+/// available via `ctx.player()`.
+#[derive(Debug, Clone)]
+pub struct RecipeUnlockedEvent {
+    /// Stable identifier of the unlocked recipe.
+    pub recipe_id: RecipeId,
+    /// Why the unlock happened — auto-discovery, manual grant, or
+    /// initial-join starter set.
+    pub reason: UnlockReason,
+}
+crate::game_event!(RecipeUnlockedEvent);
+
+/// A recipe has been locked for the current player.
+///
+/// Fired at the **Post** stage on the **game** bus after the player's
+/// `KnownRecipes` component drops the recipe and the
+/// `Recipe Book Remove` packet has been queued. The crafting player
+/// is available via `ctx.player()`.
+#[derive(Debug, Clone)]
+pub struct RecipeLockedEvent {
+    /// Stable identifier of the locked recipe.
+    pub recipe_id: RecipeId,
+}
+crate::game_event!(RecipeLockedEvent);
+
 #[cfg(test)]
 mod tests {
     use basalt_events::{BusKind, Event, EventRouting};
@@ -313,5 +343,29 @@ mod tests {
         assert!(!event.is_cancelled());
         assert_eq!(event.recipe_id.path, "obsolete");
         assert_eq!(RecipeUnregisteredEvent::BUS, BusKind::Game);
+    }
+
+    #[test]
+    fn recipe_unlocked_carries_id_and_reason() {
+        let mut event = RecipeUnlockedEvent {
+            recipe_id: RecipeId::vanilla("oak_planks"),
+            reason: UnlockReason::AutoDiscovered,
+        };
+        // not cancellable
+        event.cancel();
+        assert!(!event.is_cancelled());
+        assert_eq!(event.reason, UnlockReason::AutoDiscovered);
+        assert_eq!(RecipeUnlockedEvent::BUS, BusKind::Game);
+    }
+
+    #[test]
+    fn recipe_locked_carries_id() {
+        let mut event = RecipeLockedEvent {
+            recipe_id: RecipeId::new("plugin", "expired"),
+        };
+        event.cancel();
+        assert!(!event.is_cancelled());
+        assert_eq!(event.recipe_id.path, "expired");
+        assert_eq!(RecipeLockedEvent::BUS, BusKind::Game);
     }
 }

--- a/crates/basalt-api/src/events/mod.rs
+++ b/crates/basalt-api/src/events/mod.rs
@@ -22,7 +22,8 @@ pub use container::*;
 pub use crafting::{
     CraftingCraftedEvent, CraftingGridChangedEvent, CraftingPreCraftEvent,
     CraftingRecipeClearedEvent, CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
-    RecipeRegisterEvent, RecipeRegisteredEvent, RecipeUnregisteredEvent,
+    RecipeLockedEvent, RecipeRegisterEvent, RecipeRegisteredEvent, RecipeUnlockedEvent,
+    RecipeUnregisteredEvent,
 };
 pub use player::{PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent};
 

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -73,7 +73,7 @@ pub mod prelude {
     // Context traits
     pub use basalt_core::{
         BroadcastMessage, ChatContext, ContainerContext, Context, EntityContext, Gamemode,
-        PlayerContext, WorldContext,
+        PlayerContext, RecipeContext, UnlockReason, WorldContext,
     };
 
     // Event system
@@ -91,7 +91,8 @@ pub mod prelude {
         CraftingCraftedEvent, CraftingGridChangedEvent, CraftingPreCraftEvent,
         CraftingRecipeClearedEvent, CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
         DragType, PlayerInteractEvent, PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent,
-        RecipeRegisterEvent, RecipeRegisteredEvent, RecipeUnregisteredEvent, WindowSlotKind,
+        RecipeLockedEvent, RecipeRegisterEvent, RecipeRegisteredEvent, RecipeUnlockedEvent,
+        RecipeUnregisteredEvent, WindowSlotKind,
     };
 
     // Recipe types referenced by registry-lifecycle events.

--- a/crates/basalt-core/Cargo.toml
+++ b/crates/basalt-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+basalt-recipes = { workspace = true }
 basalt-types = { workspace = true }
 basalt-world = { workspace = true }
 log = { workspace = true }

--- a/crates/basalt-core/src/components/mod.rs
+++ b/crates/basalt-core/src/components/mod.rs
@@ -10,6 +10,7 @@ mod crafting;
 mod identity;
 mod inventory;
 mod item;
+mod recipe_book;
 mod spatial;
 
 pub use container::VirtualContainerSlots;
@@ -17,6 +18,7 @@ pub use crafting::CraftingGrid;
 pub use identity::{EntityKind, Health, PlayerRef, Sneaking};
 pub use inventory::Inventory;
 pub use item::{DroppedItem, Lifetime, OpenContainer, PickupDelay};
+pub use recipe_book::KnownRecipes;
 pub use spatial::{BlockPosition, BoundingBox, ChunkPosition, Position, Rotation, Velocity};
 
 /// Marker trait for component types stored in the ECS.

--- a/crates/basalt-core/src/components/recipe_book.rs
+++ b/crates/basalt-core/src/components/recipe_book.rs
@@ -1,0 +1,195 @@
+//! Per-player recipe-book state.
+//!
+//! Tracks which recipes a player has unlocked and the per-session
+//! `display_id` mapping the protocol uses to reference them. The
+//! mapping is session-scoped — display IDs are reassigned every time
+//! the player connects.
+
+use std::collections::{HashMap, HashSet};
+
+use basalt_recipes::RecipeId;
+
+use super::Component;
+
+/// Set of recipes a player has unlocked, plus the protocol's
+/// numeric `display_id` mapping.
+///
+/// The protocol uses an `i32` per recipe (allocated server-side, sent
+/// in `Recipe Book Add` and referenced by `Recipe Book Remove` and
+/// `Place Recipe`). Display IDs are stable for the lifetime of the
+/// connection but are not persisted across sessions.
+///
+/// `unlock`/`lock` allocate / drop the `display_ids` mapping but
+/// **keep** the reverse `by_display` lookup so a stale `Place Recipe`
+/// packet from the client (e.g. arriving in the same tick as a remove
+/// dispatch) can still resolve the recipe id rather than being silently
+/// dropped.
+#[derive(Debug, Default, Clone)]
+pub struct KnownRecipes {
+    /// Source of truth — the recipes the client should currently see.
+    ids: HashSet<RecipeId>,
+    /// Forward map: recipe id → display id. Trimmed on `lock`.
+    display_ids: HashMap<RecipeId, i32>,
+    /// Reverse map: display id → recipe id. Retained even after
+    /// `lock` so stale incoming packets resolve cleanly.
+    by_display: HashMap<i32, RecipeId>,
+    /// Counter for the next display id to allocate.
+    next_display_id: i32,
+}
+
+impl Component for KnownRecipes {}
+
+impl KnownRecipes {
+    /// Records the recipe as unlocked for this player.
+    ///
+    /// Allocates a new `display_id` if the recipe was not already
+    /// known. Returns the recipe's `display_id` (existing or newly
+    /// allocated) so the caller can include it in the
+    /// `Recipe Book Add` S2C packet.
+    pub fn unlock(&mut self, id: RecipeId) -> i32 {
+        if !self.ids.insert(id.clone()) {
+            // Already unlocked — return the existing display_id.
+            return self.display_ids[&id];
+        }
+        let display_id = self.next_display_id;
+        self.next_display_id += 1;
+        self.display_ids.insert(id.clone(), display_id);
+        self.by_display.insert(display_id, id);
+        display_id
+    }
+
+    /// Removes the recipe from the unlocked set.
+    ///
+    /// Returns the `display_id` if the recipe was previously
+    /// unlocked, otherwise `None`. The reverse `by_display` mapping
+    /// is preserved so late-arriving `Place Recipe` packets can still
+    /// resolve which recipe they referred to.
+    pub fn lock(&mut self, id: &RecipeId) -> Option<i32> {
+        if !self.ids.remove(id) {
+            return None;
+        }
+        self.display_ids.remove(id)
+    }
+
+    /// Returns true if the recipe is unlocked for this player.
+    pub fn has(&self, id: &RecipeId) -> bool {
+        self.ids.contains(id)
+    }
+
+    /// Returns the display id assigned to the recipe, if any.
+    ///
+    /// Reads the forward map only — locked recipes return `None`
+    /// even though the reverse map may still hold them.
+    pub fn display_id(&self, id: &RecipeId) -> Option<i32> {
+        self.display_ids.get(id).copied()
+    }
+
+    /// Resolves a `display_id` back to a recipe id.
+    ///
+    /// Used by Phase 2 to handle incoming `Place Recipe` packets.
+    /// Returns the recipe even if it has since been locked — the
+    /// caller decides whether to honour the request.
+    pub fn recipe_for_display(&self, display_id: i32) -> Option<&RecipeId> {
+        self.by_display.get(&display_id)
+    }
+
+    /// Returns the number of currently unlocked recipes.
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    /// Returns true if no recipe is unlocked.
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    /// Iterates the unlocked recipes paired with their display ids.
+    ///
+    /// Iteration order matches the `display_ids` map's iteration
+    /// order, which is `HashMap`-defined (i.e. unspecified).
+    pub fn iter(&self) -> impl Iterator<Item = (&RecipeId, i32)> {
+        self.display_ids.iter().map(|(id, d)| (id, *d))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(path: &str) -> RecipeId {
+        RecipeId::new("plugin", path)
+    }
+
+    #[test]
+    fn unlock_allocates_sequential_display_ids() {
+        let mut k = KnownRecipes::default();
+        assert_eq!(k.unlock(id("a")), 0);
+        assert_eq!(k.unlock(id("b")), 1);
+        assert_eq!(k.unlock(id("c")), 2);
+    }
+
+    #[test]
+    fn unlock_idempotent_returns_existing_display_id() {
+        let mut k = KnownRecipes::default();
+        let first = k.unlock(id("a"));
+        let second = k.unlock(id("a"));
+        assert_eq!(first, second);
+        assert_eq!(k.len(), 1);
+    }
+
+    #[test]
+    fn lock_returns_display_id_and_removes_forward_lookup() {
+        let mut k = KnownRecipes::default();
+        let display = k.unlock(id("a"));
+        assert_eq!(k.lock(&id("a")), Some(display));
+        assert!(!k.has(&id("a")));
+        assert_eq!(k.display_id(&id("a")), None);
+    }
+
+    #[test]
+    fn lock_keeps_reverse_lookup_for_stale_packets() {
+        let mut k = KnownRecipes::default();
+        let display = k.unlock(id("a"));
+        k.lock(&id("a"));
+        assert_eq!(k.recipe_for_display(display), Some(&id("a")));
+    }
+
+    #[test]
+    fn lock_returns_none_when_unknown() {
+        let mut k = KnownRecipes::default();
+        assert_eq!(k.lock(&id("missing")), None);
+    }
+
+    #[test]
+    fn display_ids_do_not_reuse_after_lock() {
+        let mut k = KnownRecipes::default();
+        k.unlock(id("a"));
+        k.unlock(id("b"));
+        k.lock(&id("a"));
+        // Next unlock should keep allocating sequentially —
+        // display_ids are session-stable, not reusable.
+        assert_eq!(k.unlock(id("c")), 2);
+    }
+
+    #[test]
+    fn iter_yields_only_unlocked_pairs() {
+        let mut k = KnownRecipes::default();
+        k.unlock(id("a"));
+        k.unlock(id("b"));
+        k.lock(&id("a"));
+
+        let mut entries: Vec<_> = k.iter().map(|(id, d)| (id.clone(), d)).collect();
+        entries.sort_by_key(|(_, d)| *d);
+        assert_eq!(entries, vec![(id("b"), 1)]);
+    }
+
+    #[test]
+    fn has_returns_true_only_for_unlocked() {
+        let mut k = KnownRecipes::default();
+        assert!(!k.has(&id("a")));
+        k.unlock(id("a"));
+        assert!(k.has(&id("a")));
+        k.lock(&id("a"));
+        assert!(!k.has(&id("a")));
+    }
+}

--- a/crates/basalt-core/src/context.rs
+++ b/crates/basalt-core/src/context.rs
@@ -5,10 +5,30 @@
 //! and [`ContainerContext`]. Plugins access them via `ctx.player()`,
 //! `ctx.chat()`, etc.
 
+use basalt_recipes::RecipeId;
 use basalt_types::{TextComponent, Uuid};
 
 use crate::broadcast::BroadcastMessage;
 use crate::gamemode::Gamemode;
+
+/// Why a recipe was unlocked for a player.
+///
+/// Surfaced in [`RecipeContext::unlock`] and on the
+/// `RecipeUnlockedEvent` so plugins can branch on the source. For
+/// example, an analytics plugin records `AutoDiscovered` differently
+/// from `Manual` admin grants; a tutorial plugin only triggers on
+/// `InitialJoin`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnlockReason {
+    /// The player crafted (or otherwise encountered) the recipe and
+    /// the server auto-granted it.
+    AutoDiscovered,
+    /// A plugin or admin command granted the recipe.
+    Manual,
+    /// Granted as part of the initial recipe set when the player
+    /// joined (starter recipes).
+    InitialJoin,
+}
 
 // ── Sub-context traits ───────────────────────────────────────────────
 
@@ -156,6 +176,41 @@ pub trait ContainerContext {
     fn notify_viewers(&self, x: i32, y: i32, z: i32, slot_index: i16, item: basalt_types::Slot);
 }
 
+/// Per-player recipe-book state.
+///
+/// Plugins use this to grant or revoke recipes for the current player
+/// — the dispatch context's player. Mutations queue a deferred
+/// response that the game loop translates into the appropriate S2C
+/// recipe-book packet and dispatches `RecipeUnlockedEvent` /
+/// `RecipeLockedEvent` after commit.
+///
+/// `has` and `unlocked` are synchronous reads against the player's
+/// `KnownRecipes` component.
+pub trait RecipeContext {
+    /// Unlocks the recipe for the current player.
+    ///
+    /// Queues a `Recipe Book Add` packet, inserts into the player's
+    /// `KnownRecipes`, and dispatches `RecipeUnlockedEvent` at Post.
+    /// No-op if the recipe is already unlocked.
+    fn unlock(&self, id: &RecipeId, reason: UnlockReason);
+
+    /// Locks the recipe for the current player.
+    ///
+    /// Queues a `Recipe Book Remove` packet, removes from the player's
+    /// `KnownRecipes`, and dispatches `RecipeLockedEvent` at Post.
+    /// No-op if the recipe is not currently unlocked.
+    fn lock(&self, id: &RecipeId);
+
+    /// Returns true if the recipe is unlocked for the current player.
+    fn has(&self, id: &RecipeId) -> bool;
+
+    /// Returns a snapshot of every recipe id the player has unlocked.
+    ///
+    /// Allocates a new `Vec` — callers that only need to test for
+    /// membership should prefer [`has`](Self::has).
+    fn unlocked(&self) -> Vec<RecipeId>;
+}
+
 // ── Main Context trait ───────────────────────────────────────────────
 
 /// Execution context for commands and event handlers.
@@ -164,7 +219,7 @@ pub trait ContainerContext {
 /// Implemented by `ServerContext` (in-game player) and potentially
 /// `ConsoleContext` (server terminal) in the future.
 pub trait Context:
-    PlayerContext + ChatContext + WorldContext + EntityContext + ContainerContext
+    PlayerContext + ChatContext + WorldContext + EntityContext + ContainerContext + RecipeContext
 {
     /// Returns a logger scoped to the current plugin.
     fn logger(&self) -> crate::logger::PluginLogger;
@@ -183,4 +238,7 @@ pub trait Context:
 
     /// Access container interaction.
     fn containers(&self) -> &dyn ContainerContext;
+
+    /// Access the current player's recipe-book state.
+    fn recipes(&self) -> &dyn RecipeContext;
 }

--- a/crates/basalt-core/src/lib.rs
+++ b/crates/basalt-core/src/lib.rs
@@ -26,12 +26,13 @@ pub use broadcast::{BroadcastMessage, PlayerSnapshot, ProfileProperty};
 pub use budget::TickBudget;
 pub use components::{
     BlockPosition, BoundingBox, ChunkPosition, Component, CraftingGrid, DroppedItem, EntityId,
-    EntityKind, Health, Inventory, Lifetime, OpenContainer, Phase, PickupDelay, PlayerRef,
-    Position, Rotation, Sneaking, Velocity, VirtualContainerSlots,
+    EntityKind, Health, Inventory, KnownRecipes, Lifetime, OpenContainer, Phase, PickupDelay,
+    PlayerRef, Position, Rotation, Sneaking, Velocity, VirtualContainerSlots,
 };
 pub use container::{Container, ContainerBacking, ContainerBuilder, InventoryType};
 pub use context::{
-    ChatContext, ContainerContext, Context, EntityContext, PlayerContext, WorldContext,
+    ChatContext, ContainerContext, Context, EntityContext, PlayerContext, RecipeContext,
+    UnlockReason, WorldContext,
 };
 pub use gamemode::Gamemode;
 pub use logger::PluginLogger;

--- a/crates/basalt-core/src/testing.rs
+++ b/crates/basalt-core/src/testing.rs
@@ -6,10 +6,12 @@
 
 use crate::broadcast::BroadcastMessage;
 use crate::context::{
-    ChatContext, ContainerContext, Context, EntityContext, PlayerContext, WorldContext,
+    ChatContext, ContainerContext, Context, EntityContext, PlayerContext, RecipeContext,
+    UnlockReason, WorldContext,
 };
 use crate::gamemode::Gamemode;
 use crate::logger::PluginLogger;
+use basalt_recipes::RecipeId;
 use basalt_types::{TextComponent, Uuid};
 
 /// A no-op [`Context`] implementation for unit tests.
@@ -109,6 +111,17 @@ impl ContainerContext for NoopContext {
     }
 }
 
+impl RecipeContext for NoopContext {
+    fn unlock(&self, _id: &RecipeId, _reason: UnlockReason) {}
+    fn lock(&self, _id: &RecipeId) {}
+    fn has(&self, _id: &RecipeId) -> bool {
+        false
+    }
+    fn unlocked(&self) -> Vec<RecipeId> {
+        Vec::new()
+    }
+}
+
 impl Context for NoopContext {
     fn logger(&self) -> PluginLogger {
         PluginLogger::new("test")
@@ -126,6 +139,9 @@ impl Context for NoopContext {
         self
     }
     fn containers(&self) -> &dyn ContainerContext {
+        self
+    }
+    fn recipes(&self) -> &dyn RecipeContext {
         self
     }
 }

--- a/crates/basalt-protocol/src/lib.rs
+++ b/crates/basalt-protocol/src/lib.rs
@@ -14,6 +14,7 @@ pub mod packets;
 pub mod registry;
 pub mod registry_data;
 pub mod state;
+pub mod types;
 pub mod version;
 
 pub use error::{Error, Result};

--- a/crates/basalt-protocol/src/types/mod.rs
+++ b/crates/basalt-protocol/src/types/mod.rs
@@ -1,0 +1,13 @@
+//! Hand-rolled protocol types that the codegen IR cannot represent.
+//!
+//! These are switch-on-tag union types whose variant data is laid out
+//! directly after the tag with no length prefix. The codegen falls back
+//! to opaque `Vec<u8>` for them, which produces invalid wire bytes (the
+//! default `Encode for Vec<u8>` adds a varint length prefix that the
+//! protocol does not expect). Anything in this module is the
+//! authoritative encoding — the matching codegen'd structs in
+//! `crate::packets` are dead code today.
+
+pub mod recipe_display;
+
+pub use recipe_display::{IDSet, RecipeBookEntry, RecipeDisplay, SlotDisplay};

--- a/crates/basalt-protocol/src/types/recipe_display.rs
+++ b/crates/basalt-protocol/src/types/recipe_display.rs
@@ -1,0 +1,775 @@
+//! Hand-rolled `SlotDisplay`, `RecipeDisplay`, and `RecipeBookEntry`
+//! used by the 1.21.4 recipe-book S2C packets.
+//!
+//! The codegen IR cannot represent recursive, switch-on-tag union types
+//! (the `data: type ?` clauses in `proto.yml`), so the generated structs
+//! fall back to opaque `Vec<u8>` whose default `Encode` impl prepends a
+//! varint length — the wrong wire format. These hand-written types are
+//! the authoritative encoding.
+//!
+//! Wire format (1.21.4):
+//!
+//! ```text
+//! SlotDisplay  := varint tag (0..=7) + variant fields
+//! RecipeDisplay := varint tag (0..=4) + variant fields
+//! ```
+//!
+//! Only `Encode` and `EncodedSize` are implemented — these types are S2C
+//! only, the server never decodes them.
+
+use basalt_types::{Encode, EncodedSize, Result, Slot, VarInt};
+
+/// One display slot in a recipe — empty, a literal item, an item tag, or
+/// a recursive composition.
+///
+/// See the [type-level docs](self) for the wire format.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SlotDisplay {
+    /// No item — shown as a blank slot (tag 0, no payload).
+    Empty,
+    /// Any fuel item (used in furnace recipe displays — tag 1, no payload).
+    AnyFuel,
+    /// A specific item by id (tag 2 + varint).
+    Item {
+        /// Item registry id.
+        item_id: i32,
+    },
+    /// A specific item stack with optional NBT (tag 3 + Slot).
+    ItemStack {
+        /// The full item stack.
+        slot: Slot,
+    },
+    /// Items matching a registry tag (tag 4 + string identifier).
+    Tag {
+        /// Tag identifier, e.g. `"minecraft:logs"`.
+        name: String,
+    },
+    /// Smithing trim composite display (tag 5 + 3 nested SlotDisplays).
+    SmithingTrim {
+        /// Base item slot (the equipment being trimmed).
+        base: Box<SlotDisplay>,
+        /// Trim material slot.
+        material: Box<SlotDisplay>,
+        /// Trim pattern slot.
+        pattern: Box<SlotDisplay>,
+    },
+    /// "Take input, leave remainder" pair for recipes that don't fully
+    /// consume the input slot (tag 6 + 2 nested SlotDisplays).
+    WithRemainder {
+        /// What the player must place.
+        input: Box<SlotDisplay>,
+        /// What is left in the slot after crafting.
+        remainder: Box<SlotDisplay>,
+    },
+    /// Cycle through several display options (tag 7 + varint count + slots).
+    ///
+    /// The vanilla client cycles between entries every ~30 ticks, used
+    /// for tag-based ingredients to show all matching items in turn.
+    Composite {
+        /// Sub-displays cycled by the client.
+        entries: Vec<SlotDisplay>,
+    },
+}
+
+impl SlotDisplay {
+    /// Returns the wire tag (0..=7) for this variant.
+    fn tag(&self) -> i32 {
+        match self {
+            Self::Empty => 0,
+            Self::AnyFuel => 1,
+            Self::Item { .. } => 2,
+            Self::ItemStack { .. } => 3,
+            Self::Tag { .. } => 4,
+            Self::SmithingTrim { .. } => 5,
+            Self::WithRemainder { .. } => 6,
+            Self::Composite { .. } => 7,
+        }
+    }
+}
+
+impl Encode for SlotDisplay {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        VarInt(self.tag()).encode(buf)?;
+        match self {
+            Self::Empty | Self::AnyFuel => Ok(()),
+            Self::Item { item_id } => VarInt(*item_id).encode(buf),
+            Self::ItemStack { slot } => slot.encode(buf),
+            Self::Tag { name } => name.encode(buf),
+            Self::SmithingTrim {
+                base,
+                material,
+                pattern,
+            } => {
+                base.encode(buf)?;
+                material.encode(buf)?;
+                pattern.encode(buf)
+            }
+            Self::WithRemainder { input, remainder } => {
+                input.encode(buf)?;
+                remainder.encode(buf)
+            }
+            Self::Composite { entries } => {
+                VarInt(entries.len() as i32).encode(buf)?;
+                for entry in entries {
+                    entry.encode(buf)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl EncodedSize for SlotDisplay {
+    fn encoded_size(&self) -> usize {
+        let tag_size = VarInt(self.tag()).encoded_size();
+        let body_size = match self {
+            Self::Empty | Self::AnyFuel => 0,
+            Self::Item { item_id } => VarInt(*item_id).encoded_size(),
+            Self::ItemStack { slot } => slot.encoded_size(),
+            Self::Tag { name } => name.encoded_size(),
+            Self::SmithingTrim {
+                base,
+                material,
+                pattern,
+            } => base.encoded_size() + material.encoded_size() + pattern.encoded_size(),
+            Self::WithRemainder { input, remainder } => {
+                input.encoded_size() + remainder.encoded_size()
+            }
+            Self::Composite { entries } => {
+                let count_size = VarInt(entries.len() as i32).encoded_size();
+                count_size + entries.iter().map(|e| e.encoded_size()).sum::<usize>()
+            }
+        };
+        tag_size + body_size
+    }
+}
+
+/// A recipe display in the player's recipe book — describes the slots
+/// the client should render for this recipe.
+///
+/// This is a presentation type: the actual matching logic lives in
+/// `basalt-recipes::RecipeRegistry`, which produces the `Recipe` enum.
+/// Convert from `Recipe` to `RecipeDisplay` via the
+/// `basalt-server::game::recipe_book::to_display` helper.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RecipeDisplay {
+    /// Shapeless 2x2 / 3x3 crafting recipe (tag 0).
+    CraftingShapeless {
+        /// Ingredient slots in any order.
+        ingredients: Vec<SlotDisplay>,
+        /// Result slot.
+        result: SlotDisplay,
+        /// Station shown next to the recipe (typically `Item { CRAFTING_TABLE }`).
+        crafting_station: SlotDisplay,
+    },
+    /// Shaped grid crafting recipe (tag 1).
+    CraftingShaped {
+        /// Pattern width (1..=3).
+        width: i32,
+        /// Pattern height (1..=3).
+        height: i32,
+        /// Ingredient grid in row-major order, length `width * height`.
+        ingredients: Vec<SlotDisplay>,
+        /// Result slot.
+        result: SlotDisplay,
+        /// Station shown next to the recipe.
+        crafting_station: SlotDisplay,
+    },
+    /// Furnace / blast furnace / smoker / campfire recipe (tag 2).
+    Furnace {
+        /// Input ingredient.
+        ingredient: SlotDisplay,
+        /// Fuel slot (typically `AnyFuel`).
+        fuel: SlotDisplay,
+        /// Smelted result.
+        result: SlotDisplay,
+        /// Station shown next to the recipe.
+        crafting_station: SlotDisplay,
+        /// Smelt duration in ticks.
+        duration: i32,
+        /// Experience awarded on completion.
+        experience: f32,
+    },
+    /// Stonecutter recipe (tag 3).
+    Stonecutter {
+        /// Input ingredient.
+        ingredient: SlotDisplay,
+        /// Result.
+        result: SlotDisplay,
+        /// Station shown next to the recipe.
+        crafting_station: SlotDisplay,
+    },
+    /// Smithing-table recipe (tag 4).
+    Smithing {
+        /// Smithing template slot.
+        template: SlotDisplay,
+        /// Base equipment slot.
+        base: SlotDisplay,
+        /// Addition material slot.
+        addition: SlotDisplay,
+        /// Resulting equipment.
+        result: SlotDisplay,
+        /// Station shown next to the recipe.
+        crafting_station: SlotDisplay,
+    },
+}
+
+impl RecipeDisplay {
+    /// Returns the wire tag (0..=4) for this variant.
+    fn tag(&self) -> i32 {
+        match self {
+            Self::CraftingShapeless { .. } => 0,
+            Self::CraftingShaped { .. } => 1,
+            Self::Furnace { .. } => 2,
+            Self::Stonecutter { .. } => 3,
+            Self::Smithing { .. } => 4,
+        }
+    }
+}
+
+impl Encode for RecipeDisplay {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        VarInt(self.tag()).encode(buf)?;
+        match self {
+            Self::CraftingShapeless {
+                ingredients,
+                result,
+                crafting_station,
+            } => {
+                encode_slot_vec(ingredients, buf)?;
+                result.encode(buf)?;
+                crafting_station.encode(buf)
+            }
+            Self::CraftingShaped {
+                width,
+                height,
+                ingredients,
+                result,
+                crafting_station,
+            } => {
+                VarInt(*width).encode(buf)?;
+                VarInt(*height).encode(buf)?;
+                encode_slot_vec(ingredients, buf)?;
+                result.encode(buf)?;
+                crafting_station.encode(buf)
+            }
+            Self::Furnace {
+                ingredient,
+                fuel,
+                result,
+                crafting_station,
+                duration,
+                experience,
+            } => {
+                ingredient.encode(buf)?;
+                fuel.encode(buf)?;
+                result.encode(buf)?;
+                crafting_station.encode(buf)?;
+                VarInt(*duration).encode(buf)?;
+                experience.encode(buf)
+            }
+            Self::Stonecutter {
+                ingredient,
+                result,
+                crafting_station,
+            } => {
+                ingredient.encode(buf)?;
+                result.encode(buf)?;
+                crafting_station.encode(buf)
+            }
+            Self::Smithing {
+                template,
+                base,
+                addition,
+                result,
+                crafting_station,
+            } => {
+                template.encode(buf)?;
+                base.encode(buf)?;
+                addition.encode(buf)?;
+                result.encode(buf)?;
+                crafting_station.encode(buf)
+            }
+        }
+    }
+}
+
+/// A set of registry entries — referenced either by name (an inline
+/// tag identifier) or by an inline list of registry ids.
+///
+/// Wire format (`registryEntryHolderSet` per minecraft-data 1.21.4):
+///
+/// ```text
+/// IDSet := varint tag
+///   if tag == 0: name: string
+///   else:        ids: varint[tag - 1]
+/// ```
+///
+/// Used by `crafting_requirements` on a recipe-book entry to gate
+/// when the recipe should appear in the book (e.g. "only show if the
+/// player carries an item from this tag").
+#[derive(Debug, Clone, PartialEq)]
+pub enum IDSet {
+    /// Reference a registered tag by its identifier
+    /// (e.g. `"minecraft:logs"`).
+    Tag(String),
+    /// Inline list of registry ids.
+    Ids(Vec<i32>),
+}
+
+impl Encode for IDSet {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        match self {
+            Self::Tag(name) => {
+                VarInt(0).encode(buf)?;
+                name.encode(buf)
+            }
+            Self::Ids(ids) => {
+                // Tag = ids.len() + 1; ids are written without an
+                // additional length prefix (the length is recovered
+                // from the tag by the reader).
+                VarInt((ids.len() as i32) + 1).encode(buf)?;
+                for id in ids {
+                    VarInt(*id).encode(buf)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl EncodedSize for IDSet {
+    fn encoded_size(&self) -> usize {
+        match self {
+            Self::Tag(name) => VarInt(0).encoded_size() + name.encoded_size(),
+            Self::Ids(ids) => {
+                VarInt((ids.len() as i32) + 1).encoded_size()
+                    + ids
+                        .iter()
+                        .map(|id| VarInt(*id).encoded_size())
+                        .sum::<usize>()
+            }
+        }
+    }
+}
+
+impl EncodedSize for RecipeDisplay {
+    fn encoded_size(&self) -> usize {
+        let tag_size = VarInt(self.tag()).encoded_size();
+        let body_size = match self {
+            Self::CraftingShapeless {
+                ingredients,
+                result,
+                crafting_station,
+            } => {
+                slot_vec_size(ingredients) + result.encoded_size() + crafting_station.encoded_size()
+            }
+            Self::CraftingShaped {
+                width,
+                height,
+                ingredients,
+                result,
+                crafting_station,
+            } => {
+                VarInt(*width).encoded_size()
+                    + VarInt(*height).encoded_size()
+                    + slot_vec_size(ingredients)
+                    + result.encoded_size()
+                    + crafting_station.encoded_size()
+            }
+            Self::Furnace {
+                ingredient,
+                fuel,
+                result,
+                crafting_station,
+                duration,
+                experience,
+            } => {
+                ingredient.encoded_size()
+                    + fuel.encoded_size()
+                    + result.encoded_size()
+                    + crafting_station.encoded_size()
+                    + VarInt(*duration).encoded_size()
+                    + experience.encoded_size()
+            }
+            Self::Stonecutter {
+                ingredient,
+                result,
+                crafting_station,
+            } => {
+                ingredient.encoded_size() + result.encoded_size() + crafting_station.encoded_size()
+            }
+            Self::Smithing {
+                template,
+                base,
+                addition,
+                result,
+                crafting_station,
+            } => {
+                template.encoded_size()
+                    + base.encoded_size()
+                    + addition.encoded_size()
+                    + result.encoded_size()
+                    + crafting_station.encoded_size()
+            }
+        };
+        tag_size + body_size
+    }
+}
+
+/// One entry in a [`ClientboundPlayRecipeBookAdd`](crate::packets::play::ClientboundPlayRecipeBookAdd) packet.
+///
+/// Wire layout: `display_id (varint) | display (RecipeDisplay) | group (varint) | category (varint) | crafting_requirements (Option<Vec<IDSet>>) | flags (u8)`.
+///
+/// Plugin-registered recipes typically carry no `crafting_requirements`
+/// (they show up unconditionally in the book); the field is here so
+/// future furnace / data-driven recipes can populate the predicates
+/// the vanilla client expects.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecipeBookEntry {
+    /// Per-player numeric id assigned by the server. Stable for the
+    /// lifetime of the connection so subsequent `Place Recipe` C2S
+    /// packets can reference it.
+    pub display_id: i32,
+    /// The display payload.
+    pub display: RecipeDisplay,
+    /// Recipe-book group tag — recipes sharing the same group are
+    /// shown together in the book. `0` for ungrouped.
+    pub group: i32,
+    /// Category index from `recipe_book_category` (0..=12 in 1.21.4):
+    /// `crafting_building_blocks`, `crafting_redstone`,
+    /// `crafting_equipment`, `crafting_misc`, `furnace_food`,
+    /// `furnace_blocks`, `furnace_misc`, `blast_furnace_blocks`,
+    /// `blast_furnace_misc`, `smoker_food`, `stonecutter`, `smithing`,
+    /// `campfire`.
+    pub category: i32,
+    /// Optional list of [`IDSet`] predicates that gate when this recipe
+    /// is shown. `None` (the common case for plugin recipes) means the
+    /// recipe is always visible.
+    pub crafting_requirements: Option<Vec<IDSet>>,
+    /// Bitflags. `0x01` notify the player on add; `0x02` highlight in
+    /// the book UI.
+    pub flags: u8,
+}
+
+impl Encode for RecipeBookEntry {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
+        VarInt(self.display_id).encode(buf)?;
+        self.display.encode(buf)?;
+        VarInt(self.group).encode(buf)?;
+        VarInt(self.category).encode(buf)?;
+        match &self.crafting_requirements {
+            Some(requirements) => {
+                true.encode(buf)?;
+                VarInt(requirements.len() as i32).encode(buf)?;
+                for req in requirements {
+                    req.encode(buf)?;
+                }
+            }
+            None => {
+                false.encode(buf)?;
+            }
+        }
+        self.flags.encode(buf)
+    }
+}
+
+impl EncodedSize for RecipeBookEntry {
+    fn encoded_size(&self) -> usize {
+        let req_size = match &self.crafting_requirements {
+            Some(requirements) => {
+                true.encoded_size()
+                    + VarInt(requirements.len() as i32).encoded_size()
+                    + requirements.iter().map(|r| r.encoded_size()).sum::<usize>()
+            }
+            None => false.encoded_size(),
+        };
+        VarInt(self.display_id).encoded_size()
+            + self.display.encoded_size()
+            + VarInt(self.group).encoded_size()
+            + VarInt(self.category).encoded_size()
+            + req_size
+            + self.flags.encoded_size()
+    }
+}
+
+/// Encodes a varint length prefix followed by each [`SlotDisplay`].
+fn encode_slot_vec(items: &[SlotDisplay], buf: &mut Vec<u8>) -> Result<()> {
+    VarInt(items.len() as i32).encode(buf)?;
+    for item in items {
+        item.encode(buf)?;
+    }
+    Ok(())
+}
+
+/// Returns the encoded byte length of a varint-prefixed slot vector.
+fn slot_vec_size(items: &[SlotDisplay]) -> usize {
+    VarInt(items.len() as i32).encoded_size()
+        + items.iter().map(|s| s.encoded_size()).sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip: encode then verify length matches `encoded_size`.
+    fn roundtrip<T: Encode + EncodedSize>(value: &T) -> Vec<u8> {
+        let mut buf = Vec::new();
+        value.encode(&mut buf).expect("encode");
+        assert_eq!(
+            buf.len(),
+            value.encoded_size(),
+            "encoded_size disagrees with encode output length"
+        );
+        buf
+    }
+
+    #[test]
+    fn slot_display_empty_writes_only_tag() {
+        let bytes = roundtrip(&SlotDisplay::Empty);
+        assert_eq!(bytes, vec![0x00]);
+    }
+
+    #[test]
+    fn slot_display_any_fuel() {
+        let bytes = roundtrip(&SlotDisplay::AnyFuel);
+        assert_eq!(bytes, vec![0x01]);
+    }
+
+    #[test]
+    fn slot_display_item() {
+        let bytes = roundtrip(&SlotDisplay::Item { item_id: 879 });
+        // tag 2 + varint(879) — 879 = 0xef + 0x06 in varint
+        assert_eq!(bytes, vec![0x02, 0xef, 0x06]);
+    }
+
+    #[test]
+    fn slot_display_tag() {
+        let bytes = roundtrip(&SlotDisplay::Tag {
+            name: "minecraft:logs".into(),
+        });
+        // tag 4 + varint length 14 + "minecraft:logs"
+        let mut expected = vec![0x04, 14];
+        expected.extend_from_slice(b"minecraft:logs");
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn slot_display_with_remainder_recursive() {
+        // Encode a WithRemainder whose remainder is also a WithRemainder.
+        let inner = SlotDisplay::WithRemainder {
+            input: Box::new(SlotDisplay::Item { item_id: 1 }),
+            remainder: Box::new(SlotDisplay::Empty),
+        };
+        let outer = SlotDisplay::WithRemainder {
+            input: Box::new(SlotDisplay::Item { item_id: 2 }),
+            remainder: Box::new(inner),
+        };
+        let bytes = roundtrip(&outer);
+        // tag 6 (outer) | tag 2 + varint 2 (input) | tag 6 (inner) | tag 2 + varint 1 | tag 0
+        assert_eq!(bytes, vec![0x06, 0x02, 0x02, 0x06, 0x02, 0x01, 0x00]);
+    }
+
+    #[test]
+    fn slot_display_composite_with_count_prefix() {
+        let composite = SlotDisplay::Composite {
+            entries: vec![
+                SlotDisplay::Item { item_id: 1 },
+                SlotDisplay::Item { item_id: 2 },
+                SlotDisplay::Empty,
+            ],
+        };
+        let bytes = roundtrip(&composite);
+        // tag 7 | varint(3) | tag 2 + varint 1 | tag 2 + varint 2 | tag 0
+        assert_eq!(bytes, vec![0x07, 3, 0x02, 0x01, 0x02, 0x02, 0x00]);
+    }
+
+    #[test]
+    fn slot_display_smithing_trim_three_nested() {
+        let st = SlotDisplay::SmithingTrim {
+            base: Box::new(SlotDisplay::Item { item_id: 10 }),
+            material: Box::new(SlotDisplay::Item { item_id: 20 }),
+            pattern: Box::new(SlotDisplay::Item { item_id: 30 }),
+        };
+        let bytes = roundtrip(&st);
+        // tag 5 | (tag 2 + 10) | (tag 2 + 20) | (tag 2 + 30)
+        assert_eq!(bytes, vec![0x05, 0x02, 0x0a, 0x02, 0x14, 0x02, 0x1e]);
+    }
+
+    #[test]
+    fn recipe_display_crafting_shaped_layout() {
+        let rd = RecipeDisplay::CraftingShaped {
+            width: 2,
+            height: 2,
+            ingredients: vec![
+                SlotDisplay::Item { item_id: 1 },
+                SlotDisplay::Item { item_id: 1 },
+                SlotDisplay::Item { item_id: 1 },
+                SlotDisplay::Item { item_id: 1 },
+            ],
+            result: SlotDisplay::Empty,
+            crafting_station: SlotDisplay::Empty,
+        };
+        let bytes = roundtrip(&rd);
+        // tag 1 | varint 2 | varint 2 | count(4) + 4×(tag 2 + 1) | empty result | empty station
+        assert_eq!(
+            bytes,
+            vec![
+                0x01, 0x02, 0x02, // tag, width, height
+                0x04, // ingredients count
+                0x02, 0x01, 0x02, 0x01, 0x02, 0x01, 0x02, 0x01, 0x00, // result: empty
+                0x00, // crafting_station: empty
+            ]
+        );
+    }
+
+    #[test]
+    fn recipe_display_crafting_shapeless_layout() {
+        let rd = RecipeDisplay::CraftingShapeless {
+            ingredients: vec![SlotDisplay::Item { item_id: 5 }],
+            result: SlotDisplay::Empty,
+            crafting_station: SlotDisplay::Empty,
+        };
+        let bytes = roundtrip(&rd);
+        // tag 0 | count(1) + (tag 2 + 5) | empty | empty
+        assert_eq!(bytes, vec![0x00, 0x01, 0x02, 0x05, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn recipe_display_furnace_with_duration_and_xp() {
+        let rd = RecipeDisplay::Furnace {
+            ingredient: SlotDisplay::Empty,
+            fuel: SlotDisplay::AnyFuel,
+            result: SlotDisplay::Empty,
+            crafting_station: SlotDisplay::Empty,
+            duration: 200,
+            experience: 0.5,
+        };
+        let bytes = roundtrip(&rd);
+        // tag 2 | empty | any_fuel | empty | empty | varint(200) | f32 0.5
+        let mut expected = vec![0x02, 0x00, 0x01, 0x00, 0x00];
+        // 200 = 0xc8 | 0x80 ⇒ 0xc8 0x01 in varint
+        expected.extend_from_slice(&[0xc8, 0x01]);
+        expected.extend_from_slice(&0.5f32.to_be_bytes());
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn recipe_display_stonecutter_layout() {
+        let rd = RecipeDisplay::Stonecutter {
+            ingredient: SlotDisplay::Item { item_id: 1 },
+            result: SlotDisplay::Item { item_id: 2 },
+            crafting_station: SlotDisplay::Empty,
+        };
+        let bytes = roundtrip(&rd);
+        assert_eq!(bytes, vec![0x03, 0x02, 0x01, 0x02, 0x02, 0x00]);
+    }
+
+    #[test]
+    fn recipe_display_smithing_layout() {
+        let rd = RecipeDisplay::Smithing {
+            template: SlotDisplay::Item { item_id: 1 },
+            base: SlotDisplay::Item { item_id: 2 },
+            addition: SlotDisplay::Item { item_id: 3 },
+            result: SlotDisplay::Item { item_id: 4 },
+            crafting_station: SlotDisplay::Empty,
+        };
+        let bytes = roundtrip(&rd);
+        assert_eq!(
+            bytes,
+            vec![0x04, 0x02, 0x01, 0x02, 0x02, 0x02, 0x03, 0x02, 0x04, 0x00]
+        );
+    }
+
+    #[test]
+    fn recipe_book_entry_no_requirements_writes_false_byte() {
+        let entry = RecipeBookEntry {
+            display_id: 7,
+            display: RecipeDisplay::CraftingShapeless {
+                ingredients: vec![SlotDisplay::Item { item_id: 1 }],
+                result: SlotDisplay::Empty,
+                crafting_station: SlotDisplay::Empty,
+            },
+            group: 0,
+            category: 3,
+            crafting_requirements: None,
+            flags: 0x01,
+        };
+        let bytes = roundtrip(&entry);
+        assert_eq!(
+            bytes,
+            vec![
+                0x07, // display_id
+                0x00, 0x01, 0x02, 0x01, 0x00, 0x00, // display
+                0x00, // group
+                0x03, // category
+                0x00, // crafting_requirements: false
+                0x01, // flags
+            ]
+        );
+    }
+
+    #[test]
+    fn recipe_book_entry_with_requirements_writes_optional_vec() {
+        let entry = RecipeBookEntry {
+            display_id: 1,
+            display: RecipeDisplay::CraftingShapeless {
+                ingredients: vec![],
+                result: SlotDisplay::Empty,
+                crafting_station: SlotDisplay::Empty,
+            },
+            group: 0,
+            category: 0,
+            crafting_requirements: Some(vec![
+                IDSet::Tag("minecraft:logs".into()),
+                IDSet::Ids(vec![43, 44]),
+            ]),
+            flags: 0,
+        };
+        let bytes = roundtrip(&entry);
+        // display_id, display (tag 0 + count 0 + empty + empty), group, cat,
+        // true, len 2, IDSet[0] (tag 0 + "minecraft:logs"), IDSet[1] (tag 3 + 43, 44), flags
+        let mut expected = vec![
+            0x01, // display_id
+            0x00, 0x00, 0x00, 0x00, // display: shapeless, no ingredients, empty, empty
+            0x00, 0x00, // group, category
+            0x01, // crafting_requirements present
+            0x02, // 2 entries
+            0x00, // IDSet::Tag tag = 0
+            14,   // string length 14
+        ];
+        expected.extend_from_slice(b"minecraft:logs");
+        expected.extend_from_slice(&[
+            0x03, // IDSet::Ids tag = ids.len() + 1 = 3
+            0x2b, 0x2c, // 43, 44 as varint
+            0x00, // flags
+        ]);
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn id_set_tag_round_trip() {
+        let set = IDSet::Tag("minecraft:planks".into());
+        let bytes = roundtrip(&set);
+        // tag 0 | varint length 16 | "minecraft:planks"
+        let mut expected = vec![0x00, 16];
+        expected.extend_from_slice(b"minecraft:planks");
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn id_set_ids_writes_offset_tag() {
+        let set = IDSet::Ids(vec![1, 2, 3]);
+        let bytes = roundtrip(&set);
+        // tag = 4 (3 ids + 1) | 1 | 2 | 3
+        assert_eq!(bytes, vec![0x04, 0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn id_set_empty_ids_uses_tag_one() {
+        let set = IDSet::Ids(vec![]);
+        let bytes = roundtrip(&set);
+        // tag = 1 (0 ids + 1)
+        assert_eq!(bytes, vec![0x01]);
+    }
+}

--- a/crates/basalt-recipes/src/registry.rs
+++ b/crates/basalt-recipes/src/registry.rs
@@ -234,6 +234,22 @@ impl RecipeRegistry {
         self.shaped.iter().any(|r| &r.id == id) || self.shapeless.iter().any(|r| &r.id == id)
     }
 
+    /// Returns a clone of the recipe with the given id, or `None`.
+    ///
+    /// Searches shaped recipes first then shapeless. The clone is
+    /// owned by the caller — useful for converting the matched recipe
+    /// into a presentation payload (e.g. `RecipeDisplay`) without
+    /// holding a borrow on the registry.
+    pub fn find_by_id(&self, id: &RecipeId) -> Option<Recipe> {
+        if let Some(r) = self.shaped.iter().find(|r| &r.id == id) {
+            return Some(Recipe::Shaped(r.clone()));
+        }
+        if let Some(r) = self.shapeless.iter().find(|r| &r.id == id) {
+            return Some(Recipe::Shapeless(r.clone()));
+        }
+        None
+    }
+
     /// Matches a crafting grid against all registered recipes.
     ///
     /// The `grid` is a flat row-major array of item slots. `grid_size` is

--- a/crates/basalt-server/src/game/dispatch.rs
+++ b/crates/basalt-server/src/game/dispatch.rs
@@ -222,6 +222,13 @@ impl GameLoop {
                         }
                     }
                 }
+                GameInput::PlaceRecipe {
+                    uuid,
+                    window_id,
+                    display_id,
+                } => {
+                    self.handle_place_recipe(uuid, window_id, display_id);
+                }
             }
         }
     }

--- a/crates/basalt-server/src/game/lifecycle.rs
+++ b/crates/basalt-server/src/game/lifecycle.rs
@@ -54,6 +54,8 @@ impl GameLoop {
         );
         self.ecs.set(eid, basalt_core::Inventory::empty());
         self.ecs.set(eid, basalt_core::CraftingGrid::empty());
+        self.ecs
+            .set(eid, basalt_core::components::KnownRecipes::default());
         self.ecs.set(
             eid,
             SkinData {
@@ -66,6 +68,11 @@ impl GameLoop {
 
         // Send initial world data
         self.send_initial_world(eid, entity_id, position);
+
+        // Initialise the recipe book — even an empty one is required;
+        // the 1.21.4 client expects a `RecipeBookAdd { replace: true }`
+        // packet on join to set up its book UI.
+        self.send_initial_recipe_book(eid);
 
         // Send existing players to the new player + broadcast join
         let snapshot = basalt_api::broadcast::PlayerSnapshot {

--- a/crates/basalt-server/src/game/mod.rs
+++ b/crates/basalt-server/src/game/mod.rs
@@ -16,6 +16,7 @@ mod inventory;
 mod items;
 mod lifecycle;
 mod movement;
+mod recipe_book;
 mod responses;
 
 use std::collections::HashSet;

--- a/crates/basalt-server/src/game/recipe_book.rs
+++ b/crates/basalt-server/src/game/recipe_book.rs
@@ -1,0 +1,530 @@
+//! Recipe-book server-side wiring: response handlers, on-join hook,
+//! and `Recipe → RecipeDisplay` conversion.
+//!
+//! Phase 1 covers shaped + shapeless crafting recipes. Furnace,
+//! stonecutter, and smithing displays are placeholders here — those
+//! domains (#138 and follow-ups) construct their own `RecipeDisplay`s.
+
+use basalt_api::events::{RecipeLockedEvent, RecipeUnlockedEvent};
+use basalt_core::components::KnownRecipes;
+use basalt_core::context::UnlockReason;
+use basalt_ecs::EntityId;
+use basalt_protocol::types::{RecipeBookEntry, RecipeDisplay, SlotDisplay};
+use basalt_recipes::{Recipe, RecipeId};
+use basalt_types::{Slot, Uuid};
+
+use super::{GameLoop, OutputHandle};
+use crate::messages::ServerOutput;
+
+/// Item id of a vanilla crafting table — drawn next to crafting
+/// recipes in the recipe book UI.
+const CRAFTING_TABLE_ITEM_ID: i32 = 314;
+
+/// Default recipe-book category for crafting recipes.
+///
+/// `crafting_misc` = `3` per the 1.21.4 `recipe_book_category`
+/// registry. We pick a single bucket for Phase 1; per-recipe category
+/// classification (building blocks / redstone / equipment) needs the
+/// item registry and is deferred.
+const CATEGORY_CRAFTING_MISC: i32 = 3;
+
+impl GameLoop {
+    /// Handles `Response::UnlockRecipe`.
+    ///
+    /// Resolves the source player, mutates their `KnownRecipes`,
+    /// dispatches `RecipeUnlockedEvent`, and queues a single-entry
+    /// `Recipe Book Add` S2C packet.
+    pub(super) fn unlock_recipe(
+        &mut self,
+        source_uuid: Uuid,
+        recipe_id: RecipeId,
+        reason: UnlockReason,
+    ) {
+        let Some(eid) = self.find_by_uuid(source_uuid) else {
+            return;
+        };
+        let Some(recipe) = self.recipes.find_by_id(&recipe_id) else {
+            log::warn!(
+                target: "basalt::recipes",
+                "unlock_recipe: unknown recipe id {recipe_id}"
+            );
+            return;
+        };
+        let display = to_display(&recipe);
+
+        let display_id = {
+            let Some(known) = self.ecs.get_mut::<KnownRecipes>(eid) else {
+                return;
+            };
+            // Skip if already unlocked — KnownRecipes::unlock returns
+            // the existing display_id but we should not re-send the
+            // RecipeBookAdd packet (the client already has the entry).
+            if known.has(&recipe_id) {
+                return;
+            }
+            known.unlock(recipe_id.clone())
+        };
+
+        let entry = RecipeBookEntry {
+            display_id,
+            display,
+            group: 0,
+            category: CATEGORY_CRAFTING_MISC,
+            crafting_requirements: None,
+            // 0x01 = notification (toast on add).
+            flags: 0x01,
+        };
+        self.send_to(eid, |tx| {
+            let _ = tx.try_send(ServerOutput::RecipeBookAdd {
+                entries: vec![entry],
+                replace: false,
+            });
+        });
+
+        let (entity_id, username, yaw, pitch) = self.player_dispatch_args(eid);
+        let ctx = self.make_context(source_uuid, entity_id, &username, yaw, pitch);
+        let mut event = RecipeUnlockedEvent { recipe_id, reason };
+        self.dispatch_event(&mut event, &ctx);
+        self.process_responses(source_uuid, &ctx.drain_responses());
+    }
+
+    /// Handles `Response::LockRecipe`.
+    pub(super) fn lock_recipe(&mut self, source_uuid: Uuid, recipe_id: RecipeId) {
+        let Some(eid) = self.find_by_uuid(source_uuid) else {
+            return;
+        };
+
+        let display_id = {
+            let Some(known) = self.ecs.get_mut::<KnownRecipes>(eid) else {
+                return;
+            };
+            match known.lock(&recipe_id) {
+                Some(d) => d,
+                None => return,
+            }
+        };
+
+        self.send_to(eid, |tx| {
+            let _ = tx.try_send(ServerOutput::RecipeBookRemove {
+                display_ids: vec![display_id],
+            });
+        });
+
+        let (entity_id, username, yaw, pitch) = self.player_dispatch_args(eid);
+        let ctx = self.make_context(source_uuid, entity_id, &username, yaw, pitch);
+        let mut event = RecipeLockedEvent { recipe_id };
+        self.dispatch_event(&mut event, &ctx);
+        self.process_responses(source_uuid, &ctx.drain_responses());
+    }
+
+    /// Handles `GameInput::PlaceRecipe` (the `Place Recipe` C2S
+    /// packet) by sending a ghost-recipe reply to the player's open
+    /// crafting window.
+    ///
+    /// Resolves the protocol's per-player `display_id` to a
+    /// [`RecipeId`] via the player's [`KnownRecipes`] (the reverse
+    /// map is intentionally retained even after lock, so a stale
+    /// click on a freshly-locked recipe still finds the entry), then
+    /// looks the recipe up in the registry, builds a
+    /// [`RecipeDisplay`], and queues a
+    /// [`ServerOutput::SendGhostRecipe`].
+    ///
+    /// No items are moved on the server in Phase 1 — the ghost is a
+    /// purely visual preview. Auto-fill (the
+    /// `RecipeBookFillRequestEvent` / `RecipeBookFilledEvent` pair)
+    /// is tracked as a follow-up issue.
+    pub(super) fn handle_place_recipe(
+        &mut self,
+        source_uuid: Uuid,
+        window_id: i32,
+        display_id: i32,
+    ) {
+        let Some(eid) = self.find_by_uuid(source_uuid) else {
+            return;
+        };
+        let recipe_id = match self.ecs.get::<KnownRecipes>(eid) {
+            Some(known) => match known.recipe_for_display(display_id) {
+                Some(id) => id.clone(),
+                None => return,
+            },
+            None => return,
+        };
+        let Some(recipe) = self.recipes.find_by_id(&recipe_id) else {
+            return;
+        };
+        let display = to_display(&recipe);
+        self.send_to(eid, |tx| {
+            let _ = tx.try_send(ServerOutput::SendGhostRecipe { window_id, display });
+        });
+    }
+
+    /// Pulls the dispatch args (entity id, username, yaw, pitch) for a
+    /// player entity. Returns sentinels if any component is missing —
+    /// dispatch goes through with stub values rather than skipping.
+    fn player_dispatch_args(&self, eid: EntityId) -> (i32, String, f32, f32) {
+        let entity_id = eid as i32;
+        let username = self
+            .ecs
+            .get::<basalt_core::PlayerRef>(eid)
+            .map_or_else(String::new, |p| p.username.clone());
+        let (yaw, pitch) = self
+            .ecs
+            .get::<basalt_core::Rotation>(eid)
+            .map_or((0.0, 0.0), |r| (r.yaw, r.pitch));
+        (entity_id, username, yaw, pitch)
+    }
+
+    /// Sends the player's current recipe book on join.
+    ///
+    /// Always sends a `RecipeBookAdd { replace: true }` even when the
+    /// player has no unlocked recipes — the 1.21.4 client expects the
+    /// packet to initialize its book UI. Without it the client may
+    /// display a stale book or refuse to open it.
+    pub(super) fn send_initial_recipe_book(&self, eid: EntityId) {
+        let entries = self
+            .ecs
+            .get::<KnownRecipes>(eid)
+            .map(|known| {
+                known
+                    .iter()
+                    .filter_map(|(id, display_id)| {
+                        let recipe = self.recipes.find_by_id(id)?;
+                        Some(RecipeBookEntry {
+                            display_id,
+                            display: to_display(&recipe),
+                            group: 0,
+                            category: CATEGORY_CRAFTING_MISC,
+                            crafting_requirements: None,
+                            flags: 0,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        if let Some(handle) = self.ecs.get::<OutputHandle>(eid) {
+            let _ = handle.tx.try_send(ServerOutput::RecipeBookAdd {
+                entries,
+                replace: true,
+            });
+        }
+    }
+}
+
+/// Converts a [`Recipe`] into the wire-level [`RecipeDisplay`].
+///
+/// Shaped recipes preserve their `width` × `height` grid; ingredient
+/// slots become `SlotDisplay::Item` (or `Empty` for `None`). Shapeless
+/// recipes drop into `CraftingShapeless` with the same item-by-id
+/// mapping. Other variants (Furnace, Stonecutter, Smithing) are
+/// constructed by their domain plugins — out of scope for this phase.
+pub fn to_display(recipe: &Recipe) -> RecipeDisplay {
+    match recipe {
+        Recipe::Shaped(r) => RecipeDisplay::CraftingShaped {
+            width: i32::from(r.width),
+            height: i32::from(r.height),
+            ingredients: r.pattern.iter().map(slot_for_pattern).collect(),
+            result: SlotDisplay::ItemStack {
+                slot: Slot::new(r.result_id, r.result_count),
+            },
+            crafting_station: SlotDisplay::Item {
+                item_id: CRAFTING_TABLE_ITEM_ID,
+            },
+        },
+        Recipe::Shapeless(r) => RecipeDisplay::CraftingShapeless {
+            ingredients: r
+                .ingredients
+                .iter()
+                .map(|item_id| SlotDisplay::Item { item_id: *item_id })
+                .collect(),
+            result: SlotDisplay::ItemStack {
+                slot: Slot::new(r.result_id, r.result_count),
+            },
+            crafting_station: SlotDisplay::Item {
+                item_id: CRAFTING_TABLE_ITEM_ID,
+            },
+        },
+    }
+}
+
+fn slot_for_pattern(slot: &Option<i32>) -> SlotDisplay {
+    match slot {
+        Some(id) => SlotDisplay::Item { item_id: *id },
+        None => SlotDisplay::Empty,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use basalt_recipes::{OwnedShapedRecipe, OwnedShapelessRecipe};
+
+    fn shaped(width: u8, height: u8, pattern: Vec<Option<i32>>) -> Recipe {
+        Recipe::Shaped(OwnedShapedRecipe {
+            id: RecipeId::vanilla("test"),
+            width,
+            height,
+            pattern,
+            result_id: 879,
+            result_count: 4,
+        })
+    }
+
+    fn shapeless(ingredients: Vec<i32>) -> Recipe {
+        Recipe::Shapeless(OwnedShapelessRecipe {
+            id: RecipeId::vanilla("test_shapeless"),
+            ingredients,
+            result_id: 2,
+            result_count: 1,
+        })
+    }
+
+    #[test]
+    fn to_display_shaped_preserves_dimensions_and_pattern() {
+        let r = shaped(2, 1, vec![Some(43), Some(43)]);
+        match to_display(&r) {
+            RecipeDisplay::CraftingShaped {
+                width,
+                height,
+                ingredients,
+                result,
+                crafting_station,
+            } => {
+                assert_eq!(width, 2);
+                assert_eq!(height, 1);
+                assert_eq!(ingredients.len(), 2);
+                assert!(matches!(ingredients[0], SlotDisplay::Item { item_id: 43 }));
+                assert!(matches!(result, SlotDisplay::ItemStack { .. }));
+                assert!(
+                    matches!(crafting_station, SlotDisplay::Item { item_id } if item_id == CRAFTING_TABLE_ITEM_ID)
+                );
+            }
+            _ => panic!("expected CraftingShaped"),
+        }
+    }
+
+    #[test]
+    fn to_display_shaped_maps_none_to_empty() {
+        let r = shaped(2, 2, vec![Some(1), None, None, Some(2)]);
+        match to_display(&r) {
+            RecipeDisplay::CraftingShaped { ingredients, .. } => {
+                assert!(matches!(ingredients[0], SlotDisplay::Item { item_id: 1 }));
+                assert!(matches!(ingredients[1], SlotDisplay::Empty));
+                assert!(matches!(ingredients[2], SlotDisplay::Empty));
+                assert!(matches!(ingredients[3], SlotDisplay::Item { item_id: 2 }));
+            }
+            _ => panic!("expected CraftingShaped"),
+        }
+    }
+
+    #[test]
+    fn to_display_shapeless_maps_each_ingredient() {
+        let r = shapeless(vec![10, 20, 30]);
+        match to_display(&r) {
+            RecipeDisplay::CraftingShapeless { ingredients, .. } => {
+                assert_eq!(ingredients.len(), 3);
+                assert!(matches!(ingredients[0], SlotDisplay::Item { item_id: 10 }));
+                assert!(matches!(ingredients[2], SlotDisplay::Item { item_id: 30 }));
+            }
+            _ => panic!("expected CraftingShapeless"),
+        }
+    }
+
+    /// End-to-end test: unlock_recipe mutates KnownRecipes and queues
+    /// a `RecipeBookAdd` packet to the player's output channel.
+    #[test]
+    fn unlock_recipe_updates_state_and_sends_packet() {
+        use basalt_types::Uuid;
+
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Drain the on-join packets so we only see the unlock dispatch.
+        while rx.try_recv().is_ok() {}
+
+        let id = RecipeId::vanilla("shaped_0");
+        game_loop.unlock_recipe(uuid, id.clone(), UnlockReason::Manual);
+
+        let eid = game_loop.find_by_uuid(uuid).expect("player entity");
+        let known = game_loop
+            .ecs
+            .get::<KnownRecipes>(eid)
+            .expect("KnownRecipes attached on join");
+        assert!(known.has(&id));
+        assert_eq!(known.display_id(&id), Some(0));
+
+        let mut saw_add = false;
+        while let Ok(out) = rx.try_recv() {
+            if let crate::messages::ServerOutput::RecipeBookAdd { entries, replace } = out {
+                assert!(!replace, "per-recipe unlock uses replace=false");
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].display_id, 0);
+                saw_add = true;
+            }
+        }
+        assert!(saw_add, "unlock_recipe should queue a RecipeBookAdd");
+    }
+
+    /// unlock_recipe is a no-op when the recipe id isn't in the
+    /// registry — the player's KnownRecipes stays empty.
+    #[test]
+    fn unlock_recipe_unknown_id_is_noop() {
+        use basalt_types::Uuid;
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let _rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        game_loop.unlock_recipe(
+            uuid,
+            RecipeId::new("plugin", "does_not_exist"),
+            UnlockReason::Manual,
+        );
+
+        let eid = game_loop.find_by_uuid(uuid).unwrap();
+        let known = game_loop.ecs.get::<KnownRecipes>(eid).unwrap();
+        assert_eq!(known.len(), 0);
+    }
+
+    /// unlock_recipe is idempotent — a second call for the same id
+    /// does not allocate a new display_id and does not queue a duplicate
+    /// packet.
+    #[test]
+    fn unlock_recipe_idempotent() {
+        use basalt_types::Uuid;
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        let id = RecipeId::vanilla("shaped_0");
+        game_loop.unlock_recipe(uuid, id.clone(), UnlockReason::Manual);
+        // Drain the first add.
+        while rx.try_recv().is_ok() {}
+
+        // Second call — should be a no-op.
+        game_loop.unlock_recipe(uuid, id, UnlockReason::Manual);
+
+        let mut saw_add = false;
+        while let Ok(out) = rx.try_recv() {
+            if matches!(out, crate::messages::ServerOutput::RecipeBookAdd { .. }) {
+                saw_add = true;
+            }
+        }
+        assert!(
+            !saw_add,
+            "second unlock for same recipe must not queue another packet"
+        );
+    }
+
+    /// lock_recipe removes from KnownRecipes and queues a
+    /// `RecipeBookRemove` packet with the previously-allocated display_id.
+    #[test]
+    fn lock_recipe_after_unlock_sends_remove() {
+        use basalt_types::Uuid;
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        let id = RecipeId::vanilla("shaped_0");
+        game_loop.unlock_recipe(uuid, id.clone(), UnlockReason::Manual);
+        while rx.try_recv().is_ok() {}
+
+        game_loop.lock_recipe(uuid, id.clone());
+
+        let eid = game_loop.find_by_uuid(uuid).unwrap();
+        let known = game_loop.ecs.get::<KnownRecipes>(eid).unwrap();
+        assert!(!known.has(&id));
+
+        let mut saw_remove = false;
+        while let Ok(out) = rx.try_recv() {
+            if let crate::messages::ServerOutput::RecipeBookRemove { display_ids } = out {
+                assert_eq!(display_ids, vec![0]);
+                saw_remove = true;
+            }
+        }
+        assert!(
+            saw_remove,
+            "lock_recipe should queue a RecipeBookRemove with the removed display_id"
+        );
+    }
+
+    /// `handle_place_recipe` resolves the per-player `display_id` and
+    /// queues a `SendGhostRecipe` reply with the recipe's display.
+    #[test]
+    fn place_recipe_sends_ghost_recipe_for_known_display_id() {
+        use basalt_types::Uuid;
+
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        let id = RecipeId::vanilla("shaped_0");
+        game_loop.unlock_recipe(uuid, id, UnlockReason::Manual);
+        // Drain the unlock-related packets (RecipeBookAdd) so we
+        // see only the ghost reply afterwards.
+        while rx.try_recv().is_ok() {}
+
+        // Display id 0 was assigned by KnownRecipes::unlock above.
+        game_loop.handle_place_recipe(uuid, 0, 0);
+
+        let mut saw_ghost = false;
+        while let Ok(out) = rx.try_recv() {
+            if let crate::messages::ServerOutput::SendGhostRecipe { window_id, .. } = out {
+                assert_eq!(window_id, 0);
+                saw_ghost = true;
+            }
+        }
+        assert!(
+            saw_ghost,
+            "place_recipe with known display_id should queue SendGhostRecipe"
+        );
+    }
+
+    /// `handle_place_recipe` is a no-op when the `display_id` was
+    /// never allocated for this player.
+    #[test]
+    fn place_recipe_unknown_display_id_is_noop() {
+        use basalt_types::Uuid;
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+        while rx.try_recv().is_ok() {}
+
+        game_loop.handle_place_recipe(uuid, 0, 9999);
+
+        let saw_ghost = std::iter::from_fn(|| rx.try_recv().ok())
+            .any(|o| matches!(o, crate::messages::ServerOutput::SendGhostRecipe { .. }));
+        assert!(
+            !saw_ghost,
+            "unknown display_id must not queue a ghost reply"
+        );
+    }
+
+    /// On player join, the server sends an empty
+    /// `RecipeBookAdd { replace: true }` so the client initialises its
+    /// recipe-book UI even when no recipes are unlocked.
+    #[test]
+    fn join_sends_initial_replace_recipe_book() {
+        use basalt_types::Uuid;
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let mut found = false;
+        while let Ok(out) = rx.try_recv() {
+            if let crate::messages::ServerOutput::RecipeBookAdd { entries, replace } = out
+                && replace
+                && entries.is_empty()
+            {
+                found = true;
+            }
+        }
+        assert!(
+            found,
+            "expected RecipeBookAdd {{ replace: true, entries: [] }} on join"
+        );
+    }
+}

--- a/crates/basalt-server/src/game/responses.rs
+++ b/crates/basalt-server/src/game/responses.rs
@@ -185,6 +185,12 @@ impl GameLoop {
                         );
                     }
                 }
+                Response::UnlockRecipe { recipe_id, reason } => {
+                    self.unlock_recipe(source_uuid, recipe_id.clone(), *reason);
+                }
+                Response::LockRecipe { recipe_id } => {
+                    self.lock_recipe(source_uuid, recipe_id.clone());
+                }
             }
         }
     }

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -160,6 +160,17 @@ pub enum GameInput {
         /// Action ID (0 = start sneak, 1 = stop sneak).
         action_id: i32,
     },
+    /// Player clicked a recipe in their book — the client expects
+    /// a `CraftRecipeResponse` (ghost recipe) reply showing the
+    /// ingredient layout in the open crafting window.
+    PlaceRecipe {
+        /// UUID of the requesting player.
+        uuid: Uuid,
+        /// Window id of the open crafting window.
+        window_id: i32,
+        /// Per-player numeric `display_id` of the chosen recipe.
+        display_id: i32,
+    },
 }
 
 /// Output from the game loop to a player's net task.
@@ -287,6 +298,37 @@ pub enum ServerOutput {
         z: i32,
         /// Block entity type (2 = chest).
         action: i32,
+    },
+
+    /// Push entries into the player's recipe book.
+    ///
+    /// `replace = true` clears the existing book first (used on join);
+    /// `replace = false` adds to the current set (used per-unlock).
+    /// Entries carry per-player `display_id`s allocated by `KnownRecipes`.
+    /// Net task encodes packet id `0x44`.
+    RecipeBookAdd {
+        /// Recipe-display entries to add.
+        entries: Vec<basalt_protocol::types::RecipeBookEntry>,
+        /// Replace the existing book contents.
+        replace: bool,
+    },
+
+    /// Remove the given `display_id`s from the player's recipe book.
+    ///
+    /// Net task encodes packet id `0x45`.
+    RecipeBookRemove {
+        /// Display IDs whose entries should be removed.
+        display_ids: Vec<i32>,
+    },
+
+    /// Reply to a `Place Recipe` C2S with the ghost-recipe display so
+    /// the client can show the ingredient layout in the open crafting
+    /// window. Net task encodes packet id `0x39`.
+    SendGhostRecipe {
+        /// Window id of the open crafting window the ghost is for.
+        window_id: i32,
+        /// Recipe display payload (variant + slots).
+        display: basalt_protocol::types::RecipeDisplay,
     },
 
     // ── Chunk path (cache-based, zero alloc) ──────────────────────────

--- a/crates/basalt-server/src/net/play_handler.rs
+++ b/crates/basalt-server/src/net/play_handler.rs
@@ -260,6 +260,15 @@ pub(super) async fn handle_packet(
             });
         }
 
+        // -- Game loop: place recipe (ghost preview) --
+        ServerboundPlayPacket::CraftRecipeRequest(req) => {
+            let _ = game_tx.send(GameInput::PlaceRecipe {
+                uuid,
+                window_id: req.window_id,
+                display_id: req.recipe_id,
+            });
+        }
+
         // -- Inline (no routing) --
         ServerboundPlayPacket::TeleportConfirm(_)
         | ServerboundPlayPacket::Flying(_)
@@ -274,7 +283,12 @@ pub(super) async fn handle_packet(
         | ServerboundPlayPacket::MessageAcknowledgement(_)
         | ServerboundPlayPacket::ConfigurationAcknowledged(_)
         | ServerboundPlayPacket::UseItem(_)
-        | ServerboundPlayPacket::ArmAnimation(_) => {}
+        | ServerboundPlayPacket::ArmAnimation(_)
+        // Recipe book settings (which tabs are open / filtering) and
+        // displayed-recipe notifications are accepted but ignored —
+        // tracking the player's UI tab state isn't useful server-side.
+        | ServerboundPlayPacket::RecipeBook(_)
+        | ServerboundPlayPacket::DisplayedRecipe(_) => {}
 
         other => {
             log::trace!(target: "basalt::net_task", "[{addr}] {username} unhandled: {:?}", std::mem::discriminant(&other));
@@ -355,7 +369,9 @@ async fn process_instant_responses(
             | Response::OpenContainer(_)
             | Response::BroadcastBlockAction { .. }
             | Response::NotifyContainerViewers { .. }
-            | Response::DestroyBlockEntity { .. } => {}
+            | Response::DestroyBlockEntity { .. }
+            | Response::UnlockRecipe { .. }
+            | Response::LockRecipe { .. } => {}
         }
     }
     Ok(())

--- a/crates/basalt-server/src/net/play_sender.rs
+++ b/crates/basalt-server/src/net/play_sender.rs
@@ -182,6 +182,55 @@ pub(super) async fn write_server_output(
             conn.write_packet_typed(ClientboundPlayTileEntityData::PACKET_ID, &packet)
                 .await?;
         }
+        ServerOutput::RecipeBookAdd { entries, replace } => {
+            // Manual encoding: codegen falls back to opaque Vec<u8> for
+            // RecipeDisplay/SlotDisplay (recursive switch types). The
+            // typed RecipeBookEntry implements Encode + EncodedSize.
+            use basalt_types::{Encode, EncodedSize, VarInt};
+            let mut payload = Vec::with_capacity(
+                VarInt(entries.len() as i32).encoded_size()
+                    + entries.iter().map(|e| e.encoded_size()).sum::<usize>()
+                    + 1,
+            );
+            VarInt(entries.len() as i32).encode(&mut payload).unwrap();
+            for entry in entries {
+                entry.encode(&mut payload).unwrap();
+            }
+            replace.encode(&mut payload).unwrap();
+            // Packet ID 0x44 = ClientboundPlayRecipeBookAdd in 1.21.4.
+            conn.write_packet_typed(0x44, &RawPayload(payload)).await?;
+        }
+        ServerOutput::RecipeBookRemove { display_ids } => {
+            use basalt_types::{Encode, EncodedSize, VarInt};
+            let mut payload = Vec::with_capacity(
+                VarInt(display_ids.len() as i32).encoded_size()
+                    + display_ids
+                        .iter()
+                        .map(|d| VarInt(*d).encoded_size())
+                        .sum::<usize>(),
+            );
+            VarInt(display_ids.len() as i32)
+                .encode(&mut payload)
+                .unwrap();
+            for d in display_ids {
+                VarInt(*d).encode(&mut payload).unwrap();
+            }
+            // Packet ID 0x45 = ClientboundPlayRecipeBookRemove in 1.21.4.
+            conn.write_packet_typed(0x45, &RawPayload(payload)).await?;
+        }
+        ServerOutput::SendGhostRecipe { window_id, display } => {
+            // Packet 0x39 = ClientboundPlayCraftRecipeResponse — same
+            // RecipeDisplay encoding as RecipeBookAdd, so we use the
+            // typed `RecipeDisplay` directly. Codegen can't model the
+            // recursive switch, so we hand-encode the payload.
+            use basalt_types::{Encode, EncodedSize, VarInt};
+            let window_size = VarInt(*window_id).encoded_size();
+            let display_size = display.encoded_size();
+            let mut payload = Vec::with_capacity(window_size + display_size);
+            VarInt(*window_id).encode(&mut payload).unwrap();
+            display.encode(&mut payload).unwrap();
+            conn.write_packet_typed(0x39, &RawPayload(payload)).await?;
+        }
         // ── Chunk path: cache-based ──────────────────────────────────
         ServerOutput::SendChunk { cx, cz } => {
             let bytes = chunk_cache.get_or_encode(*cx, *cz);

--- a/crates/basalt-testkit/src/lib.rs
+++ b/crates/basalt-testkit/src/lib.rs
@@ -406,6 +406,26 @@ impl DispatchResult {
             .iter()
             .any(|r| matches!(r, Response::DestroyBlockEntity { .. }))
     }
+
+    /// Returns true if any response unlocks the given recipe id.
+    pub fn has_unlock_recipe(&self, id: &basalt_recipes::RecipeId) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::UnlockRecipe { recipe_id, .. } if recipe_id == id
+            )
+        })
+    }
+
+    /// Returns true if any response locks the given recipe id.
+    pub fn has_lock_recipe(&self, id: &basalt_recipes::RecipeId) -> bool {
+        self.responses.iter().any(|r| {
+            matches!(
+                r,
+                Response::LockRecipe { recipe_id } if recipe_id == id
+            )
+        })
+    }
 }
 
 /// Test context for system plugins.


### PR DESCRIPTION
## Summary

Phase 1 of #166 — the recipe book becomes functional in 1.21.4.

- Hand-rolled `SlotDisplay` / `RecipeDisplay` / `RecipeBookEntry` / `IDSet` typed enums in \`basalt-protocol\` with manual \`Encode\` + \`EncodedSize\` (S2C only). The codegen IR cannot represent recursive switch-on-tag union types — the generated structs were emitting the wrong wire format. \`crafting_requirements\` is now \`Option<Vec<IDSet>>\` instead of a hardcoded \`false\`.
- New \`KnownRecipes\` ECS component on each player: \`HashSet<RecipeId>\` + forward \`display_id\` map + reverse map (intentionally retained after lock so a stale Place Recipe packet still resolves).
- Plugin-facing \`RecipeContext\` trait: \`unlock(&id, reason)\`, \`lock(&id)\`, \`has(&id)\`, \`unlocked()\`. \`UnlockReason\` (AutoDiscovered / Manual / InitialJoin) is carried on the event so plugins can branch on the source.
- Two events on the game bus, Post-only: \`RecipeUnlockedEvent\`, \`RecipeLockedEvent\`. Plugins listen via the standard \`registrar.on::<E>(...)\` API.
- On player join, the server dispatches \`RecipeBookAdd { replace: true, entries: <known> }\` so the client initialises its book UI (without it the vanilla 1.21.4 client refuses to open the book).
- On \`Response::UnlockRecipe\` / \`LockRecipe\`, the game loop mutates \`KnownRecipes\`, queues the appropriate S2C packet, and dispatches the lifecycle event.
- **Ghost recipe** (parity with Minestom): on \`ServerboundPlayCraftRecipeRequest\` (player clicks a recipe in the book), the server resolves \`display_id → Recipe → RecipeDisplay\` and replies with \`CraftRecipeResponse\` (packet 0x39). The client shows the ingredient layout fantôme in the open crafting window. No items are moved server-side — that's auto-fill, deferred.

## Comparison with Minestom

We're now richer than Minestom on the event surface (they fire zero events for the recipe book) and on per-player state granularity (they have no \`KnownRecipes\` equivalent — bulk \`refreshRecipes()\` only). We match them on ghost recipe behaviour and on the \`crafting_requirements\` API surface (still \`None\` in practice but the typed slot exists).

## Out of scope (follow-up issue)

- \`RecipeBookFillRequestEvent\` (Validate, cancellable) + \`RecipeBookFilledEvent\` (Post) — the auto-fill events. Need a real ingredient-search-and-place algorithm.
- Persistence of \`KnownRecipes\` to disk (needs basalt-storage extension).
- Real recipe paths instead of \`minecraft:shaped_<n>\` placeholders (needs item registry).
- Codegen fix for the broken \`ClientboundPlayRecipeBookAdd*\` / \`ClientboundPlayCraftRecipeResponse*\` structs (currently dead code, replaced by the typed equivalents).

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --tests --bins --examples --all-features -- -D warnings\`
- [x] \`cargo test --workspace --all-features\` → 1066 passed
- [x] \`cargo llvm-cov --fail-under-lines 90\` → 92.23% global
- [x] **Coverage on new files**: \`recipe_display.rs\` 92%, \`recipe_book.rs\` (core) 98%, \`recipe.rs\` (api) 100%, \`recipe_book.rs\` (server) 93%.
- [x] **Tests added**: 17 (protocol type round-trips incl. recursive cases + IDSet variants), 8 (KnownRecipes), 5 (events + 3 RecipeContext path tests), 10 (server: 3 to_display + 5 unlock/lock/join + 2 ghost recipe).
- [ ] **Manual smoke test**: connect a 1.21.4 client, verify the recipe book opens cleanly. Write a tiny test plugin that registers a custom shaped recipe via \`RecipeRegistrar\` and calls \`ctx.recipes().unlock(&id, UnlockReason::InitialJoin)\` on join — verify the recipe appears, click it, verify the ghost preview shows in the grid.

Part of #166