### PR TITLE
ci(ci): publish crates to crates.io on release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,28 @@ jobs:
       - run: cargo test --all-features
       - run: cargo clippy --lib --bins --tests --examples --all-features -- -D warnings
 
+  publish:
+    name: Publish to crates.io
+    needs: [ test ]
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Publish basalt-derive
+        run: cargo publish -p basalt-derive
+      - name: Publish basalt-types
+        run: cargo publish -p basalt-types
+      - name: Publish basalt-protocol
+        run: cargo publish -p basalt-protocol
+      - name: Publish basalt-api
+        run: cargo publish -p basalt-api
+
   build:
     name: Build (${{ matrix.target }})
-    needs: [ test ]
+    needs: [ publish ]
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Extends \`.github/workflows/release.yml\` so a \`v*\` tag now publishes the four crates (\`basalt-derive\`, \`basalt-types\`, \`basalt-protocol\`, \`basalt-api\`) to crates.io before the binary build runs.

### Workflow shape

\`\`\`
test → publish → build (5-platform matrix) → release
\`\`\`

A failed publish halts the entire release flow — guarantees the invariant *if a GitHub release exists for vX.Y.Z, then crates.io has vX.Y.Z*.

### Publish order (dependency order)

1. \`basalt-derive\` (proc-macro, zero internal deps)
2. \`basalt-types\` (zero internal deps)
3. \`basalt-protocol\` (depends on derive + types)
4. \`basalt-api\` (depends on types + protocol optional)

\`cargo publish\` (Cargo ≥ 1.79) waits for the registry to index each crate before exiting, so sequential publishes work without explicit \`sleep\`.

### Operator action required before first use

Create a \`CARGO_REGISTRY_TOKEN\` repository secret:

1. Generate a token at https://crates.io/me with both \`publish-new\` (for the first publish of each crate) and \`publish-update\` scopes.
2. Add as a repo secret: Settings → Secrets and variables → Actions → New repository secret. Name: \`CARGO_REGISTRY_TOKEN\`.

After the first successful publish of all four crates, the token can be rotated to a \`publish-update\`-only one.

### Failure / recovery

\`cargo publish\` of an already-published version fails with \`crate already exists\`. Re-running the workflow on the same tag will fail loudly. To recover from a partial-publish failure: bump the workspace version, retag.

This is by design — \`cargo publish\` is irreversible, so idempotent re-runs would mask real issues.

### Scope

- Adds one job (\`publish\`) to one workflow file.
- Changes \`build.needs\` from \`[ test ]\` to \`[ publish ]\`.
- No code changes, no manifest changes (the four crates were prepared in #198 and #200).

### Non-goals

- Automatic version bumping
- Manual approval gate (chose full-auto on tag — can add later via GitHub environment protection if needed)
- Publication of internal crates (basalt-server, basalt-world, etc., stay \`publish = false\`)

Spec: \`docs/superpowers/specs/2026-04-26-publish-ci-design.md\`

## Test plan

- [ ] CI on this PR runs the unchanged \`ci.yml\` workflow as usual (no publish runs without a tag)
- [ ] After merge + creating the \`CARGO_REGISTRY_TOKEN\` secret, push a \`v0.1.0\` tag (or whatever version is being released) to trigger the new flow
- [ ] First-tag verification:
  - test job passes
  - publish job runs four \`cargo publish\` commands sequentially
  - all four publishes succeed (visible in https://crates.io/crates/basalt-derive etc.)
  - build matrix produces 5 binaries
  - release job creates a GitHub release with the binaries attached
- [ ] Re-pushing the same tag fails at the publish step with \`crate already exists\` (expected)