### PR TITLE
feat(server): recipe-book Phase 2 — auto-fill grid on Place Recipe

### DIFF
--- a/crates/basalt-api/src/events/crafting.rs
+++ b/crates/basalt-api/src/events/crafting.rs
@@ -211,6 +211,47 @@ pub struct RecipeLockedEvent {
 }
 crate::game_event!(RecipeLockedEvent);
 
+/// A player is about to auto-fill a recipe from the recipe book
+/// (cancellable).
+///
+/// Fired at the **Validate** stage on the **game** bus after the
+/// server has resolved the recipe and pre-checked that the player's
+/// inventory has enough ingredients, but **before** any item is
+/// moved. Cancelling the event aborts the auto-fill — the grid stays
+/// untouched and `RecipeBookFilledEvent` is not dispatched. Plugins
+/// use it for permission gating (admin-only recipes, anti-grief
+/// rate-limits, gated unlocks).
+///
+/// The crafting player is available via `ctx.player()`.
+#[derive(Debug, Clone)]
+pub struct RecipeBookFillRequestEvent {
+    /// Stable identifier of the recipe the player clicked.
+    pub recipe_id: RecipeId,
+    /// Whether the player shift-clicked (asking for the largest
+    /// possible batch). The Phase 2 server implementation always
+    /// behaves as if `false` — `true` is plumbed through but
+    /// silently degrades for now (Phase 3 will add real stacking).
+    pub make_all: bool,
+    /// Whether this event has been cancelled by a Validate handler.
+    pub cancelled: bool,
+}
+crate::game_cancellable_event!(RecipeBookFillRequestEvent);
+
+/// A player auto-filled a recipe from the recipe book.
+///
+/// Fired at the **Post** stage on the **game** bus after the
+/// inventory has been drained and the grid populated. The standard
+/// match cycle (`CraftingRecipeMatchedEvent` etc.) has already run
+/// at this point, so `ctx.player()`'s grid reflects the new state.
+#[derive(Debug, Clone)]
+pub struct RecipeBookFilledEvent {
+    /// Stable identifier of the filled recipe.
+    pub recipe_id: RecipeId,
+    /// Whether the original request was a shift-click.
+    pub make_all: bool,
+}
+crate::game_event!(RecipeBookFilledEvent);
+
 #[cfg(test)]
 mod tests {
     use basalt_events::{BusKind, Event, EventRouting};
@@ -367,5 +408,40 @@ mod tests {
         assert!(!event.is_cancelled());
         assert_eq!(event.recipe_id.path, "expired");
         assert_eq!(RecipeLockedEvent::BUS, BusKind::Game);
+    }
+
+    #[test]
+    fn fill_request_cancellation() {
+        let mut event = RecipeBookFillRequestEvent {
+            recipe_id: RecipeId::vanilla("oak_planks"),
+            make_all: false,
+            cancelled: false,
+        };
+        assert!(!event.is_cancelled());
+        event.cancel();
+        assert!(event.is_cancelled());
+        assert_eq!(RecipeBookFillRequestEvent::BUS, BusKind::Game);
+    }
+
+    #[test]
+    fn fill_request_carries_make_all() {
+        let event = RecipeBookFillRequestEvent {
+            recipe_id: RecipeId::vanilla("oak_planks"),
+            make_all: true,
+            cancelled: false,
+        };
+        assert!(event.make_all);
+    }
+
+    #[test]
+    fn filled_carries_id_and_make_all() {
+        let mut event = RecipeBookFilledEvent {
+            recipe_id: RecipeId::vanilla("crafting_table"),
+            make_all: false,
+        };
+        // not cancellable
+        event.cancel();
+        assert!(!event.is_cancelled());
+        assert_eq!(RecipeBookFilledEvent::BUS, BusKind::Game);
     }
 }

--- a/crates/basalt-api/src/events/mod.rs
+++ b/crates/basalt-api/src/events/mod.rs
@@ -22,8 +22,8 @@ pub use container::*;
 pub use crafting::{
     CraftingCraftedEvent, CraftingGridChangedEvent, CraftingPreCraftEvent,
     CraftingRecipeClearedEvent, CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
-    RecipeLockedEvent, RecipeRegisterEvent, RecipeRegisteredEvent, RecipeUnlockedEvent,
-    RecipeUnregisteredEvent,
+    RecipeBookFillRequestEvent, RecipeBookFilledEvent, RecipeLockedEvent, RecipeRegisterEvent,
+    RecipeRegisteredEvent, RecipeUnlockedEvent, RecipeUnregisteredEvent,
 };
 pub use player::{PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent};
 

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -91,8 +91,8 @@ pub mod prelude {
         CraftingCraftedEvent, CraftingGridChangedEvent, CraftingPreCraftEvent,
         CraftingRecipeClearedEvent, CraftingRecipeMatchedEvent, CraftingShiftClickBatchEvent,
         DragType, PlayerInteractEvent, PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent,
-        RecipeLockedEvent, RecipeRegisterEvent, RecipeRegisteredEvent, RecipeUnlockedEvent,
-        RecipeUnregisteredEvent, WindowSlotKind,
+        RecipeBookFillRequestEvent, RecipeBookFilledEvent, RecipeLockedEvent, RecipeRegisterEvent,
+        RecipeRegisteredEvent, RecipeUnlockedEvent, RecipeUnregisteredEvent, WindowSlotKind,
     };
 
     // Recipe types referenced by registry-lifecycle events.

--- a/crates/basalt-server/src/game/dispatch.rs
+++ b/crates/basalt-server/src/game/dispatch.rs
@@ -226,8 +226,9 @@ impl GameLoop {
                     uuid,
                     window_id,
                     display_id,
+                    make_all,
                 } => {
-                    self.handle_place_recipe(uuid, window_id, display_id);
+                    self.handle_place_recipe(uuid, window_id, display_id, make_all);
                 }
             }
         }

--- a/crates/basalt-server/src/game/recipe_book.rs
+++ b/crates/basalt-server/src/game/recipe_book.rs
@@ -5,10 +5,15 @@
 //! stonecutter, and smithing displays are placeholders here — those
 //! domains (#138 and follow-ups) construct their own `RecipeDisplay`s.
 
-use basalt_api::events::{RecipeLockedEvent, RecipeUnlockedEvent};
-use basalt_core::components::KnownRecipes;
+use std::collections::HashMap;
+
+use basalt_api::events::{
+    RecipeBookFillRequestEvent, RecipeBookFilledEvent, RecipeLockedEvent, RecipeUnlockedEvent,
+};
+use basalt_core::components::{CraftingGrid, Inventory, KnownRecipes, Position};
 use basalt_core::context::UnlockReason;
 use basalt_ecs::EntityId;
+use basalt_events::Event;
 use basalt_protocol::types::{RecipeBookEntry, RecipeDisplay, SlotDisplay};
 use basalt_recipes::{Recipe, RecipeId};
 use basalt_types::{Slot, Uuid};
@@ -118,27 +123,34 @@ impl GameLoop {
     }
 
     /// Handles `GameInput::PlaceRecipe` (the `Place Recipe` C2S
-    /// packet) by sending a ghost-recipe reply to the player's open
-    /// crafting window.
+    /// packet) — sends a ghost-recipe reply and auto-fills the
+    /// player's crafting grid with the recipe's ingredients.
     ///
-    /// Resolves the protocol's per-player `display_id` to a
-    /// [`RecipeId`] via the player's [`KnownRecipes`] (the reverse
-    /// map is intentionally retained even after lock, so a stale
-    /// click on a freshly-locked recipe still finds the entry), then
-    /// looks the recipe up in the registry, builds a
-    /// [`RecipeDisplay`], and queues a
-    /// [`ServerOutput::SendGhostRecipe`].
+    /// Auto-fill is atomic: it pre-checks that the inventory has all
+    /// required ingredients before mutating anything. If the
+    /// inventory is short, only the ghost reply is sent. Plugins can
+    /// veto a fill at the [`RecipeBookFillRequestEvent`] (Validate)
+    /// stage — the ghost still goes out (purely visual), but no
+    /// items move. Existing grid contents are returned to the
+    /// inventory before placement; if the inventory is full they're
+    /// dropped at the player's feet, mirroring manual click-out.
     ///
-    /// No items are moved on the server in Phase 1 — the ghost is a
-    /// purely visual preview. Auto-fill (the
-    /// `RecipeBookFillRequestEvent` / `RecipeBookFilledEvent` pair)
-    /// is tracked as a follow-up issue.
+    /// `make_all = true` is plumbed through but treated as `false`
+    /// (single craft) for now — multi-craft stacking is a Phase 3
+    /// follow-up.
     pub(super) fn handle_place_recipe(
         &mut self,
         source_uuid: Uuid,
         window_id: i32,
         display_id: i32,
+        make_all: bool,
     ) {
+        if make_all {
+            log::trace!(
+                target: "basalt::recipes",
+                "PlaceRecipe make_all=true degraded to single craft (Phase 3 follow-up)"
+            );
+        }
         let Some(eid) = self.find_by_uuid(source_uuid) else {
             return;
         };
@@ -152,9 +164,136 @@ impl GameLoop {
         let Some(recipe) = self.recipes.find_by_id(&recipe_id) else {
             return;
         };
+
+        // Ghost reply — Phase 1 behaviour, fires whether or not
+        // auto-fill succeeds so the visual preview is reliable.
         let display = to_display(&recipe);
         self.send_to(eid, |tx| {
             let _ = tx.try_send(ServerOutput::SendGhostRecipe { window_id, display });
+        });
+
+        // ── Auto-fill ──────────────────────────────────────
+        let grid_size = self
+            .ecs
+            .get::<CraftingGrid>(eid)
+            .map(|g| g.grid_size)
+            .unwrap_or(2);
+        let Some(plan) = build_placement_plan(&recipe, grid_size) else {
+            return; // Recipe doesn't fit the open grid.
+        };
+        let requirements = aggregate_requirements(&plan);
+
+        let drain = match self.ecs.get::<Inventory>(eid) {
+            Some(inv) => match find_inventory_drain(inv, &requirements) {
+                Some(d) => d,
+                None => return, // Inventory is short — silent abort.
+            },
+            None => return,
+        };
+
+        // Validate hook — plugins can cancel here.
+        let (entity_id, username, yaw, pitch) = self.player_dispatch_args(eid);
+        let ctx = self.make_context(source_uuid, entity_id, &username, yaw, pitch);
+        let mut request_event = RecipeBookFillRequestEvent {
+            recipe_id: recipe_id.clone(),
+            make_all,
+            cancelled: false,
+        };
+        self.dispatch_event(&mut request_event, &ctx);
+        self.process_responses(source_uuid, &ctx.drain_responses());
+        if request_event.is_cancelled() {
+            return;
+        }
+
+        // Snapshot the existing grid so we can return its contents
+        // to the inventory after the drain.
+        let grid_capacity = (grid_size as usize) * (grid_size as usize);
+        let returns: Vec<Slot> = self
+            .ecs
+            .get::<CraftingGrid>(eid)
+            .map(|g| {
+                (0..grid_capacity)
+                    .filter_map(|i| {
+                        let s = &g.slots[i];
+                        if s.item_id.is_some() {
+                            Some(s.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Drain the inventory and re-insert returns. Returns that
+        // don't fit overflow into the world as dropped items.
+        let mut overflow: Vec<Slot> = Vec::new();
+        if let Some(inv) = self.ecs.get_mut::<Inventory>(eid) {
+            for (inv_slot, dec) in &drain {
+                let s = &mut inv.slots[*inv_slot];
+                s.item_count -= *dec;
+                if s.item_count <= 0 {
+                    *s = Slot::empty();
+                }
+            }
+            for slot in returns {
+                let item_id = slot.item_id.expect("filtered to non-empty above");
+                if inv.try_insert(item_id, slot.item_count).is_none() {
+                    overflow.push(slot);
+                }
+            }
+        }
+        if !overflow.is_empty() {
+            let (px, py, pz) = self
+                .ecs
+                .get::<Position>(eid)
+                .map(|p| (p.x as i32, p.y as i32, p.z as i32))
+                .unwrap_or((0, 0, 0));
+            for slot in overflow {
+                if let Some(item_id) = slot.item_id {
+                    self.spawn_item_entity(px, py + 1, pz, item_id, slot.item_count);
+                }
+            }
+        }
+
+        // Apply placements: clear unused grid slots first so any
+        // leftovers from the previous match don't linger.
+        if let Some(grid) = self.ecs.get_mut::<CraftingGrid>(eid) {
+            for i in 0..grid_capacity {
+                grid.slots[i] = Slot::empty();
+            }
+            for (grid_idx, item_id) in &plan {
+                grid.slots[*grid_idx] = Slot::new(*item_id, 1);
+            }
+        }
+
+        // Sync — full inventory window items + grid slots, then run
+        // the match cycle so the result slot lights up.
+        self.sync_full_inventory(eid);
+        self.sync_crafting_grid_to_client(eid);
+        self.run_crafting_match_cycle(source_uuid, eid);
+
+        // Post hook — plugins observe the completed fill.
+        let mut filled_event = RecipeBookFilledEvent {
+            recipe_id,
+            make_all,
+        };
+        self.dispatch_event(&mut filled_event, &ctx);
+        self.process_responses(source_uuid, &ctx.drain_responses());
+    }
+
+    /// Sends every inventory slot to the client.
+    ///
+    /// Used after an auto-fill to make sure both the player-inventory
+    /// window and the open container window (if any) reflect the new
+    /// state, since the auto-fill may touch many slots at once.
+    fn sync_full_inventory(&self, eid: EntityId) {
+        let Some(inv) = self.ecs.get::<Inventory>(eid) else {
+            return;
+        };
+        let slots = inv.to_protocol_slots();
+        self.send_to(eid, |tx| {
+            let _ = tx.try_send(ServerOutput::SyncInventory { slots });
         });
     }
 
@@ -254,6 +393,90 @@ fn slot_for_pattern(slot: &Option<i32>) -> SlotDisplay {
     }
 }
 
+/// Builds the placement plan for auto-fill: a list of
+/// `(grid_index, item_id)` pairs in row-major order.
+///
+/// Shaped recipes are placed top-left aligned in the target grid.
+/// Returns `None` when the recipe doesn't fit the open grid (e.g.
+/// a 3-wide recipe in a 2x2 inventory grid, or a shapeless recipe
+/// with more ingredients than the grid has slots).
+pub(super) fn build_placement_plan(recipe: &Recipe, grid_size: u8) -> Option<Vec<(usize, i32)>> {
+    let g = grid_size as usize;
+    match recipe {
+        Recipe::Shaped(r) => {
+            if r.width as usize > g || r.height as usize > g {
+                return None;
+            }
+            let mut plan = Vec::new();
+            for row in 0..(r.height as usize) {
+                for col in 0..(r.width as usize) {
+                    let pat_idx = row * (r.width as usize) + col;
+                    if let Some(item_id) = r.pattern[pat_idx] {
+                        let grid_idx = row * g + col;
+                        plan.push((grid_idx, item_id));
+                    }
+                }
+            }
+            Some(plan)
+        }
+        Recipe::Shapeless(r) => {
+            if r.ingredients.len() > g * g {
+                return None;
+            }
+            Some(
+                r.ingredients
+                    .iter()
+                    .enumerate()
+                    .map(|(i, item_id)| (i, *item_id))
+                    .collect(),
+            )
+        }
+    }
+}
+
+/// Aggregates a placement plan into `(item_id, total_count)` pairs
+/// so the inventory drain can be sized correctly per ingredient.
+pub(super) fn aggregate_requirements(plan: &[(usize, i32)]) -> Vec<(i32, i32)> {
+    let mut by_id: HashMap<i32, i32> = HashMap::new();
+    for (_, item_id) in plan {
+        *by_id.entry(*item_id).or_insert(0) += 1;
+    }
+    by_id.into_iter().collect()
+}
+
+/// Greedy search for a way to drain the inventory to satisfy the
+/// given `(item_id, total_count)` requirements.
+///
+/// Walks hotbar (internal slots 0..9) then main (9..36), reserving
+/// counts from matching stacks. Returns `Some(drain_plan)` when the
+/// requirement is fully sourced, `None` otherwise. The drain plan is
+/// `(internal_slot, decrement_count)` — apply each pair to the
+/// inventory.
+pub(super) fn find_inventory_drain(
+    inv: &Inventory,
+    requirements: &[(i32, i32)],
+) -> Option<Vec<(usize, i32)>> {
+    let mut drain = Vec::new();
+    for (item_id, total_needed) in requirements {
+        let mut remaining = *total_needed;
+        for slot_idx in (0..9).chain(9..36) {
+            if remaining == 0 {
+                break;
+            }
+            let slot = &inv.slots[slot_idx];
+            if slot.item_id == Some(*item_id) && slot.item_count > 0 {
+                let take = slot.item_count.min(remaining);
+                drain.push((slot_idx, take));
+                remaining -= take;
+            }
+        }
+        if remaining > 0 {
+            return None;
+        }
+    }
+    Some(drain)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,6 +551,236 @@ mod tests {
             }
             _ => panic!("expected CraftingShapeless"),
         }
+    }
+
+    #[test]
+    fn placement_plan_shaped_top_left_aligned_in_3x3() {
+        // 1×2 stick recipe (one column, two rows) placed at top-left
+        // of a 3x3 crafting-table grid → indices 0 (row 0, col 0) and 3 (row 1, col 0).
+        let r = shaped(1, 2, vec![Some(43), Some(43)]);
+        let plan = build_placement_plan(&r, 3).expect("fits");
+        assert_eq!(plan, vec![(0, 43), (3, 43)]);
+    }
+
+    #[test]
+    fn placement_plan_shaped_skips_pattern_holes() {
+        // Asymmetric 2x2 with one empty slot in the corner.
+        let r = shaped(2, 2, vec![Some(1), Some(2), Some(3), None]);
+        let plan = build_placement_plan(&r, 3).expect("fits");
+        // Row 0: indices 0, 1 → (0, 1), (1, 2)
+        // Row 1: indices 3, 4 → (3, 3), and the None is skipped.
+        assert_eq!(plan, vec![(0, 1), (1, 2), (3, 3)]);
+    }
+
+    #[test]
+    fn placement_plan_shaped_3x3_in_2x2_returns_none() {
+        let r = shaped(3, 3, vec![Some(1); 9]);
+        assert_eq!(build_placement_plan(&r, 2), None);
+    }
+
+    #[test]
+    fn placement_plan_shapeless_walks_slots_in_order() {
+        let r = shapeless(vec![10, 20, 30]);
+        let plan = build_placement_plan(&r, 3).expect("fits");
+        assert_eq!(plan, vec![(0, 10), (1, 20), (2, 30)]);
+    }
+
+    #[test]
+    fn placement_plan_shapeless_too_many_ingredients_returns_none() {
+        // 5 ingredients can't fit in a 2x2 grid (4 slots).
+        let r = shapeless(vec![1, 2, 3, 4, 5]);
+        assert_eq!(build_placement_plan(&r, 2), None);
+    }
+
+    #[test]
+    fn aggregate_requirements_counts_each_item() {
+        let plan = vec![(0, 43), (1, 43), (3, 43), (4, 879)];
+        let mut req = aggregate_requirements(&plan);
+        req.sort_by_key(|(id, _)| *id);
+        assert_eq!(req, vec![(43, 3), (879, 1)]);
+    }
+
+    #[test]
+    fn drain_finds_single_slot_with_enough_count() {
+        let mut inv = basalt_core::Inventory::empty();
+        inv.slots[0] = Slot::new(43, 8);
+        let plan = find_inventory_drain(&inv, &[(43, 3)]).expect("sufficient");
+        assert_eq!(plan, vec![(0, 3)]);
+    }
+
+    #[test]
+    fn drain_splits_across_slots_when_needed() {
+        let mut inv = basalt_core::Inventory::empty();
+        inv.slots[0] = Slot::new(43, 2);
+        inv.slots[5] = Slot::new(43, 4);
+        let plan = find_inventory_drain(&inv, &[(43, 5)]).expect("sufficient");
+        // Hotbar 0 (2) is fully drained, then hotbar 5 contributes 3.
+        assert_eq!(plan, vec![(0, 2), (5, 3)]);
+    }
+
+    #[test]
+    fn drain_returns_none_when_inventory_short() {
+        let mut inv = basalt_core::Inventory::empty();
+        inv.slots[0] = Slot::new(43, 2);
+        assert_eq!(find_inventory_drain(&inv, &[(43, 3)]), None);
+    }
+
+    #[test]
+    fn drain_handles_mixed_ingredients() {
+        let mut inv = basalt_core::Inventory::empty();
+        inv.slots[0] = Slot::new(43, 4); // 4 oak planks
+        inv.slots[10] = Slot::new(879, 2); // 2 sticks (in main inventory range)
+        let plan = find_inventory_drain(&inv, &[(43, 2), (879, 1)]).expect("sufficient");
+        assert!(plan.contains(&(0, 2)));
+        assert!(plan.contains(&(10, 1)));
+    }
+
+    /// End-to-end auto-fill: 2 oak planks in hotbar slot 0 produce a
+    /// stick recipe (1×2 oak planks → 4 sticks) when the player
+    /// clicks it in the book. The grid lights up and the inventory
+    /// is drained.
+    #[test]
+    fn auto_fill_stick_recipe_drains_inventory_and_fills_grid() {
+        use basalt_recipes::{OwnedShapedRecipe, RecipeId};
+        use basalt_types::Uuid;
+
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        // Stick recipe: 1×2 oak planks → 4 sticks. id 1234 is unused
+        // by vanilla so we can register it cleanly.
+        let recipe_id = RecipeId::new("plugin", "test_sticks");
+        let recipes =
+            std::sync::Arc::get_mut(&mut game_loop.recipes).expect("registry is unique here");
+        recipes.add_shaped(OwnedShapedRecipe {
+            id: recipe_id.clone(),
+            width: 1,
+            height: 2,
+            pattern: vec![Some(43), Some(43)],
+            result_id: 879,
+            result_count: 4,
+        });
+        game_loop.unlock_recipe(uuid, recipe_id.clone(), UnlockReason::Manual);
+
+        // Stock the player with 2 oak planks in hotbar slot 0.
+        let eid = game_loop.find_by_uuid(uuid).unwrap();
+        if let Some(inv) = game_loop.ecs.get_mut::<Inventory>(eid) {
+            inv.slots[0] = Slot::new(43, 2);
+        }
+        while rx.try_recv().is_ok() {}
+
+        let display_id = game_loop
+            .ecs
+            .get::<KnownRecipes>(eid)
+            .and_then(|k| k.display_id(&recipe_id))
+            .unwrap();
+        game_loop.handle_place_recipe(uuid, 0, display_id, false);
+
+        let grid = game_loop.ecs.get::<CraftingGrid>(eid).unwrap();
+        // 2x2 player-inventory grid: slot 0 + slot 2 (row 0, col 0 / row 1, col 0).
+        assert_eq!(grid.slots[0].item_id, Some(43));
+        assert_eq!(grid.slots[2].item_id, Some(43));
+        assert!(grid.slots[1].is_empty());
+        assert!(grid.slots[3].is_empty());
+        assert_eq!(grid.output.item_id, Some(879));
+        assert_eq!(grid.output.item_count, 4);
+
+        let inv = game_loop.ecs.get::<Inventory>(eid).unwrap();
+        assert!(inv.slots[0].is_empty(), "hotbar slot 0 should be drained");
+    }
+
+    /// When the player has no matching ingredients the auto-fill
+    /// silently aborts — no grid mutation, no events fired beyond
+    /// the ghost reply.
+    #[test]
+    fn auto_fill_aborts_silently_with_empty_inventory() {
+        use basalt_recipes::{OwnedShapedRecipe, RecipeId};
+        use basalt_types::Uuid;
+
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let recipe_id = RecipeId::new("plugin", "test_sticks");
+        let recipes =
+            std::sync::Arc::get_mut(&mut game_loop.recipes).expect("registry is unique here");
+        recipes.add_shaped(OwnedShapedRecipe {
+            id: recipe_id.clone(),
+            width: 1,
+            height: 2,
+            pattern: vec![Some(43), Some(43)],
+            result_id: 879,
+            result_count: 4,
+        });
+        game_loop.unlock_recipe(uuid, recipe_id.clone(), UnlockReason::Manual);
+        while rx.try_recv().is_ok() {}
+
+        let eid = game_loop.find_by_uuid(uuid).unwrap();
+        let display_id = game_loop
+            .ecs
+            .get::<KnownRecipes>(eid)
+            .and_then(|k| k.display_id(&recipe_id))
+            .unwrap();
+        game_loop.handle_place_recipe(uuid, 0, display_id, false);
+
+        let grid = game_loop.ecs.get::<CraftingGrid>(eid).unwrap();
+        assert!(grid.slots[0].is_empty(), "grid should not be filled");
+        assert!(grid.output.is_empty(), "no recipe matched");
+    }
+
+    /// Existing grid contents are returned to the inventory before
+    /// the auto-fill places its own ingredients.
+    #[test]
+    fn auto_fill_returns_existing_grid_contents_to_inventory() {
+        use basalt_recipes::{OwnedShapedRecipe, RecipeId};
+        use basalt_types::Uuid;
+
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let recipe_id = RecipeId::new("plugin", "test_sticks");
+        let recipes =
+            std::sync::Arc::get_mut(&mut game_loop.recipes).expect("registry is unique here");
+        recipes.add_shaped(OwnedShapedRecipe {
+            id: recipe_id.clone(),
+            width: 1,
+            height: 2,
+            pattern: vec![Some(43), Some(43)],
+            result_id: 879,
+            result_count: 4,
+        });
+        game_loop.unlock_recipe(uuid, recipe_id.clone(), UnlockReason::Manual);
+
+        // Stock the player with 2 oak planks AND seed the grid with
+        // an unrelated diamond (id 56). After the fill, the diamond
+        // should be back in the inventory.
+        let eid = game_loop.find_by_uuid(uuid).unwrap();
+        if let Some(inv) = game_loop.ecs.get_mut::<Inventory>(eid) {
+            inv.slots[0] = Slot::new(43, 2);
+        }
+        if let Some(grid) = game_loop.ecs.get_mut::<CraftingGrid>(eid) {
+            grid.slots[1] = Slot::new(56, 1);
+        }
+        while rx.try_recv().is_ok() {}
+
+        let display_id = game_loop
+            .ecs
+            .get::<KnownRecipes>(eid)
+            .and_then(|k| k.display_id(&recipe_id))
+            .unwrap();
+        game_loop.handle_place_recipe(uuid, 0, display_id, false);
+
+        let inv = game_loop.ecs.get::<Inventory>(eid).unwrap();
+        let has_diamond = inv
+            .slots
+            .iter()
+            .any(|s| s.item_id == Some(56) && s.item_count == 1);
+        assert!(
+            has_diamond,
+            "the pre-existing diamond should have been returned to the inventory"
+        );
     }
 
     /// End-to-end test: unlock_recipe mutates KnownRecipes and queues
@@ -468,7 +921,7 @@ mod tests {
         while rx.try_recv().is_ok() {}
 
         // Display id 0 was assigned by KnownRecipes::unlock above.
-        game_loop.handle_place_recipe(uuid, 0, 0);
+        game_loop.handle_place_recipe(uuid, 0, 0, false);
 
         let mut saw_ghost = false;
         while let Ok(out) = rx.try_recv() {
@@ -493,7 +946,7 @@ mod tests {
         let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
         while rx.try_recv().is_ok() {}
 
-        game_loop.handle_place_recipe(uuid, 0, 9999);
+        game_loop.handle_place_recipe(uuid, 0, 9999, false);
 
         let saw_ghost = std::iter::from_fn(|| rx.try_recv().ok())
             .any(|o| matches!(o, crate::messages::ServerOutput::SendGhostRecipe { .. }));
@@ -525,6 +978,68 @@ mod tests {
         assert!(
             found,
             "expected RecipeBookAdd {{ replace: true, entries: [] }} on join"
+        );
+    }
+
+    /// A Validate-stage handler that cancels `RecipeBookFillRequestEvent`
+    /// blocks the auto-fill — the inventory is untouched and the grid
+    /// stays empty. The ghost reply still goes out (purely visual).
+    #[test]
+    fn auto_fill_validate_cancellation_blocks_inventory_drain() {
+        use basalt_api::events::RecipeBookFillRequestEvent;
+        use basalt_recipes::{OwnedShapedRecipe, RecipeId};
+        use basalt_types::Uuid;
+
+        let (mut game_loop, game_tx, _io_rx) = super::super::tests::test_game_loop();
+
+        // Register a Validate handler that cancels every fill.
+        game_loop
+            .bus
+            .on::<RecipeBookFillRequestEvent, basalt_api::context::ServerContext>(
+                basalt_events::Stage::Validate,
+                0,
+                |event, _| event.cancel(),
+            );
+
+        let uuid = Uuid::from_bytes([1; 16]);
+        let mut rx = super::super::tests::connect_player(&mut game_loop, &game_tx, uuid, 1);
+
+        let recipe_id = RecipeId::new("plugin", "test_sticks");
+        let recipes =
+            std::sync::Arc::get_mut(&mut game_loop.recipes).expect("registry is unique here");
+        recipes.add_shaped(OwnedShapedRecipe {
+            id: recipe_id.clone(),
+            width: 1,
+            height: 2,
+            pattern: vec![Some(43), Some(43)],
+            result_id: 879,
+            result_count: 4,
+        });
+        game_loop.unlock_recipe(uuid, recipe_id.clone(), UnlockReason::Manual);
+
+        let eid = game_loop.find_by_uuid(uuid).unwrap();
+        if let Some(inv) = game_loop.ecs.get_mut::<Inventory>(eid) {
+            inv.slots[0] = Slot::new(43, 2);
+        }
+        while rx.try_recv().is_ok() {}
+
+        let display_id = game_loop
+            .ecs
+            .get::<KnownRecipes>(eid)
+            .and_then(|k| k.display_id(&recipe_id))
+            .unwrap();
+        game_loop.handle_place_recipe(uuid, 0, display_id, false);
+
+        let grid = game_loop.ecs.get::<CraftingGrid>(eid).unwrap();
+        assert!(
+            grid.slots[0].is_empty(),
+            "cancellation should leave grid empty"
+        );
+
+        let inv = game_loop.ecs.get::<Inventory>(eid).unwrap();
+        assert_eq!(
+            inv.slots[0].item_count, 2,
+            "cancellation should preserve the planks"
         );
     }
 }

--- a/crates/basalt-server/src/messages.rs
+++ b/crates/basalt-server/src/messages.rs
@@ -161,8 +161,9 @@ pub enum GameInput {
         action_id: i32,
     },
     /// Player clicked a recipe in their book — the client expects
-    /// a `CraftRecipeResponse` (ghost recipe) reply showing the
-    /// ingredient layout in the open crafting window.
+    /// a `CraftRecipeResponse` (ghost recipe) reply and the
+    /// ingredients to be moved from the inventory into the crafting
+    /// grid (auto-fill).
     PlaceRecipe {
         /// UUID of the requesting player.
         uuid: Uuid,
@@ -170,6 +171,10 @@ pub enum GameInput {
         window_id: i32,
         /// Per-player numeric `display_id` of the chosen recipe.
         display_id: i32,
+        /// Whether the player shift-clicked (asks for the largest
+        /// possible batch). The current Phase 2 implementation
+        /// degrades this to a single craft.
+        make_all: bool,
     },
 }
 

--- a/crates/basalt-server/src/net/play_handler.rs
+++ b/crates/basalt-server/src/net/play_handler.rs
@@ -260,12 +260,13 @@ pub(super) async fn handle_packet(
             });
         }
 
-        // -- Game loop: place recipe (ghost preview) --
+        // -- Game loop: place recipe (ghost preview + auto-fill) --
         ServerboundPlayPacket::CraftRecipeRequest(req) => {
             let _ = game_tx.send(GameInput::PlaceRecipe {
                 uuid,
                 window_id: req.window_id,
                 display_id: req.recipe_id,
+                make_all: req.make_all,
             });
         }
 


### PR DESCRIPTION
## Summary

Closes #166. Phase 2 of the recipe book — clicking a recipe in the book now actually fills the crafting grid.

- 2 new events on the game bus: \`RecipeBookFillRequestEvent\` (Validate, cancellable) and \`RecipeBookFilledEvent\` (Post). Both carry the \`make_all\` flag so plugins can distinguish shift-click from single-click intent.
- Auto-fill is **atomic**: the server pre-checks that the recipe fits the open grid (2x2 inventory or 3x3 crafting table) and that the inventory has every ingredient before mutating anything. If either check fails, only the Phase 1 ghost reply is sent.
- Existing grid contents are returned to the inventory via \`Inventory::try_insert\` before placement. If the inventory is full, leftovers overflow into the world as dropped item entities — same behaviour as a manual click-out.
- Plugins veto fills at \`RecipeBookFillRequestEvent\` (Validate) — the ghost still goes out (visual feedback) but no items move and \`Filled\` is not dispatched.
- After placement the standard match cycle (\`run_crafting_match_cycle\`) re-runs so \`CraftingRecipeMatchedEvent\` fires as usual, then \`RecipeBookFilledEvent\` (Post) closes the loop.
- \`make_all=true\` (shift-click in the book) is plumbed all the way through (\`GameInput::PlaceRecipe.make_all\`, both events) but the server-side handler currently degrades it to a single craft. Multi-craft stacking is tracked as a Phase 3 follow-up issue.

## Implementation notes

Three pure helpers in \`game/recipe_book.rs\` keep the layout logic unit-testable:

- \`build_placement_plan(recipe, grid_size) -> Option<Vec<(grid_idx, item_id)>>\` — top-left aligned for shaped, sequential for shapeless. Returns \`None\` when the recipe doesn't fit.
- \`aggregate_requirements(plan) -> Vec<(item_id, total_count)>\` — counts duplicates so the drain is sized per ingredient.
- \`find_inventory_drain(inv, requirements) -> Option<Vec<(slot, decrement)>>\` — greedy hotbar-then-main scan; returns \`None\` if the inventory is short.

The full inventory + grid are re-synced via \`SyncInventory\` and \`sync_crafting_grid_to_client\` after the mutation. No fine-grained per-slot diffing — the auto-fill touches enough slots that a bulk sync is simpler and there's no observable difference at 20 TPS.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --tests --bins --examples --all-features -- -D warnings\`
- [x] \`cargo test --workspace --all-features\` → 1083 passed
- [x] \`cargo llvm-cov --fail-under-lines 90\` → 92.27% global; \`game/recipe_book.rs\` 94.29%
- [x] **Tests added (17)**: 5 unit on \`build_placement_plan\` (shaped fits 3x3 / shaped 3x3 in 2x2 → None / shaped holes / shapeless walk / shapeless overflow → None), 1 on \`aggregate_requirements\`, 4 on \`find_inventory_drain\`, 4 server-side via \`test_game_loop\` (auto-fill drains inventory, empty inventory → silent abort, returns existing grid contents, Validate cancellation preserves state), 3 on the new events (cancellation, make_all carrying, BUS == Game).
- [ ] **Manual smoke test**: connect a 1.21.4 client. Register a custom recipe via \`RecipeRegistrar\`, unlock it on join via \`ctx.recipes().unlock(...)\`. Open a crafting table. Click the recipe in the book → ingredients appear in the grid + result slot lights up. Right-click with empty inventory → only the ghost preview appears (no items moved). Write a Validate handler that cancels \`RecipeBookFillRequestEvent\` for one specific id → that recipe never auto-fills, others do.

## Out of scope

- **\`make_all=true\` proper stacking**: each slot fills to the largest count that lets the player craft multiple results at once. Tracked as Phase 3.
- Persistence of \`KnownRecipes\` to disk.
- Real recipe paths (\`minecraft:oak_planks\` instead of synthetic \`shaped_<n>\` ids).

Closes #166