### PR TITLE
feat(api): gate raw-packets behind feature flag (6/8)

### DIFF
--- a/crates/basalt-api/Cargo.toml
+++ b/crates/basalt-api/Cargo.toml
@@ -6,8 +6,12 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+raw-packets = ["dep:basalt-protocol"]
+
 [dependencies]
-basalt-protocol = { workspace = true }
+basalt-protocol = { workspace = true, optional = true }
 basalt-types = { workspace = true }
 basalt-world = { workspace = true }
 basalt-recipes = { workspace = true }

--- a/crates/basalt-api/src/events/mod.rs
+++ b/crates/basalt-api/src/events/mod.rs
@@ -25,6 +25,7 @@ mod bus;
 mod chat;
 mod container;
 mod crafting;
+#[cfg(feature = "raw-packets")]
 mod packet;
 mod player;
 mod traits;
@@ -39,6 +40,7 @@ pub use crafting::{
     RecipeBookFillRequestEvent, RecipeBookFilledEvent, RecipeLockedEvent, RecipeRegisterEvent,
     RecipeRegisteredEvent, RecipeUnlockedEvent, RecipeUnregisteredEvent,
 };
+#[cfg(feature = "raw-packets")]
 pub use packet::RawPacketEvent;
 pub use player::{PlayerJoinedEvent, PlayerLeftEvent, PlayerMovedEvent};
 pub use traits::{BusKind, Event, EventRouting, Stage};

--- a/crates/basalt-api/src/lib.rs
+++ b/crates/basalt-api/src/lib.rs
@@ -43,6 +43,9 @@ pub mod world;
 /// rather than reaching into packet structs directly. The packets
 /// module is here for the cases where the wire-level shape matters —
 /// e.g. inspecting [`events::RawPacketEvent::packet`].
+///
+/// Available only when the `raw-packets` feature is enabled.
+#[cfg(feature = "raw-packets")]
 pub use basalt_protocol::packets;
 
 // Top-level re-exports for non-prelude usage.

--- a/crates/basalt-server/Cargo.toml
+++ b/crates/basalt-server/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 [dependencies]
 basalt-types = { workspace = true }
 basalt-protocol = { workspace = true }
-basalt-api = { workspace = true }
+basalt-api = { workspace = true, features = ["raw-packets"] }
 basalt-ecs = { workspace = true }
 basalt-net = { workspace = true }
 basalt-world = { workspace = true }


### PR DESCRIPTION
## Summary

Sixth step of the api-standalone refactor (#190). Gates the `pub use basalt_protocol::packets;` re-export and the `RawPacketEvent` type behind a new `raw-packets` cargo feature on `basalt-api`. `basalt-protocol` becomes an optional dependency pulled in only when the feature is enabled.

## Why

The basalt-protocol crate has 225+ auto-generated packet structs that change with every Minecraft version. Forcing every plugin to pull this when most plugins only listen to domain events (`BlockBrokenEvent`, `PlayerMovedEvent`, etc.) is unnecessary. With this feature flag, anti-cheat / telemetry plugins opt-in explicitly:

```toml
basalt-api = { version = "0.1", features = ["raw-packets"] }
```

Plugins that don't care take the default and never pull `basalt-protocol`.

## Changes

- `basalt-api/Cargo.toml`: declare `[features]` with `raw-packets = ["dep:basalt-protocol"]`. Mark `basalt-protocol` as `optional = true`.
- `basalt-api/src/lib.rs`: `#[cfg(feature = "raw-packets")] pub use basalt_protocol::packets;`
- `basalt-api/src/events/mod.rs`: gate `mod packet;` and `pub use packet::RawPacketEvent;` with `#[cfg(feature = "raw-packets")]`
- `basalt-server/Cargo.toml`: enable `raw-packets` on its `basalt-api` dep so the server keeps dispatching the event in `play_handler.rs`

## Verification

- [x] `cargo check -p basalt-api` (no features) — clean
- [x] `cargo check -p basalt-api --features raw-packets` — clean
- [x] `cargo check --workspace --tests` — clean (basalt-server pulls the feature)
- [x] `cargo test --workspace` — 1103 passed, 13 ignored, 0 failed
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

## Atomic commit rationale

Feature definition + gating + consumer activation must land together — splitting would leave the workspace uncompilable in between.

Refs #190.