### PR TITLE
feat(protocol): cache encoded registry data payloads at first use

### DIFF
--- a/crates/basalt-protocol/src/registry_data.rs
+++ b/crates/basalt-protocol/src/registry_data.rs
@@ -17,10 +17,43 @@
 //! - `minecraft:jukebox_song` — music disc definitions
 //! - `minecraft:instrument` — goat horn instrument definitions
 
+use std::sync::OnceLock;
+
 use crate::packets::configuration::{
     ClientboundConfigurationRegistryData, ClientboundConfigurationRegistryDataEntries,
 };
 use basalt_types::nbt::{NbtCompound, NbtTag};
+use basalt_types::{Encode, EncodedSize};
+
+/// Returns the pre-encoded payloads of every default registry packet,
+/// suitable for direct write via a `RawSlice`-style wrapper.
+///
+/// `build_default_registries` produces identical content for every
+/// login (six static registries: dimension type, biome, damage type,
+/// painting variant, wolf variant, chat type), so encoding it fresh
+/// per connection is pure waste — most visible on cold-start mass
+/// joins. This function encodes each registry once on first call,
+/// caches the byte vectors in a `OnceLock`, and returns the slice
+/// for every subsequent caller. The packet ID is unchanged across
+/// payloads (`ClientboundConfigurationRegistryData::PACKET_ID`); the
+/// caller frames each slice with that id.
+///
+/// Order matches `build_default_registries` exactly — keeping the
+/// cache and the builder bytewise comparable in tests.
+pub fn cached_registry_payloads() -> &'static [Vec<u8>] {
+    static CACHE: OnceLock<Vec<Vec<u8>>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        build_default_registries()
+            .into_iter()
+            .map(|reg| {
+                let mut buf = Vec::with_capacity(reg.encoded_size());
+                reg.encode(&mut buf)
+                    .expect("registry data encoding cannot fail");
+                buf
+            })
+            .collect()
+    })
+}
 
 /// Builds all required registry data packets for the Configuration state.
 ///
@@ -685,7 +718,6 @@ fn build_chat_type_registry() -> ClientboundConfigurationRegistryData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use basalt_types::{Encode, EncodedSize};
 
     #[test]
     fn build_all_registries() {
@@ -756,5 +788,34 @@ mod tests {
                 reg.id
             );
         }
+    }
+
+    #[test]
+    fn cached_payloads_match_freshly_built() {
+        let cached = cached_registry_payloads();
+        let built: Vec<Vec<u8>> = build_default_registries()
+            .into_iter()
+            .map(|reg| {
+                let mut buf = Vec::with_capacity(reg.encoded_size());
+                reg.encode(&mut buf).unwrap();
+                buf
+            })
+            .collect();
+        assert_eq!(cached.len(), built.len(), "cached entry count mismatch");
+        for (i, (c, b)) in cached.iter().zip(built.iter()).enumerate() {
+            assert_eq!(c, b, "cached payload {i} differs from freshly encoded");
+        }
+    }
+
+    #[test]
+    fn cached_payloads_returns_same_storage_across_calls() {
+        // Two consecutive calls must hand back the same backing slice —
+        // proves the OnceLock is hit instead of rebuilding on every call.
+        let first = cached_registry_payloads();
+        let second = cached_registry_payloads();
+        assert!(
+            std::ptr::eq(first.as_ptr(), second.as_ptr()),
+            "cached_registry_payloads must return the same storage on repeat calls"
+        );
     }
 }

--- a/crates/basalt-server/src/net/connection.rs
+++ b/crates/basalt-server/src/net/connection.rs
@@ -15,11 +15,12 @@ use basalt_protocol::packets::login::{ClientboundLoginSuccess, ServerboundLoginP
 use basalt_protocol::packets::status::{
     ClientboundStatusPing, ClientboundStatusServerInfo, ServerboundStatusPacket,
 };
-use basalt_protocol::registry_data::build_default_registries;
+use basalt_protocol::registry_data::cached_registry_payloads;
 use basalt_types::Uuid;
 use dashmap::DashMap;
 use tokio::sync::{broadcast, mpsc};
 
+use crate::helpers::RawSlice;
 use crate::messages::{GameInput, ServerOutput};
 use crate::net::channels::player_output_channel;
 use crate::state::ServerState;
@@ -174,10 +175,14 @@ async fn handle_configuration(
     let skin_task =
         tokio::spawn(async move { crate::net::skin::fetch_skin_properties(&skin_username).await });
 
-    let registries = build_default_registries();
-    for reg in &registries {
-        conn.write_packet_typed(ClientboundConfigurationRegistryData::PACKET_ID, reg)
-            .await?;
+    // Registry payloads are identical across logins; encode once at
+    // first call, write the cached bytes per connection.
+    for payload in cached_registry_payloads() {
+        conn.write_packet_typed(
+            ClientboundConfigurationRegistryData::PACKET_ID,
+            &RawSlice(payload),
+        )
+        .await?;
     }
 
     let conn = conn.finish_configuration().await?;


### PR DESCRIPTION
## Summary

- Adds `cached_registry_payloads() -> &'static [Vec<u8>]` in `basalt-protocol`. Encodes each of the six default registries (`dimension_type`, `biome`, `damage_type`, `painting_variant`, `wolf_variant`, `chat_type`) once on first call via `OnceLock`, then returns the byte vectors for every subsequent caller.
- Updates `handle_configuration` in `basalt-server` to write each cached payload via `RawSlice` instead of re-encoding per login.
- Wire output is byte-for-byte identical (validated by existing e2e login tests).

Closes #174.

## Why

`build_default_registries()` produces identical content for every login — there's no per-player customization. Re-encoding it from in-memory NBT structures on every connection is pure waste, most visible on cold-start mass joins. With this PR the encoding cost is paid exactly once per process lifetime.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace` — 1098 passed (1096 baseline + 2 new)
- [x] `cargo llvm-cov --all-features --fail-under-lines 90 --ignore-filename-regex "(examples|packets/|xtask/src/recipes\.rs|basalt-recipes/src/generated\.rs)"` — 90.79% lines
- [x] New unit test `cached_payloads_match_freshly_built` — bytewise compare cache vs `build_default_registries() + encode`
- [x] New unit test `cached_payloads_returns_same_storage_across_calls` — proves the `OnceLock` is hit on repeat calls
- [x] Existing e2e `e2e_server_login_and_configuration` validates the cached bytes still decode correctly client-side

## Notes

- Scope is intentionally narrow: only the Configuration-state registry data. A general `ServerOutput::Static` variant for the Play state was discussed in #174 but is out of scope here — it would need wiring through the per-player output channel and is best handled in its own PR.
- `build_default_registries()` stays public — several internal tests still call it for structural assertions, and external tools (e.g. test fixtures) may rely on it.
