### PR TITLE
perf(net): pool read frame buffer to eliminate per-packet alloc

### DIFF
--- a/crates/basalt-net/src/stream.rs
+++ b/crates/basalt-net/src/stream.rs
@@ -47,6 +47,12 @@ pub struct ProtocolStream<W = TcpStream> {
     /// (`VarInt(frame_length)` + frame content). Same lifecycle as
     /// `packet_buf`.
     frame_buf: Vec<u8>,
+    /// Reusable read-side staging buffer for the raw decrypted frame
+    /// (post-VarInt-length-prefix, pre-decompression). Cleared and
+    /// resized on every `read_raw_packet` call — eliminates the
+    /// per-packet `vec![0u8; length]` allocation that mirrored the
+    /// pre-#180 write-side waste.
+    read_buf: Vec<u8>,
 }
 
 impl<W> ProtocolStream<W> {
@@ -61,6 +67,7 @@ impl<W> ProtocolStream<W> {
             packet_buf: Vec::new(),
             compressed_buf: Vec::new(),
             frame_buf: Vec::new(),
+            read_buf: Vec::new(),
         }
     }
 
@@ -168,19 +175,25 @@ impl<W: AsyncReadExt + AsyncWriteExt + Unpin> ProtocolStream<W> {
             });
         }
 
-        // Read full frame (decrypted transparently)
-        let mut frame = vec![0u8; length];
-        self.read_exact(&mut frame).await.map_err(Error::Io)?;
+        // Read full frame into the pooled buffer (decrypted transparently).
+        self.read_buffered(length).await.map_err(Error::Io)?;
 
-        // Decompress if compression is enabled
-        let data = if self.compression_threshold.is_some() {
-            compression::decompress_packet(&frame)?
+        // Decompress if compression is enabled. The compression branch
+        // still allocates inside `decompress_packet`; pooling it would
+        // require a `decompress_packet_into` mirror — separate concern,
+        // out of scope for this PR (issue #183 covers the frame buffer
+        // only). The `decompressed` storage binding lives in the outer
+        // scope so `data: &[u8]` can refer into either buffer.
+        let decompressed: Vec<u8>;
+        let data: &[u8] = if self.compression_threshold.is_some() {
+            decompressed = compression::decompress_packet(&self.read_buf)?;
+            &decompressed
         } else {
-            frame
+            &self.read_buf
         };
 
         // Extract packet ID
-        let mut cursor = data.as_slice();
+        let mut cursor = data;
         let packet_id = VarInt::decode(&mut cursor)
             .map_err(|e| Error::Protocol(basalt_protocol::Error::Type(e)))?;
 
@@ -188,6 +201,23 @@ impl<W: AsyncReadExt + AsyncWriteExt + Unpin> ProtocolStream<W> {
             id: packet_id.0,
             payload: cursor.to_vec(),
         }))
+    }
+
+    /// Reads exactly `length` bytes into the pooled `read_buf`,
+    /// decrypting in place if encryption is active.
+    ///
+    /// Private mirror of [`Self::write_buffered`] — extracted so the
+    /// borrow on `self.read_buf` and the `&mut self` access in
+    /// `self.stream.read_exact` can resolve as split borrows on
+    /// disjoint fields.
+    async fn read_buffered(&mut self, length: usize) -> std::io::Result<()> {
+        self.read_buf.clear();
+        self.read_buf.resize(length, 0);
+        self.stream.read_exact(&mut self.read_buf).await?;
+        if let Some(cipher) = &mut self.cipher {
+            cipher.decrypt(&mut self.read_buf);
+        }
+        Ok(())
     }
 
     /// Writes a single VarInt length-prefixed packet, with optional


### PR DESCRIPTION
## Summary

Mirrors the write-path pooling from #175 Phase 2 (PR #180) on the read side. Adds a `read_buf: Vec<u8>` field to `ProtocolStream` and refactors `read_raw_packet` to clear+resize+read into the pooled buffer instead of allocating fresh for every received packet.

Files:
- `crates/basalt-net/src/stream.rs` — new `read_buf` field, init in `new()`, new private `read_buffered(length)` helper, refactored `read_raw_packet` body.

Closes #183.

## Why

`ProtocolStream::read_raw_packet` allocated a fresh `Vec<u8>` for every received packet (`let mut frame = vec![0u8; length];` at the previous `stream.rs:172`). Length can be up to 2 MB. At ~50 players × ~20 inbound packets/s, that's ~1000 allocations/s on the read hot path — the symmetric counterpart of the write-path waste fixed by PR #180.

The pattern is the exact mirror: clear+resize the field, read into it, decrypt in place. Same `read_buffered(&mut self, length: usize)` helper as the write side's `write_buffered` to keep the borrow on `self.read_buf` and the `&mut self.stream` access on disjoint-field paths the borrow checker resolves.

## What stays out of scope

- `compression::decompress_packet` still allocates internally on the compressed branch. Pooling that would mirror #180's `compress_packet_into` extraction (mechanical change, single field) but is **deliberately deferred**: this PR keeps issue #183's stated scope tight to the wire-frame allocation.
- `RawPacket::payload`'s `cursor.to_vec()` allocation stays. Eliminating it would require changing `RawPacket` to borrow from the stream (lifetime-bound, breaks async dispatch) or switching to a callback-based read API. That's a separate redesign tracked elsewhere.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --package basalt-net` — 44 passed (existing 8 `stream.rs::tests` cover encrypted + plain read paths)
- [x] `cargo test --workspace` — 1098 passed, 13 ignored
- [x] `cargo llvm-cov` — 90.79% lines (≥ 90%)

The change is byte-equivalent on the wire — pure structural refactor of the read buffer's lifecycle. Existing roundtrip tests (encrypted, compressed, large packets) all still pass.

## Notes

- The compression branch uses a `let decompressed: Vec<u8>; let data: &[u8] = if … { decompressed = …; &decompressed } else { &self.read_buf };` binding pattern so a single downstream cursor can refer into either the pooled buffer or the freshly-decompressed Vec. Borrow-checker-friendly without an `Owned`/`Borrowed` wrapper.
- `read_buffered` is the read-side mirror of `write_buffered` introduced by PR #185.
