### PR TITLE
feat(api,server): raw packet pre-dispatch hook + inbound rate limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "basalt-command",
  "basalt-core",
  "basalt-events",
+ "basalt-protocol",
  "basalt-recipes",
  "basalt-types",
  "basalt-world",

--- a/crates/basalt-api/Cargo.toml
+++ b/crates/basalt-api/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 basalt-core = { workspace = true }
 basalt-command = { workspace = true }
 basalt-events = { workspace = true }
+basalt-protocol = { workspace = true }
 basalt-types = { workspace = true }
 basalt-world = { workspace = true }
 basalt-recipes = { workspace = true }

--- a/crates/basalt-api/src/events/mod.rs
+++ b/crates/basalt-api/src/events/mod.rs
@@ -14,6 +14,7 @@ mod block;
 mod chat;
 mod container;
 mod crafting;
+mod packet;
 mod player;
 
 pub use block::{BlockBrokenEvent, BlockPlacedEvent, PlayerInteractEvent};
@@ -25,6 +26,7 @@ pub use crafting::{
     RecipeBookFillRequestEvent, RecipeBookFilledEvent, RecipeLockedEvent, RecipeRegisterEvent,
     RecipeRegisteredEvent, RecipeUnlockedEvent, RecipeUnregisteredEvent,
 };
+pub use packet::RawPacketEvent;
 pub use player::{PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent};
 
 /// Implements [`Event`](basalt_events::Event) and

--- a/crates/basalt-api/src/events/packet.rs
+++ b/crates/basalt-api/src/events/packet.rs
@@ -1,0 +1,81 @@
+//! Raw serverbound packet events — pre-dispatch hook for plugins
+//! that operate at the wire layer (anti-cheat, telemetry, packet
+//! logging, custom protocol gateways).
+
+use basalt_protocol::packets::play::ServerboundPlayPacket;
+
+/// Fires before a serverbound Play packet is dispatched to its
+/// domain handler. Cancelling drops the packet — no further
+/// processing in the net task or the game loop.
+///
+/// Runs on the **instant** event bus, on the per-player net task
+/// thread, before chat / command dispatch and before forwarding to
+/// the game loop. Cancellation is the only side-effect plugins
+/// should perform here; mutating the carried packet has no effect
+/// on subsequent dispatch (the original is consumed by the handler
+/// path independently).
+///
+/// Plugins typically match `event.packet` to detect a specific
+/// packet type and inspect its fields:
+///
+/// ```text
+/// match &event.packet {
+///     ServerboundPlayPacket::BlockDig(d) => {
+///         if too_far(d.location) { event.cancelled = true; }
+///     }
+///     _ => {}
+/// }
+/// ```
+///
+/// The packet is owned (cloned at dispatch time) so plugins can
+/// stash it for later inspection without lifetime gymnastics.
+#[derive(Debug, Clone)]
+pub struct RawPacketEvent {
+    /// The decoded serverbound packet about to be dispatched.
+    pub packet: ServerboundPlayPacket,
+    /// Set to `true` to drop the packet.
+    pub cancelled: bool,
+}
+crate::instant_cancellable_event!(RawPacketEvent);
+
+#[cfg(test)]
+mod tests {
+    use basalt_events::Event;
+    use basalt_protocol::packets::play::ServerboundPlayPacket;
+    use basalt_protocol::packets::play::misc::ServerboundPlayKeepAlive;
+
+    use super::*;
+
+    #[test]
+    fn raw_packet_event_cancellation() {
+        let mut event = RawPacketEvent {
+            packet: ServerboundPlayPacket::KeepAlive(ServerboundPlayKeepAlive {
+                keep_alive_id: 42,
+            }),
+            cancelled: false,
+        };
+        assert!(!event.is_cancelled());
+        event.cancel();
+        assert!(event.is_cancelled());
+    }
+
+    #[test]
+    fn raw_packet_event_routes_to_instant_bus() {
+        use basalt_events::{BusKind, EventRouting};
+        assert_eq!(RawPacketEvent::BUS, BusKind::Instant);
+    }
+
+    #[test]
+    fn raw_packet_event_downcast_roundtrip() {
+        let mut event = RawPacketEvent {
+            packet: ServerboundPlayPacket::KeepAlive(ServerboundPlayKeepAlive { keep_alive_id: 7 }),
+            cancelled: false,
+        };
+        let any = event.as_any_mut();
+        let concrete = any.downcast_mut::<RawPacketEvent>().unwrap();
+        assert!(matches!(
+            &concrete.packet,
+            ServerboundPlayPacket::KeepAlive(ka) if ka.keep_alive_id == 7
+        ));
+    }
+}

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -51,6 +51,16 @@ pub mod types {
 /// World access: block states, collision, block entities, chunk storage.
 pub use basalt_world as world;
 
+/// Wire-level protocol packet definitions, exposed for plugins that
+/// need raw packet inspection (anti-cheat, telemetry, packet logging).
+///
+/// Most plugins should listen to domain events
+/// ([`events::BlockBrokenEvent`], [`events::PlayerMovedEvent`], …)
+/// rather than reaching into packet structs directly. The packets
+/// module is here for the cases where the wire-level shape matters —
+/// e.g. inspecting [`events::RawPacketEvent::packet`].
+pub use basalt_protocol::packets;
+
 // Top-level re-exports for non-prelude usage.
 pub use basalt_events::{Event, EventBus, Stage};
 pub use context::{Response, ServerContext};

--- a/crates/basalt-server/src/config.rs
+++ b/crates/basalt-server/src/config.rs
@@ -75,6 +75,13 @@ pub struct ServerSection {
     /// to defend against malformed values and unbounded server-side burst.
     /// Default: 100.0.
     pub chunk_batch_max_rate: f32,
+    /// Maximum inbound packets per second per player. Exceeding the
+    /// budget kicks the connection (DoS mitigation). Vanilla caps
+    /// game-relevant traffic at ~400/sec (20 packets/tick × 20 TPS);
+    /// 1000 leaves comfortable headroom for chunk-batch ACKs and
+    /// other low-frequency control packets without being trivially
+    /// abusable. Default: 1000.
+    pub max_inbound_packets_per_second: u32,
     /// Performance tuning.
     pub performance: PerformanceSection,
     /// Per-system CPU budget overrides (milliseconds per tick).
@@ -259,6 +266,7 @@ impl Default for ServerSection {
             persistence_interval_seconds: 30,
             chunk_batch_initial_rate: 25.0,
             chunk_batch_max_rate: 100.0,
+            max_inbound_packets_per_second: 1000,
             performance: PerformanceSection::default(),
             budgets: BudgetsSection::default(),
         }
@@ -470,6 +478,22 @@ chunk_batch_max_rate = 50.0
         let config: ServerConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.server.chunk_batch_initial_rate, 12.5);
         assert_eq!(config.server.chunk_batch_max_rate, 50.0);
+    }
+
+    #[test]
+    fn default_inbound_rate_limit() {
+        let config = ServerConfig::default();
+        assert_eq!(config.server.max_inbound_packets_per_second, 1000);
+    }
+
+    #[test]
+    fn parse_inbound_rate_limit() {
+        let toml = r#"
+[server]
+max_inbound_packets_per_second = 250
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.server.max_inbound_packets_per_second, 250);
     }
 
     #[test]

--- a/crates/basalt-server/src/lib.rs
+++ b/crates/basalt-server/src/lib.rs
@@ -82,7 +82,11 @@ impl Server {
         let world = Arc::new(self.config.create_world());
         let plugins = self.config.create_plugins();
         let (server_state, instant_bus, game_bus, plugin_systems, recipes) =
-            ServerState::build_for_loops(Arc::clone(&world), plugins);
+            ServerState::build_for_loops(
+                Arc::clone(&world),
+                plugins,
+                self.config.server.max_inbound_packets_per_second,
+            );
 
         // Initialize rayon thread pool for parallel ECS system dispatch
         let system_threads = self.config.server.performance.system_threads.unwrap_or(0);

--- a/crates/basalt-server/src/net/connection.rs
+++ b/crates/basalt-server/src/net/connection.rs
@@ -233,6 +233,7 @@ async fn handle_configuration(
             world,
             chunk_cache,
             command_args: state.command_args.clone(),
+            max_inbound_packets_per_second: state.max_inbound_packets_per_second,
         },
         output_rx,
     )

--- a/crates/basalt-server/src/net/play_handler.rs
+++ b/crates/basalt-server/src/net/play_handler.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use basalt_api::context::{Response, ServerContext};
-use basalt_api::events::{ChatMessageEvent, CommandEvent};
+use basalt_api::events::{ChatMessageEvent, CommandEvent, RawPacketEvent};
 use basalt_core::PlayerInfo;
 use basalt_core::components::Rotation;
 use basalt_events::EventBus;
@@ -47,6 +47,45 @@ pub(super) async fn handle_packet(
     last_keep_alive_id: &mut i64,
     last_keep_alive_sent: &Instant,
 ) -> crate::error::Result<()> {
+    // Pre-dispatch hook — fire `RawPacketEvent` so plugins (anti-cheat,
+    // telemetry, packet logging) can inspect or cancel the packet
+    // before any domain logic runs. Cancellation drops the packet.
+    let raw_ctx = ServerContext::new(
+        Arc::clone(world),
+        PlayerInfo {
+            uuid,
+            entity_id,
+            username: username.to_string(),
+            rotation: Rotation {
+                yaw: 0.0,
+                pitch: 0.0,
+            },
+            position: basalt_core::Position {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+        },
+    );
+    let mut raw_event = RawPacketEvent {
+        packet: packet.clone(),
+        cancelled: false,
+    };
+    if let Err(panic) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        instant_bus.dispatch(&mut raw_event, &raw_ctx);
+    })) {
+        let msg = panic
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| panic.downcast_ref::<String>().map(|s| s.as_str()))
+            .unwrap_or("unknown panic");
+        log::error!(target: "basalt::net_task", "[{addr}] Plugin handler panicked on RawPacketEvent: {msg}");
+    }
+    if raw_event.cancelled {
+        log::trace!(target: "basalt::net_task", "[{addr}] {username} packet cancelled by plugin");
+        return Ok(());
+    }
+
     match packet {
         // -- Keep-alive: inline --
         ServerboundPlayPacket::KeepAlive(ka) => {

--- a/crates/basalt-server/src/net/task.rs
+++ b/crates/basalt-server/src/net/task.rs
@@ -47,6 +47,9 @@ pub(crate) struct NetTaskConfig {
     pub chunk_cache: Arc<ChunkPacketCache>,
     /// Command metadata for tab-complete and /help.
     pub command_args: Vec<CommandMeta>,
+    /// Maximum inbound packets per second per player.
+    /// Exceeding kicks the connection (DoS mitigation).
+    pub max_inbound_packets_per_second: u32,
 }
 
 /// Runs the per-player net task until disconnect.
@@ -69,6 +72,7 @@ pub(crate) async fn run_net_task(
     // and the bytes flow through `ServerOutput::RawBorrowed`.
     let _chunk_cache = config.chunk_cache;
     let command_args = config.command_args;
+    let max_inbound_packets_per_second = config.max_inbound_packets_per_second;
 
     let mut broadcast_rx = broadcast_tx.subscribe();
     let mut keep_alive = tokio::time::interval(std::time::Duration::from_secs(15));
@@ -76,6 +80,12 @@ pub(crate) async fn run_net_task(
 
     let mut last_keep_alive_id: i64 = 0;
     let mut last_keep_alive_sent = Instant::now();
+
+    // Inbound rate limit — sliding 1-second window; if more than
+    // `max_inbound_packets_per_second` packets land in the window,
+    // the connection is dropped on the next received packet.
+    let mut packet_window_start = Instant::now();
+    let mut packet_count_in_window: u32 = 0;
 
     loop {
         tokio::select! {
@@ -99,6 +109,21 @@ pub(crate) async fn run_net_task(
             result = conn.read_packet() => {
                 match result {
                     Ok(packet) => {
+                        // Rate limit check: reset the window every second,
+                        // count each inbound packet, kick if over budget.
+                        if packet_window_start.elapsed() >= std::time::Duration::from_secs(1) {
+                            packet_window_start = Instant::now();
+                            packet_count_in_window = 0;
+                        }
+                        packet_count_in_window = packet_count_in_window.saturating_add(1);
+                        if packet_count_in_window > max_inbound_packets_per_second {
+                            log::warn!(
+                                target: "basalt::net_task",
+                                "[{addr}] {username} kicked: inbound rate limit exceeded ({packet_count_in_window} packets in <1s, max {max_inbound_packets_per_second})",
+                            );
+                            break;
+                        }
+
                         if let ServerboundPlayPacket::TabComplete(tc) = &packet {
                             play_handler::handle_tab_complete(&mut conn, &command_args, tc).await?;
                             continue;

--- a/crates/basalt-server/src/state.rs
+++ b/crates/basalt-server/src/state.rs
@@ -28,6 +28,10 @@ pub(crate) struct ServerState {
     pub declare_commands: Vec<u8>,
     /// Command arg metadata for TabComplete suggestions.
     pub command_args: Vec<CommandMeta>,
+    /// Maximum inbound packets per second per player. Threading
+    /// through to each net task on connection setup so the rate
+    /// limit can be tuned via `basalt.toml`.
+    pub max_inbound_packets_per_second: u32,
 }
 
 /// Command metadata for TabComplete suggestions.
@@ -53,6 +57,7 @@ impl ServerState {
     pub fn build_for_loops(
         world: Arc<basalt_world::World>,
         plugins: Vec<Box<dyn basalt_api::Plugin>>,
+        max_inbound_packets_per_second: u32,
     ) -> (
         Arc<Self>,
         EventBus,
@@ -146,6 +151,7 @@ impl ServerState {
             world,
             declare_commands: declare_commands.0,
             command_args,
+            max_inbound_packets_per_second,
         });
 
         (state, instant_bus, game_bus, systems, recipes)
@@ -413,7 +419,7 @@ mod tests {
         let world = Arc::new(config.create_world());
         let plugins = config.create_plugins();
         let (state, _instant_bus, _game_bus, _systems, _recipes) =
-            ServerState::build_for_loops(world, plugins);
+            ServerState::build_for_loops(world, plugins, 1000);
         state
     }
 


### PR DESCRIPTION
## Summary

Two follow-ups from the inbound-design comparison done while shipping #188 — a pre-dispatch hook for plugins that operate at the wire layer, and a per-player rate limit that mitigates inbound flood attacks. Both are independent additions to the net-task handling pipeline.

## What changes

### 1. `RawPacketEvent` (cancellable, instant bus)

Fires in `play_handler::handle_packet` before any chat / command / game-loop dispatch. Plugins can match on `event.packet` (the typed `ServerboundPlayPacket`) and set `event.cancelled = true` to drop the packet.

```rust
match &event.packet {
    ServerboundPlayPacket::BlockDig(d) => {
        if too_far(d.location, player_pos) {
            event.cancelled = true;  // anti-cheat
        }
    }
    _ => {}
}
```

`basalt-api` now depends on `basalt-protocol` and re-exports the packets module via `basalt_api::packets`, so plugins can pattern-match on the wire-level enum without adding the dep manually. Most plugins still listen to domain events (`BlockBrokenEvent`, `PlayerMovedEvent`, …); this is for cases where the wire shape itself matters.

The clone cost on dispatch is one shallow memcpy per inbound packet — negligible vs the encode/decode work the packet has already gone through.

### 2. Per-player inbound rate limit (DoS mitigation)

Each net task tracks a sliding 1-second window of inbound packet counts and kicks the connection if the count exceeds `max_inbound_packets_per_second` (default 1000). Vanilla 1.21.4 caps game-relevant traffic at ~400/sec (20 packets/tick × 20 TPS); 1000 leaves comfortable headroom for chunk-batch ACKs and other low-frequency control packets without being trivially abusable.

Configurable per-deployment via `basalt.toml`:

```toml
[server]
max_inbound_packets_per_second = 250
```

When the cap trips, the net task logs a `warn!` and breaks out of its select loop, dropping the TCP connection.

## Threading

`ServerConfig.server.max_inbound_packets_per_second` → `ServerState.max_inbound_packets_per_second` → `NetTaskConfig.max_inbound_packets_per_second` → the net task's select-loop TCP read branch.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace` — 1103 passed (1098 baseline + 5 new: 3 RawPacketEvent struct/dispatch tests in `basalt-api`, 2 config parse tests for `max_inbound_packets_per_second`)
- [x] `cargo llvm-cov` — 90.81% lines (≥ 90%)
- [x] e2e tests through TCP loopback exercise the full inbound path with the new hook firing on every received packet — no regressions

## Why no e2e for cancellation / kick

Both behaviors are tail-cases on the inbound path:
- `RawPacketEvent` cancellation: requires registering a test plugin that drops packets, then asserting downstream side-effects didn't fire. The unit tests cover the event's struct + bus routing; the actual cancel-and-skip logic is a single early `return` in `handle_packet` — straightforward.
- Rate limit kick: requires sustained packet flooding plus timing assertions. Flaky in CI. The window logic (reset after 1s, counter increment, kick on overflow) is ~10 lines of straightforward code.

If a regression slips through here it would surface immediately on a real client (cancellation: no plugin observes packets) or a synthetic flood (rate limit: connection stays alive past the cap).

## Out of scope

- Per-packet-type quotas (different caps for movement vs chat vs block-place) — current design is a single global cap. Refining is a follow-up if real abuse patterns warrant.
- Bounded queue with per-tick draining (Minestom-style `PLAYER_PACKET_PER_TICK`) — would require sharing tick boundaries with the net task. Per-second window is the simplest equivalent.
- Plugin API for typed sub-events (`OnBlockDigPacket`, etc.) — kept the surface narrow with the single `RawPacketEvent`; per-type events would explode the API. Plugins match in their handler.
