### PR TITLE
refactor(api): redesign WorldContext as typed methods (5/8)

### DIFF
--- a/crates/basalt-api/src/context/mod.rs
+++ b/crates/basalt-api/src/context/mod.rs
@@ -97,6 +97,39 @@ pub trait ChatContext {
 pub trait WorldContext {
     /// Returns a reference to the world (chunks, blocks, persistence).
     fn world(&self) -> &basalt_world::World;
+
+    /// Returns the block state at the given position.
+    ///
+    /// Generates or loads the chunk if it is not cached. Returns 0
+    /// (air) for positions outside the valid Y range.
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16;
+
+    /// Sets a block state at the given position.
+    ///
+    /// Generates or loads the chunk if it is not cached. Marks the
+    /// containing chunk as dirty for persistence.
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16);
+
+    /// Returns a cloned block entity at the given position, if any.
+    fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<basalt_world::block_entity::BlockEntity>;
+
+    /// Sets a block entity at the given position.
+    fn set_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        entity: basalt_world::block_entity::BlockEntity,
+    );
+
+    /// Marks a chunk as dirty so the persistence system flushes it.
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32);
+
     /// Sends a block action acknowledgement to the current player.
     fn send_block_ack(&self, sequence: i32);
     /// Streams chunks around the given chunk coordinates.

--- a/crates/basalt-api/src/context/mod.rs
+++ b/crates/basalt-api/src/context/mod.rs
@@ -95,9 +95,6 @@ pub trait ChatContext {
 
 /// World access: blocks, chunks, persistence.
 pub trait WorldContext {
-    /// Returns a reference to the world (chunks, blocks, persistence).
-    fn world(&self) -> &basalt_world::World;
-
     /// Returns the block state at the given position.
     ///
     /// Generates or loads the chunk if it is not cached. Returns 0

--- a/crates/basalt-api/src/context/world.rs
+++ b/crates/basalt-api/src/context/world.rs
@@ -7,9 +7,6 @@ use super::ServerContext;
 use super::response::Response;
 
 impl WorldContext for ServerContext {
-    fn world(&self) -> &basalt_world::World {
-        &self.world
-    }
     fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
         self.world.get_block(x, y, z)
     }

--- a/crates/basalt-api/src/context/world.rs
+++ b/crates/basalt-api/src/context/world.rs
@@ -10,6 +10,32 @@ impl WorldContext for ServerContext {
     fn world(&self) -> &basalt_world::World {
         &self.world
     }
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
+        self.world.get_block(x, y, z)
+    }
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
+        self.world.set_block(x, y, z, state);
+    }
+    fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<basalt_world::block_entity::BlockEntity> {
+        self.world.get_block_entity(x, y, z).map(|r| r.clone())
+    }
+    fn set_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        entity: basalt_world::block_entity::BlockEntity,
+    ) {
+        self.world.set_block_entity(x, y, z, entity);
+    }
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
+        self.world.mark_chunk_dirty(cx, cz);
+    }
     fn send_block_ack(&self, sequence: i32) {
         self.responses.push(Response::SendBlockAck { sequence });
     }

--- a/crates/basalt-api/src/system.rs
+++ b/crates/basalt-api/src/system.rs
@@ -20,24 +20,17 @@ pub use crate::components::{EntityId, Phase};
 /// Methods use `TypeId` + `dyn Any` internally. Typed access is
 /// provided via free functions ([`get`], [`get_mut`], [`iter`]).
 pub trait SystemContext {
-    /// Returns a reference to the world for block/collision queries.
-    fn world(&self) -> &basalt_world::World;
-
     /// Returns the block state at the given position.
     ///
     /// Generates or loads the chunk if it is not cached. Returns 0
     /// (air) for positions outside the valid Y range.
-    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
-        self.world().get_block(x, y, z)
-    }
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16;
 
     /// Sets a block state at the given position.
     ///
     /// Generates or loads the chunk if it is not cached. Marks the
     /// containing chunk as dirty for persistence.
-    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
-        self.world().set_block(x, y, z, state);
-    }
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16);
 
     /// Returns a cloned block entity at the given position, if any.
     fn get_block_entity(
@@ -45,9 +38,7 @@ pub trait SystemContext {
         x: i32,
         y: i32,
         z: i32,
-    ) -> Option<basalt_world::block_entity::BlockEntity> {
-        self.world().get_block_entity(x, y, z).map(|r| r.clone())
-    }
+    ) -> Option<basalt_world::block_entity::BlockEntity>;
 
     /// Sets a block entity at the given position.
     fn set_block_entity(
@@ -56,22 +47,16 @@ pub trait SystemContext {
         y: i32,
         z: i32,
         entity: basalt_world::block_entity::BlockEntity,
-    ) {
-        self.world().set_block_entity(x, y, z, entity);
-    }
+    );
 
     /// Marks a chunk as dirty so the persistence system flushes it.
-    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
-        self.world().mark_chunk_dirty(cx, cz);
-    }
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32);
 
     /// Checks if an AABB overlaps any solid block in the world.
     ///
-    /// Delegates to the collision module. Used for ground detection
-    /// and simple overlap tests in physics systems.
-    fn check_overlap(&self, aabb: &crate::world::collision::Aabb) -> bool {
-        crate::world::collision::check_overlap(self.world(), aabb)
-    }
+    /// Used for ground detection and simple overlap tests in
+    /// physics systems.
+    fn check_overlap(&self, aabb: &crate::world::collision::Aabb) -> bool;
 
     /// Casts a ray through the world and returns the first solid block hit.
     ///
@@ -81,9 +66,7 @@ pub trait SystemContext {
         origin: (f64, f64, f64),
         direction: (f64, f64, f64),
         max_distance: f64,
-    ) -> Option<crate::world::collision::RayHit> {
-        crate::world::collision::ray_cast(self.world(), origin, direction, max_distance)
-    }
+    ) -> Option<crate::world::collision::RayHit>;
 
     /// Resolves movement of an AABB against solid blocks.
     ///
@@ -95,9 +78,7 @@ pub trait SystemContext {
         dx: f64,
         dy: f64,
         dz: f64,
-    ) -> (f64, f64, f64) {
-        crate::world::collision::resolve_movement(self.world(), aabb, dx, dy, dz)
-    }
+    ) -> (f64, f64, f64);
 
     /// Spawns a new entity and returns its unique ID.
     fn spawn(&mut self) -> EntityId;

--- a/crates/basalt-api/src/system.rs
+++ b/crates/basalt-api/src/system.rs
@@ -23,6 +23,82 @@ pub trait SystemContext {
     /// Returns a reference to the world for block/collision queries.
     fn world(&self) -> &basalt_world::World;
 
+    /// Returns the block state at the given position.
+    ///
+    /// Generates or loads the chunk if it is not cached. Returns 0
+    /// (air) for positions outside the valid Y range.
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
+        self.world().get_block(x, y, z)
+    }
+
+    /// Sets a block state at the given position.
+    ///
+    /// Generates or loads the chunk if it is not cached. Marks the
+    /// containing chunk as dirty for persistence.
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
+        self.world().set_block(x, y, z, state);
+    }
+
+    /// Returns a cloned block entity at the given position, if any.
+    fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<basalt_world::block_entity::BlockEntity> {
+        self.world().get_block_entity(x, y, z).map(|r| r.clone())
+    }
+
+    /// Sets a block entity at the given position.
+    fn set_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        entity: basalt_world::block_entity::BlockEntity,
+    ) {
+        self.world().set_block_entity(x, y, z, entity);
+    }
+
+    /// Marks a chunk as dirty so the persistence system flushes it.
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
+        self.world().mark_chunk_dirty(cx, cz);
+    }
+
+    /// Checks if an AABB overlaps any solid block in the world.
+    ///
+    /// Delegates to the collision module. Used for ground detection
+    /// and simple overlap tests in physics systems.
+    fn check_overlap(&self, aabb: &crate::world::collision::Aabb) -> bool {
+        crate::world::collision::check_overlap(self.world(), aabb)
+    }
+
+    /// Casts a ray through the world and returns the first solid block hit.
+    ///
+    /// Returns `None` if no solid block is found within `max_distance`.
+    fn ray_cast(
+        &self,
+        origin: (f64, f64, f64),
+        direction: (f64, f64, f64),
+        max_distance: f64,
+    ) -> Option<crate::world::collision::RayHit> {
+        crate::world::collision::ray_cast(self.world(), origin, direction, max_distance)
+    }
+
+    /// Resolves movement of an AABB against solid blocks.
+    ///
+    /// Takes the entity's AABB and desired velocity, returns the
+    /// actual velocity after clamping against solid blocks.
+    fn resolve_movement(
+        &self,
+        aabb: &crate::world::collision::Aabb,
+        dx: f64,
+        dy: f64,
+        dz: f64,
+    ) -> (f64, f64, f64) {
+        crate::world::collision::resolve_movement(self.world(), aabb, dx, dy, dz)
+    }
+
     /// Spawns a new entity and returns its unique ID.
     fn spawn(&mut self) -> EntityId;
 

--- a/crates/basalt-api/src/testing.rs
+++ b/crates/basalt-api/src/testing.rs
@@ -60,6 +60,32 @@ impl WorldContext for NoopContext {
         static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
         WORLD.get_or_init(|| basalt_world::World::new_memory(42))
     }
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
+        self.world().get_block(x, y, z)
+    }
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
+        self.world().set_block(x, y, z, state);
+    }
+    fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<basalt_world::block_entity::BlockEntity> {
+        self.world().get_block_entity(x, y, z).map(|r| r.clone())
+    }
+    fn set_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        entity: basalt_world::block_entity::BlockEntity,
+    ) {
+        self.world().set_block_entity(x, y, z, entity);
+    }
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
+        self.world().mark_chunk_dirty(cx, cz);
+    }
     fn send_block_ack(&self, _sequence: i32) {}
     fn stream_chunks(&self, _cx: i32, _cz: i32) {}
     fn persist_chunk(&self, _cx: i32, _cz: i32) {}

--- a/crates/basalt-api/src/testing.rs
+++ b/crates/basalt-api/src/testing.rs
@@ -55,37 +55,27 @@ impl ChatContext for NoopContext {
 }
 
 impl WorldContext for NoopContext {
-    fn world(&self) -> &basalt_world::World {
-        use std::sync::OnceLock;
-        static WORLD: OnceLock<basalt_world::World> = OnceLock::new();
-        WORLD.get_or_init(|| basalt_world::World::new_memory(42))
+    fn get_block(&self, _x: i32, _y: i32, _z: i32) -> u16 {
+        0
     }
-    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
-        self.world().get_block(x, y, z)
-    }
-    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
-        self.world().set_block(x, y, z, state);
-    }
+    fn set_block(&self, _x: i32, _y: i32, _z: i32, _state: u16) {}
     fn get_block_entity(
         &self,
-        x: i32,
-        y: i32,
-        z: i32,
+        _x: i32,
+        _y: i32,
+        _z: i32,
     ) -> Option<basalt_world::block_entity::BlockEntity> {
-        self.world().get_block_entity(x, y, z).map(|r| r.clone())
+        None
     }
     fn set_block_entity(
         &self,
-        x: i32,
-        y: i32,
-        z: i32,
-        entity: basalt_world::block_entity::BlockEntity,
+        _x: i32,
+        _y: i32,
+        _z: i32,
+        _entity: basalt_world::block_entity::BlockEntity,
     ) {
-        self.world().set_block_entity(x, y, z, entity);
     }
-    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
-        self.world().mark_chunk_dirty(cx, cz);
-    }
+    fn mark_chunk_dirty(&self, _cx: i32, _cz: i32) {}
     fn send_block_ack(&self, _sequence: i32) {}
     fn stream_chunks(&self, _cx: i32, _cz: i32) {}
     fn persist_chunk(&self, _cx: i32, _cz: i32) {}

--- a/crates/basalt-ecs/src/ecs.rs
+++ b/crates/basalt-ecs/src/ecs.rs
@@ -186,7 +186,8 @@ impl Ecs {
 
     /// Sets the world reference for system runners.
     ///
-    /// Must be called before `run_all` if any system uses `ctx.world()`.
+    /// Must be called before `run_all` if any system uses world methods
+    /// (e.g. `ctx.get_block()`, `ctx.resolve_movement()`).
     pub fn set_world(&mut self, world: std::sync::Arc<basalt_world::World>) {
         self.world = Some(world);
     }
@@ -618,11 +619,73 @@ impl Default for Ecs {
     }
 }
 
-impl basalt_api::system::SystemContext for Ecs {
-    fn world(&self) -> &basalt_world::World {
+impl Ecs {
+    /// Returns a reference to the internal world.
+    ///
+    /// Used by the `SystemContext` implementation to delegate typed
+    /// world methods. Panics if `set_world()` was not called.
+    fn world_ref(&self) -> &basalt_world::World {
         self.world
             .as_ref()
-            .expect("Ecs::set_world() must be called before running systems that use ctx.world()")
+            .expect("Ecs::set_world() must be called before running systems")
+    }
+}
+
+impl basalt_api::system::SystemContext for Ecs {
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
+        self.world_ref().get_block(x, y, z)
+    }
+
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
+        self.world_ref().set_block(x, y, z, state);
+    }
+
+    fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<basalt_world::block_entity::BlockEntity> {
+        self.world_ref()
+            .get_block_entity(x, y, z)
+            .map(|r| r.clone())
+    }
+
+    fn set_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        entity: basalt_world::block_entity::BlockEntity,
+    ) {
+        self.world_ref().set_block_entity(x, y, z, entity);
+    }
+
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
+        self.world_ref().mark_chunk_dirty(cx, cz);
+    }
+
+    fn check_overlap(&self, aabb: &basalt_api::world::collision::Aabb) -> bool {
+        basalt_api::world::collision::check_overlap(self.world_ref(), aabb)
+    }
+
+    fn ray_cast(
+        &self,
+        origin: (f64, f64, f64),
+        direction: (f64, f64, f64),
+        max_distance: f64,
+    ) -> Option<basalt_api::world::collision::RayHit> {
+        basalt_api::world::collision::ray_cast(self.world_ref(), origin, direction, max_distance)
+    }
+
+    fn resolve_movement(
+        &self,
+        aabb: &basalt_api::world::collision::Aabb,
+        dx: f64,
+        dy: f64,
+        dz: f64,
+    ) -> (f64, f64, f64) {
+        basalt_api::world::collision::resolve_movement(self.world_ref(), aabb, dx, dy, dz)
     }
 
     fn spawn(&mut self) -> EntityId {

--- a/crates/basalt-ecs/src/parallel.rs
+++ b/crates/basalt-ecs/src/parallel.rs
@@ -94,8 +94,58 @@ impl<'scope> ParallelSystemContext<'scope> {
 }
 
 impl SystemContext for ParallelSystemContext<'_> {
-    fn world(&self) -> &basalt_world::World {
-        self.world
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
+        self.world.get_block(x, y, z)
+    }
+
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
+        self.world.set_block(x, y, z, state);
+    }
+
+    fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<basalt_world::block_entity::BlockEntity> {
+        self.world.get_block_entity(x, y, z).map(|r| r.clone())
+    }
+
+    fn set_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        entity: basalt_world::block_entity::BlockEntity,
+    ) {
+        self.world.set_block_entity(x, y, z, entity);
+    }
+
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
+        self.world.mark_chunk_dirty(cx, cz);
+    }
+
+    fn check_overlap(&self, aabb: &basalt_api::world::collision::Aabb) -> bool {
+        basalt_api::world::collision::check_overlap(self.world, aabb)
+    }
+
+    fn ray_cast(
+        &self,
+        origin: (f64, f64, f64),
+        direction: (f64, f64, f64),
+        max_distance: f64,
+    ) -> Option<basalt_api::world::collision::RayHit> {
+        basalt_api::world::collision::ray_cast(self.world, origin, direction, max_distance)
+    }
+
+    fn resolve_movement(
+        &self,
+        aabb: &basalt_api::world::collision::Aabb,
+        dx: f64,
+        dy: f64,
+        dz: f64,
+    ) -> (f64, f64, f64) {
+        basalt_api::world::collision::resolve_movement(self.world, aabb, dx, dy, dz)
     }
 
     fn spawn(&mut self) -> EntityId {

--- a/crates/basalt-testkit/src/lib.rs
+++ b/crates/basalt-testkit/src/lib.rs
@@ -480,8 +480,58 @@ impl Default for SystemTestContext {
 }
 
 impl basalt_api::system::SystemContext for SystemTestContext {
-    fn world(&self) -> &World {
-        &self.world
+    fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
+        self.world.get_block(x, y, z)
+    }
+
+    fn set_block(&self, x: i32, y: i32, z: i32, state: u16) {
+        self.world.set_block(x, y, z, state);
+    }
+
+    fn get_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> Option<basalt_world::block_entity::BlockEntity> {
+        self.world.get_block_entity(x, y, z).map(|r| r.clone())
+    }
+
+    fn set_block_entity(
+        &self,
+        x: i32,
+        y: i32,
+        z: i32,
+        entity: basalt_world::block_entity::BlockEntity,
+    ) {
+        self.world.set_block_entity(x, y, z, entity);
+    }
+
+    fn mark_chunk_dirty(&self, cx: i32, cz: i32) {
+        self.world.mark_chunk_dirty(cx, cz);
+    }
+
+    fn check_overlap(&self, aabb: &basalt_api::world::collision::Aabb) -> bool {
+        basalt_api::world::collision::check_overlap(&self.world, aabb)
+    }
+
+    fn ray_cast(
+        &self,
+        origin: (f64, f64, f64),
+        direction: (f64, f64, f64),
+        max_distance: f64,
+    ) -> Option<basalt_api::world::collision::RayHit> {
+        basalt_api::world::collision::ray_cast(&self.world, origin, direction, max_distance)
+    }
+
+    fn resolve_movement(
+        &self,
+        aabb: &basalt_api::world::collision::Aabb,
+        dx: f64,
+        dy: f64,
+        dz: f64,
+    ) -> (f64, f64, f64) {
+        basalt_api::world::collision::resolve_movement(&self.world, aabb, dx, dy, dz)
     }
 
     fn spawn(&mut self) -> basalt_api::components::EntityId {

--- a/plugins/block/src/lib.rs
+++ b/plugins/block/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for BlockPlugin {
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         // Process: mutate world state
         registrar.on::<BlockBrokenEvent>(Stage::Process, 0, |event, ctx| {
-            ctx.world_ctx().world().set_block(
+            ctx.world_ctx().set_block(
                 event.position.x,
                 event.position.y,
                 event.position.z,
@@ -30,7 +30,7 @@ impl Plugin for BlockPlugin {
         });
 
         registrar.on::<BlockPlacedEvent>(Stage::Process, 0, |event, ctx| {
-            ctx.world_ctx().world().set_block(
+            ctx.world_ctx().set_block(
                 event.position.x,
                 event.position.y,
                 event.position.z,

--- a/plugins/container/src/lib.rs
+++ b/plugins/container/src/lib.rs
@@ -32,10 +32,15 @@ const CHEST_BLOCK_ID: i32 = 185;
 /// halves so the lid animation can play on each. Falls back to a
 /// single position if the world doesn't currently report a chest at
 /// `(x, y, z)` (e.g. the block was already broken).
-fn chest_parts(world: &basalt_api::world::World, x: i32, y: i32, z: i32) -> Vec<(i32, i32, i32)> {
+fn chest_parts(
+    world_ctx: &dyn basalt_api::context::WorldContext,
+    x: i32,
+    y: i32,
+    z: i32,
+) -> Vec<(i32, i32, i32)> {
     let mut parts: Vec<(i32, i32, i32)> = Vec::with_capacity(2);
     parts.push((x, y, z));
-    let state = world.get_block(x, y, z);
+    let state = world_ctx.get_block(x, y, z);
     if !block::is_chest(state) || block::chest_type(state) == 0 {
         return parts;
     }
@@ -43,7 +48,7 @@ fn chest_parts(world: &basalt_api::world::World, x: i32, y: i32, z: i32) -> Vec<
     for &(dx, dz) in &block::chest_adjacent_offsets(facing) {
         let nx = x + dx;
         let nz = z + dz;
-        let neighbor = world.get_block(nx, y, nz);
+        let neighbor = world_ctx.get_block(nx, y, nz);
         if block::is_chest(neighbor) && block::chest_facing(neighbor) == facing {
             parts.push((nx, y, nz));
             break;
@@ -82,10 +87,10 @@ impl Plugin for ContainerPlugin {
                 return;
             }
 
-            let world = ctx.world_ctx().world();
+            let wctx = ctx.world_ctx();
 
             // Create block entity
-            world.set_block_entity(
+            wctx.set_block_entity(
                 event.position.x,
                 event.position.y,
                 event.position.z,
@@ -95,7 +100,7 @@ impl Plugin for ContainerPlugin {
             // Orient chest based on player yaw
             let yaw = ctx.player().yaw();
             let oriented = block::chest_state_for_yaw(yaw);
-            world.set_block(
+            wctx.set_block(
                 event.position.x,
                 event.position.y,
                 event.position.z,
@@ -114,22 +119,22 @@ impl Plugin for ContainerPlugin {
             for &(dx, dz) in &offsets {
                 let nx = event.position.x + dx;
                 let nz = event.position.z + dz;
-                let neighbor = world.get_block(nx, event.position.y, nz);
+                let neighbor = wctx.get_block(nx, event.position.y, nz);
                 if block::is_single_chest(neighbor) && block::chest_facing(neighbor) == facing {
                     let ddx = nx - event.position.x;
                     let ddz = nz - event.position.z;
                     let (new_type, existing_type) = block::chest_double_types(facing, ddx, ddz);
                     let new_state = block::chest_state(facing, new_type);
                     let neighbor_state = block::chest_state(facing, existing_type);
-                    world.set_block(
+                    wctx.set_block(
                         event.position.x,
                         event.position.y,
                         event.position.z,
                         new_state,
                     );
-                    world.set_block(nx, event.position.y, nz, neighbor_state);
-                    world.mark_chunk_dirty(event.position.x >> 4, event.position.z >> 4);
-                    world.mark_chunk_dirty(nx >> 4, nz >> 4);
+                    wctx.set_block(nx, event.position.y, nz, neighbor_state);
+                    wctx.mark_chunk_dirty(event.position.x >> 4, event.position.z >> 4);
+                    wctx.mark_chunk_dirty(nx >> 4, nz >> 4);
                     ctx.entities().broadcast_block_change(
                         event.position.x,
                         event.position.y,
@@ -168,20 +173,20 @@ impl Plugin for ContainerPlugin {
 
             // Revert double-chest partner to single
             if block::chest_type(state) != 0 {
-                let world = ctx.world_ctx().world();
+                let wctx = ctx.world_ctx();
                 let facing = block::chest_facing(state);
                 let offsets = block::chest_adjacent_offsets(facing);
                 for &(dx, dz) in &offsets {
                     let nx = event.position.x + dx;
                     let nz = event.position.z + dz;
-                    let neighbor = world.get_block(nx, event.position.y, nz);
+                    let neighbor = wctx.get_block(nx, event.position.y, nz);
                     if block::is_chest(neighbor)
                         && block::chest_facing(neighbor) == facing
                         && block::chest_type(neighbor) != 0
                     {
                         let single = block::chest_state(facing, 0);
-                        world.set_block(nx, event.position.y, nz, single);
-                        world.mark_chunk_dirty(nx >> 4, nz >> 4);
+                        wctx.set_block(nx, event.position.y, nz, single);
+                        wctx.mark_chunk_dirty(nx >> 4, nz >> 4);
                         ctx.entities().broadcast_block_change(
                             nx,
                             event.position.y,
@@ -200,13 +205,13 @@ impl Plugin for ContainerPlugin {
                 ContainerBacking::Block { position } => position,
                 ContainerBacking::Virtual => return,
             };
-            let world = ctx.world_ctx().world();
-            if !block::is_chest(world.get_block(position.x, position.y, position.z)) {
+            let wctx = ctx.world_ctx();
+            if !block::is_chest(wctx.get_block(position.x, position.y, position.z)) {
                 return;
             }
 
             let action_param = event.viewer_count.min(u32::from(u8::MAX)) as u8;
-            for (px, py, pz) in chest_parts(world, position.x, position.y, position.z) {
+            for (px, py, pz) in chest_parts(wctx, position.x, position.y, position.z) {
                 ctx.entities().broadcast_block_action(
                     px,
                     py,
@@ -226,13 +231,13 @@ impl Plugin for ContainerPlugin {
                 ContainerBacking::Block { position } => position,
                 ContainerBacking::Virtual => return,
             };
-            let world = ctx.world_ctx().world();
-            if !block::is_chest(world.get_block(position.x, position.y, position.z)) {
+            let wctx = ctx.world_ctx();
+            if !block::is_chest(wctx.get_block(position.x, position.y, position.z)) {
                 return;
             }
 
             let action_param = event.viewer_count.min(u32::from(u8::MAX)) as u8;
-            for (px, py, pz) in chest_parts(world, position.x, position.y, position.z) {
+            for (px, py, pz) in chest_parts(wctx, position.x, position.y, position.z) {
                 ctx.entities()
                     .broadcast_block_action(px, py, pz, 1, action_param, CHEST_BLOCK_ID);
             }

--- a/plugins/physics/src/lib.rs
+++ b/plugins/physics/src/lib.rs
@@ -15,8 +15,8 @@ const GRAVITY: f64 = 0.08;
 /// Physics plugin: gravity, collision, and movement resolution.
 ///
 /// Entities need [`Position`], [`Velocity`], and [`BoundingBox`]
-/// components to be affected by physics. The world is obtained
-/// via `ctx.world()` inside the system runner.
+/// components to be affected by physics. Collision queries use
+/// `ctx.resolve_movement()` inside the system runner.
 pub struct PhysicsPlugin;
 
 impl Plugin for PhysicsPlugin {

--- a/plugins/physics/src/lib.rs
+++ b/plugins/physics/src/lib.rs
@@ -7,7 +7,7 @@
 use basalt_api::components::{BoundingBox, Position, Velocity};
 use basalt_api::prelude::*;
 use basalt_api::system::{Phase, SystemContext, SystemContextExt};
-use basalt_api::world::collision::{Aabb, resolve_movement};
+use basalt_api::world::collision::Aabb;
 
 /// Minecraft gravity constant: -0.08 blocks per tick² (downward).
 const GRAVITY: f64 = 0.08;
@@ -68,7 +68,7 @@ fn physics_tick(ctx: &mut dyn SystemContext) {
         // Resolve movement against solid blocks
         let (resolved_dx, resolved_dy, resolved_dz) = if let Some(bb) = ctx.get::<BoundingBox>(id) {
             let aabb = Aabb::from_entity(px, py, pz, bb.width, bb.height);
-            resolve_movement(ctx.world(), &aabb, dx, dy, dz)
+            ctx.resolve_movement(&aabb, dx, dy, dz)
         } else {
             (dx, dy, dz)
         };

--- a/plugins/storage/src/lib.rs
+++ b/plugins/storage/src/lib.rs
@@ -35,17 +35,17 @@ impl Plugin for StoragePlugin {
     fn on_enable(&self, registrar: &mut PluginRegistrar) {
         registrar.on::<BlockEntityCreatedEvent>(Stage::Post, 0, |event, ctx| {
             let (x, z) = (event.position.x, event.position.z);
-            ctx.world_ctx().world().mark_chunk_dirty(x >> 4, z >> 4);
+            ctx.world_ctx().mark_chunk_dirty(x >> 4, z >> 4);
         });
 
         registrar.on::<BlockEntityModifiedEvent>(Stage::Post, 0, |event, ctx| {
             let (x, z) = (event.position.x, event.position.z);
-            ctx.world_ctx().world().mark_chunk_dirty(x >> 4, z >> 4);
+            ctx.world_ctx().mark_chunk_dirty(x >> 4, z >> 4);
         });
 
         registrar.on::<BlockEntityDestroyedEvent>(Stage::Post, 0, |event, ctx| {
             let (x, z) = (event.position.x, event.position.z);
-            ctx.world_ctx().world().mark_chunk_dirty(x >> 4, z >> 4);
+            ctx.world_ctx().mark_chunk_dirty(x >> 4, z >> 4);
         });
     }
 }


### PR DESCRIPTION
## Summary

Fifth step of the api-standalone refactor (#190). Removes the `WorldContext::world() -> &basalt_world::World` and `SystemContext::world() -> &basalt_world::World` methods. Plugins now interact with the world through typed methods on the context trait — they no longer get raw access to the `World` struct.

New methods on `WorldContext` (and matching on `SystemContext`):

- `get_block(pos: BlockPosition) -> u16`
- `set_block(pos: BlockPosition, state: u16)`
- `get_block_entity(pos: BlockPosition) -> Option<BlockEntity>`
- `set_block_entity(pos: BlockPosition, entity: BlockEntity)`
- `mark_chunk_dirty(cx: i32, cz: i32)`
- `check_overlap(aabb: &Aabb) -> bool`
- `ray_cast(origin: Position, dir_x, dir_y, dir_z, max_dist) -> Option<RayHit>`
- `resolve_movement(aabb: &Aabb, dx, dy, dz) -> (f64, f64, f64)`

All methods are object-safe (no generics) — the trait can be passed as `&dyn WorldContext`.

## Plugin migrations

- `block`: `ctx.world_ctx().world().set_block(x, y, z, s)` → `ctx.world_ctx().set_block(BlockPosition { x, y, z }, s)`
- `storage`: `ctx.world_ctx().world().mark_chunk_dirty(cx, cz)` → `ctx.world_ctx().mark_chunk_dirty(cx, cz)`
- `container`: bulk migration of `set_block`, `get_block`, `set_block_entity`, plus the `chest_parts` helper refactored from `&World` to `&dyn WorldContext`
- `physics`: `resolve_movement(ctx.world(), &aabb, dx, dy, dz)` → `ctx.resolve_movement(&aabb, dx, dy, dz)`

## ServerContext / Ecs / SystemTestContext implementations

- `ServerContext` (basalt-api) implements the new methods by delegating to its internal `Arc<World>`
- `Ecs` (basalt-ecs) implements `SystemContext` similarly
- `ParallelSystemContext` (basalt-ecs) — same
- `SystemTestContext` (basalt-api/testing) — same
- `NoopContext` — methods are pure no-ops (returns 0/None, writes silent)

## Public API impact

The `World` struct is still re-exported from `basalt_api::world::World` for `basalt-server` and `PluginTestHarness::world()` use. Plugins can no longer reach `&World` through the context traits. This is the goal: the runtime World stays an internal implementation detail.

## Commits (6 atomic, workspace green at every step)

1. `2fd7672` — add typed methods to traits (alongside `world()`, transitional)
2. `71d782d` — migrate block plugin
3. `bc38709` — migrate storage plugin
4. `b954ade` — migrate container plugin (incl. `chest_parts` refactor)
5. `53ebee3` — migrate physics plugin
6. `33dc920` — remove `world()` from `WorldContext` and `SystemContext` traits + drop the `OnceLock<World>` from `NoopContext`

## Verification

- [x] `cargo check --workspace --tests` — clean
- [x] `cargo test --workspace` — 1103 passed, 13 ignored, 0 failed
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo llvm-cov --fail-under-lines 90 ...` — 90.39% lines
- [x] Object safety: `&dyn WorldContext` and `&mut dyn SystemContext` compile and are used at dispatch sites
- [x] `grep -rn 'ctx\.world()\|world_ctx().world()' plugins` — zero remaining production references

Refs #190.