### PR TITLE
perf(net): packet-write benchmarks for buffer pool decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
             crate: basalt-world
           - bench: ecs
             crate: basalt-ecs
+          - bench: write_packet
+            crate: basalt-net
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/crates/basalt-net/Cargo.toml
+++ b/crates/basalt-net/Cargo.toml
@@ -18,3 +18,6 @@ log = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[bench]]
+name = "write_packet"

--- a/crates/basalt-net/benches/write_packet.rs
+++ b/crates/basalt-net/benches/write_packet.rs
@@ -1,0 +1,136 @@
+//! Baseline benchmarks for the outbound packet-write hot path
+//! (issue #175, Phase 1).
+//!
+//! `framing::write_raw_packet` allocates a fresh `Vec<u8>` per call.
+//! These benches replicate the synchronous alloc + encode pattern
+//! verbatim so the allocator signal is not masked by tokio runtime
+//! overhead — the goal is to decide whether a buffer pool would
+//! actually help, not to measure TCP throughput.
+//!
+//! The single-packet benches cover four representative payload sizes
+//! (20 B / 28 B / 256 B / 10 KB). The burst benches run a tick's worth
+//! of packets in a single iteration to surface allocator amortization
+//! effects. The `prealloc` reference bench reuses one `Vec` across
+//! iterations — the delta against the fresh-alloc bench is the upper
+//! bound on what a pool can deliver.
+
+#![feature(test)]
+extern crate test;
+
+use test::{Bencher, black_box};
+
+use basalt_types::{Encode, EncodedSize, VarInt};
+
+/// Frame a single packet exactly as `framing::write_raw_packet` does:
+/// VarInt frame length, VarInt packet id, then payload bytes.
+#[inline(always)]
+fn write_one_packet(packet_id: i32, payload: &[u8]) -> Vec<u8> {
+    let id_varint = VarInt(packet_id);
+    let frame_length = id_varint.encoded_size() + payload.len();
+    let mut buf = Vec::with_capacity(VarInt(frame_length as i32).encoded_size() + frame_length);
+    VarInt(frame_length as i32).encode(&mut buf).unwrap();
+    id_varint.encode(&mut buf).unwrap();
+    buf.extend_from_slice(payload);
+    buf
+}
+
+// -- Single-packet allocation cost -----------------------------------
+
+#[bench]
+fn write_packet_block_change(b: &mut Bencher) {
+    let payload = vec![0xBBu8; 20];
+    b.iter(|| {
+        let buf = write_one_packet(black_box(0x09), black_box(&payload));
+        black_box(buf);
+    });
+}
+
+#[bench]
+fn write_packet_movement(b: &mut Bencher) {
+    let payload = vec![0xAAu8; 28];
+    b.iter(|| {
+        let buf = write_one_packet(black_box(0x2E), black_box(&payload));
+        black_box(buf);
+    });
+}
+
+#[bench]
+fn write_packet_chat(b: &mut Bencher) {
+    let payload = vec![0xCCu8; 256];
+    b.iter(|| {
+        let buf = write_one_packet(black_box(0x6C), black_box(&payload));
+        black_box(buf);
+    });
+}
+
+#[bench]
+fn write_packet_chunk(b: &mut Bencher) {
+    let payload = vec![0xDDu8; 10_240];
+    b.iter(|| {
+        let buf = write_one_packet(black_box(0x27), black_box(&payload));
+        black_box(buf);
+    });
+}
+
+// -- Burst (one tick's worth of packets) -----------------------------
+
+#[bench]
+fn write_packet_burst_50_movement(b: &mut Bencher) {
+    let payload = vec![0xAAu8; 28];
+    b.iter(|| {
+        for _ in 0..50 {
+            let buf = write_one_packet(black_box(0x2E), black_box(&payload));
+            black_box(buf);
+        }
+    });
+}
+
+#[bench]
+fn write_packet_burst_200_mixed(b: &mut Bencher) {
+    let movement = vec![0xAAu8; 28];
+    let block_change = vec![0xBBu8; 20];
+    let chat = vec![0xCCu8; 256];
+    let chunk = vec![0xDDu8; 10_240];
+    b.iter(|| {
+        for _ in 0..150 {
+            let buf = write_one_packet(black_box(0x2E), black_box(&movement));
+            black_box(buf);
+        }
+        for _ in 0..30 {
+            let buf = write_one_packet(black_box(0x09), black_box(&block_change));
+            black_box(buf);
+        }
+        for _ in 0..15 {
+            let buf = write_one_packet(black_box(0x6C), black_box(&chat));
+            black_box(buf);
+        }
+        for _ in 0..5 {
+            let buf = write_one_packet(black_box(0x27), black_box(&chunk));
+            black_box(buf);
+        }
+    });
+}
+
+// -- Pool-ceiling reference ------------------------------------------
+//
+// Same logical work as `write_packet_movement`, but the buffer is
+// reused across iterations (cleared instead of dropped). The gap
+// between this bench and `write_packet_movement` is the maximum
+// improvement an ideal buffer pool could deliver — without writing
+// the pool itself. If the gap is below 10% the issue's threshold,
+// Phase 2 should not ship.
+
+#[bench]
+fn write_packet_prealloc_movement(b: &mut Bencher) {
+    let payload = vec![0xAAu8; 28];
+    let id_varint = VarInt(0x2E);
+    let frame_length = id_varint.encoded_size() + payload.len();
+    let mut buf = Vec::with_capacity(VarInt(frame_length as i32).encoded_size() + frame_length);
+    b.iter(|| {
+        buf.clear();
+        VarInt(frame_length as i32).encode(&mut buf).unwrap();
+        id_varint.encode(&mut buf).unwrap();
+        buf.extend_from_slice(black_box(&payload));
+        black_box(&buf);
+    });
+}


### PR DESCRIPTION
## Summary

Phase 1 of issue #175. Adds 7 libtest benchmarks to `basalt-net` measuring the synchronous alloc+encode pattern from `framing::write_raw_packet`. No source-code changes — this PR is measurement only. Phase 2 (buffer pool implementation) is gated on the ≥ 10% improvement threshold defined in the issue.

Files:
- `crates/basalt-net/benches/write_packet.rs` — 7 bench functions
- `crates/basalt-net/Cargo.toml` — `[[bench]] name = "write_packet"` entry
- `.github/workflows/ci.yml` — matrix entry for nightly bench job

Closes #175 Phase 1.

## Method

Each bench replicates `framing.rs:87-98` verbatim (`Vec::with_capacity` + two `VarInt::encode` + `extend_from_slice`). Sync extraction was chosen over `cargo bench` calling the async `write_raw_packet` to a sink — the goal is isolating allocator pressure, and a tokio runtime would mask the signal. The pool-ceiling reference (`write_packet_prealloc_movement`) reuses one `Vec` across iterations: the gap against `write_packet_movement` is the upper bound on what an ideal pool can deliver.

## Findings

Measured on Apple M-series (`aarch64-apple-darwin`), `rustc nightly`, default allocator. Two runs averaged. CI x86_64 runners will produce different absolute numbers but the ratios should be similar.

### Single-packet allocation cost

| Bench | Payload | ns/iter |
|-------|--------:|--------:|
| `write_packet_block_change` | 20 B | 22.81 |
| `write_packet_movement` | 28 B | 22.11 |
| `write_packet_chat` | 256 B | 30.91 |
| `write_packet_chunk` | 10 KB | 249.42 |

For payloads ≤ 256 B, allocation cost dominates (chat is only 35% slower than movement despite 9× the payload). For 10 KB, `memcpy` dominates (chunk is 11× slower than chat).

### Pool ceiling (fresh alloc vs reuse)

| Bench | ns/iter | vs fresh |
|-------|--------:|---------:|
| `write_packet_movement` (fresh) | 22.11 | baseline |
| `write_packet_prealloc_movement` (reuse) | 6.48 | **70.7% faster** |

A perfectly recycled buffer eliminates 15.6 ns out of every 22.1 ns spent on the movement path. That's a 3.4× speedup on the dominant broadcast packet.

### Burst behavior

| Bench | ns/iter | ns/packet |
|-------|--------:|----------:|
| `write_packet_burst_50_movement` | 1,158.67 | 23.2 |
| `write_packet_burst_200_mixed` | 5,931.62 | 29.7 |

Per-packet cost stays close to the single-packet number under burst — the allocator's thread-local fast path amortizes well, but it doesn't approach the prealloc ceiling. Pooling would still win at burst scale.

### Go/no-go assessment

- **Pool ceiling on the dominant broadcast (movement): 70.7% improvement**
- Threshold for Phase 2: ≥ 10%
- **Decision: PROCEED with buffer pool implementation as a separate PR**

70% is far above the threshold — this is not a marginal call. The signal is consistent across the small payloads (chat shows similar dominance of alloc cost), and even the 10 KB chunk path would benefit on the alloc portion (the memcpy is unavoidable but the surrounding `Vec::with_capacity` is not).

## Test plan

- [x] `cargo +nightly bench --package basalt-net --bench write_packet` runs and reports stable numbers (variance < 15%, two consecutive runs match within noise)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests -- -D warnings` (bench file's `#![feature(test)]` is excluded — `benches/` is only built by `cargo bench`)
- [x] `cargo test --package basalt-net` — 44 passed (no test added or removed)
- [ ] CI bench job picks up the new matrix entry and posts results to the PR

## Out of scope

- The buffer pool implementation itself — Phase 2 will be a separate PR with this PR's numbers as the baseline
- Async-path benchmarks (tokio runtime, real TCP) — different question
- Allocator comparison (jemalloc vs system) — orthogonal
