### PR TITLE
refactor(net): extract write_buffered helper from Stage 4

### DIFF
--- a/crates/basalt-net/src/stream.rs
+++ b/crates/basalt-net/src/stream.rs
@@ -220,24 +220,28 @@ impl ProtocolStream {
             .map_err(|e| Error::Protocol(basalt_protocol::Error::Type(e)))?;
         self.frame_buf.extend_from_slice(frame_content);
 
-        // Stage 4: encrypted write. Inlines the encryption branch so the
-        // compiler can split the borrow between `&self.frame_buf` and
-        // `&mut self.encrypt_buf` — calling `self.write_all(&self.frame_buf)`
-        // would require `&mut self` whole and conflict with the shared
-        // borrow on `frame_buf`.
+        // Stage 4: encrypted write — delegates to a private helper that
+        // owns `&mut self`, so the borrow on `self.frame_buf` doesn't
+        // conflict at the call site.
+        self.write_buffered().await.map_err(Error::Io)
+    }
+
+    /// Writes the contents of `self.frame_buf` to the wire, encrypting
+    /// through `self.encrypt_buf` if a cipher is active.
+    ///
+    /// Private helper extracted from `write_raw_packet` Stage 4 — kept
+    /// inside `&mut self` so the cipher / encrypt_buf / frame_buf /
+    /// stream borrows resolve as split borrows on disjoint fields.
+    /// Mirrors the dispatch in [`Self::write_all`] but operates on the
+    /// stream-owned buffer rather than an arbitrary `&[u8]`.
+    async fn write_buffered(&mut self) -> std::io::Result<()> {
         if let Some(cipher) = &mut self.cipher {
             self.encrypt_buf.clear();
             self.encrypt_buf.extend_from_slice(&self.frame_buf);
             cipher.encrypt(&mut self.encrypt_buf);
-            self.stream
-                .write_all(&self.encrypt_buf)
-                .await
-                .map_err(Error::Io)
+            self.stream.write_all(&self.encrypt_buf).await
         } else {
-            self.stream
-                .write_all(&self.frame_buf)
-                .await
-                .map_err(Error::Io)
+            self.stream.write_all(&self.frame_buf).await
         }
     }
 


### PR DESCRIPTION
## Summary

Pure refactor — extracts the inlined cipher branch from `ProtocolStream::write_raw_packet` Stage 4 into a private `write_buffered(&mut self)` helper that operates directly on `self.frame_buf`. The borrow checker's earlier complaint (calling `self.write_all(&self.frame_buf)` requiring `&mut self` whole vs the shared borrow on `frame_buf`) is sidestepped by moving the work into a `&mut self` method that owns the field accesses internally.

Closes #181.

## Why

PR #180 (Phase 2 of #175) shipped with a known wart: ~10 lines of cipher-or-plain branching in `write_raw_packet` Stage 4 duplicated the logic of the public `write_all` method. The duplication was flagged in the PR's own review notes ("wart de code que je signale"). This PR cleans it up.

The diff is byte-equivalent on the wire — pure structural refactor.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --package basalt-net` — 44 passed (no test added/removed; the existing 8 `stream.rs::tests` cover both encrypted and plain write paths)
- [x] `cargo test --workspace` — 1098 passed, 13 ignored
- [x] `cargo llvm-cov` — 90.80% lines

## Notes

- `write_buffered` is private. The public `write_all(&mut self, data: &[u8])` stays unchanged for callers that need to write arbitrary slices (it predates the buffer refactor).
- Both methods now share the same cipher dispatch logic structurally; if a future refactor wants to deduplicate further, a tiny shared inner helper would close the loop. Left for now — the duplication between `write_all` and `write_buffered` is two short branches over different source slices.
